### PR TITLE
Refactor TemplateResponse calls to use positional request argument

### DIFF
--- a/services/web/src/routes/config.py
+++ b/services/web/src/routes/config.py
@@ -15,8 +15,9 @@ async def config_page(request: Request):
     cfg = config_store.load()
     raw = yaml.dump(cfg, default_flow_style=False, sort_keys=False)
     return templates.TemplateResponse(
+        request,
         "config.html",
-        {"request": request, "raw_yaml": raw, "saved": False, "error": None},
+        {"raw_yaml": raw, "saved": False, "error": None},
     )
 
 
@@ -36,6 +37,7 @@ async def save_config(request: Request, raw_yaml: str = Form(...)):
         error = str(exc)
 
     return templates.TemplateResponse(
+        request,
         "config.html",
-        {"request": request, "raw_yaml": raw_yaml, "saved": saved, "error": error},
+        {"raw_yaml": raw_yaml, "saved": saved, "error": error},
     )

--- a/services/web/src/routes/dashboard.py
+++ b/services/web/src/routes/dashboard.py
@@ -17,9 +17,9 @@ async def dashboard(request: Request):
     total = db.count_events()
     cameras = cfg.get("cameras", [])
     return templates.TemplateResponse(
+        request,
         "dashboard.html",
         {
-            "request": request,
             "armed": cfg.get("system", {}).get("armed", True),
             "cameras": cameras,
             "total_events": total,
@@ -44,6 +44,7 @@ async def disarm(request: Request):
 def _arm_badge(request: Request, *, armed: bool) -> HTMLResponse:
     """Return just the status badge fragment for HTMX swap."""
     return templates.TemplateResponse(
+        request,
         "partials/arm_badge.html",
-        {"request": request, "armed": armed},
+        {"armed": armed},
     )

--- a/services/web/src/routes/events.py
+++ b/services/web/src/routes/events.py
@@ -21,9 +21,9 @@ async def events_page(request: Request, page: int = 1):
     rows = db.get_events(limit=PAGE_SIZE, offset=offset)
     total = db.count_events()
     return templates.TemplateResponse(
+        request,
         "events.html",
         {
-            "request": request,
             "events": [dict(r) for r in rows],
             "page": page,
             "total_pages": max(1, -(-total // PAGE_SIZE)),  # ceiling div
@@ -38,8 +38,9 @@ async def event_rows(request: Request, page: int = 1):
     offset = (page - 1) * PAGE_SIZE
     rows = db.get_events(limit=PAGE_SIZE, offset=offset)
     return templates.TemplateResponse(
+        request,
         "partials/event_rows.html",
-        {"request": request, "events": [dict(r) for r in rows]},
+        {"events": [dict(r) for r in rows]},
     )
 
 

--- a/services/web/src/routes/feed.py
+++ b/services/web/src/routes/feed.py
@@ -22,9 +22,9 @@ async def feed_page(request: Request):
     cameras = cfg.get("cameras", [])
     latest = db.get_latest_event()
     return templates.TemplateResponse(
+        request,
         "feed.html",
         {
-            "request": request,
             "cameras": cameras,
             "latest": dict(latest) if latest else None,
         },

--- a/services/web/src/routes/models.py
+++ b/services/web/src/routes/models.py
@@ -23,8 +23,9 @@ async def models_page(request: Request, uploaded: str = ""):
         key=lambda x: str(x["name"]),
     )
     return templates.TemplateResponse(
+        request,
         "models.html",
-        {"request": request, "files": files, "uploaded": uploaded, "error": None},
+        {"files": files, "uploaded": uploaded, "error": None},
     )
 
 
@@ -35,9 +36,9 @@ async def upload_model(request: Request, file: UploadFile = File(...)):
     if suffix not in ALLOWED_EXTENSIONS:
         files = _list_files()
         return templates.TemplateResponse(
+            request,
             "models.html",
             {
-                "request": request,
                 "files": files,
                 "uploaded": "",
                 "error": f"Unsupported file type '{suffix}'. Allowed: {', '.join(ALLOWED_EXTENSIONS)}",


### PR DESCRIPTION
## Summary
Updated all `TemplateResponse` calls across the web routes to pass the `request` object as the first positional argument instead of including it in the context dictionary. This aligns with Starlette's `TemplateResponse` API where `request` is a dedicated parameter.

## Key Changes
- **config.py**: Updated 2 `TemplateResponse` calls to pass `request` as first positional argument and removed it from context dict
- **dashboard.py**: Updated 2 `TemplateResponse` calls (dashboard page and arm_badge partial) with the same pattern
- **events.py**: Updated 2 `TemplateResponse` calls (events page and event_rows partial) with the same pattern
- **models.py**: Updated 2 `TemplateResponse` calls (models page and upload error response) with the same pattern
- **feed.py**: Updated 1 `TemplateResponse` call (feed page) with the same pattern

## Implementation Details
- All changes follow the pattern: `TemplateResponse(request, template_name, context_dict)` instead of `TemplateResponse(template_name, {**context_dict, "request": request})`
- The `request` object is no longer redundantly passed in the context dictionary
- This is a cleaner API usage that leverages Starlette's built-in request parameter handling
- No functional changes; this is purely a refactoring for code consistency and clarity

https://claude.ai/code/session_01Km5bqy68NB9xJtvfH2zJw9