### PR TITLE
Enable multi-platform Docker builds for web and notifier services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
@@ -138,6 +140,7 @@ jobs:
         with:
           context: .
           file: services/web/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/scarguard-web:latest
@@ -150,6 +153,7 @@ jobs:
         with:
           context: .
           file: services/notifier/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/scarguard-notifier:latest


### PR DESCRIPTION
## Summary
This PR enables multi-platform Docker image builds for the web and notifier services, allowing the container images to run on both AMD64 and ARM64 architectures.

## Key Changes
- Added `docker/setup-qemu-action@v3` step to enable QEMU for cross-platform builds
- Added `platforms: linux/amd64,linux/arm64` configuration to both the web and notifier service Docker build steps

## Implementation Details
The changes leverage Docker's buildx with QEMU support to build and push container images that are compatible with both x86-64 and ARM64 architectures. This enables the application to run on a wider range of platforms, including ARM-based systems like Apple Silicon and various ARM servers.

https://claude.ai/code/session_01KrbNRpbpcjk6KqKKrerKF5