### PR TITLE
Enable multi-platform Docker builds for web and notifier services

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
@@ -39,7 +41,9 @@ jobs:
         with:
           context: .
           file: services/web/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: |
             ghcr.io/${{ github.repository_owner }}/scarguard-web:${{ github.ref_name }}
             ghcr.io/${{ github.repository_owner }}/scarguard-web:latest
@@ -51,7 +55,9 @@ jobs:
         with:
           context: .
           file: services/notifier/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: |
             ghcr.io/${{ github.repository_owner }}/scarguard-notifier:${{ github.ref_name }}
             ghcr.io/${{ github.repository_owner }}/scarguard-notifier:latest


### PR DESCRIPTION
## Summary
Updated the release workflow to build Docker images for multiple platforms (amd64 and arm64), enabling the application to run on both x86-64 and ARM-based systems.

## Key Changes
- Added `docker/setup-qemu-action@v3` to enable QEMU for cross-platform builds
- Added `platforms: linux/amd64,linux/arm64` to both web and notifier service builds
- Disabled provenance attestation (`provenance: false`) for both services to simplify the build output

## Implementation Details
The changes leverage Docker's buildx multi-platform build capabilities. QEMU is required to emulate non-native architectures during the build process. Provenance attestation was disabled to avoid potential compatibility issues with the multi-platform build setup.

https://claude.ai/code/session_01X4nsepYHP5dJNdnvFxoohM