### PR TITLE
docs: separate runtime-enforced config keys from planned keys

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -1,11 +1,12 @@
 # ScarGuard — Config & Detection Reference
 
-## Config File Format (scarguard.yml)
+## Config file format (`scarguard.yml`)
 
 ```yaml
 system:
   armed: true
   log_level: info
+  timezone: UTC
   snapshot_retention_days: 30
 
 web:
@@ -48,16 +49,6 @@ action_rules:
   - match:
       class: great_blue_heron
     actions: [discord, email, webhook]
-  - match:
-      class: bird
-    actions: [discord]
-  - match:
-      class: human
-    actions: [log]
-  - match:
-      camera: pond-south
-      class: raccoon
-    actions: [discord, webhook]
 
 notifications:
   discord:
@@ -78,24 +69,73 @@ notifications:
       enabled: false
       url: "http://192.168.1.x/api/fire"
       method: POST
-      headers:
-        Authorization: "Bearer YOUR_TOKEN"
-      include_snapshot_url: true
-    - name: home-assistant
-      enabled: false
-      url: "http://homeassistant.local:8123/api/webhook/scarguard"
-      method: POST
+
 redis:
   host: redis
   port: 6379
 ```
 
-## Detection Logic
+## Currently enforced by code
+
+Only keys read by these runtime/config-validation paths are listed here:
+
+- `services/detector/src/main.py`
+- `services/notifier/src/main.py`
+- `services/web/src/config_model.py`
+
+### `system`
+- `system.armed`
+- `system.log_level`
+- `system.timezone`
+
+### `cameras[]`
+- `cameras[].name`
+- `cameras[].rtsp_url`
+- `cameras[].enabled`
+- `cameras[].resolution`
+
+### `detection`
+- `detection.model_path`
+- `detection.confidence_threshold`
+- `detection.target_classes`
+- `detection.cooldown_seconds`
+- `detection.frame_skip`
+
+### `notifications`
+- `notifications.discord.enabled`
+- `notifications.discord.webhook_url`
+- `notifications.discord.mention_role`
+- `notifications.discord.include_snapshot`
+- `notifications.email.enabled`
+- `notifications.email.smtp_host`
+- `notifications.email.smtp_port`
+- `notifications.email.smtp_user`
+- `notifications.email.smtp_pass`
+- `notifications.email.to_addresses`
+- `notifications.email.include_snapshot`
+
+### `redis`
+- `redis.host`
+- `redis.port`
+
+## Planned / not yet enforced
+
+- `web.ssl.*` — **status: planned**
+- `snapshot_retention_days` — **status: planned**
+- `cameras[].exclusion_zones` runtime behavior — **status: UI-preserved only**
+- `action_rules` — **status: not implemented in runtime**
+- `notifications.webhooks` — **status: not implemented in runtime**
+
+## Structured config save behavior
+
+`services/web/src/routes/config.py` preserves unknown keys when saving structured config by merging edited sections into the existing document (including top-level unknown keys and unknown per-camera fields). This means unsupported keys are retained even when not enforced by runtime services.
+
+## Detection logic
 
 1. Pull frames from each RTSP stream (OpenCV `VideoCapture`)
 2. Run YOLO inference on GPU (`model.predict()`)
 3. Filter results by target classes and confidence threshold
-4. Apply cooldown dedup (don't fire 10 events for same heron standing there)
+4. Apply cooldown dedup (avoid repeated events for the same standing object)
 5. On new detection event:
    - Save to SQLite (timestamp, class, confidence, camera, snapshot path)
    - Publish to Redis pub/sub channel `scarguard:detections`
@@ -103,15 +143,14 @@ redis:
 6. Notifier picks up events from Redis and dispatches to configured channels
 7. Web UI subscribes to Redis for live event feed via SSE
 
-## RTSP Notes
+## RTSP notes
 
 - UniFi Protect RTSP must be enabled per-camera in Protect UI on the UDM
 - RTSP URL format: `rtsp://172.16.0.1:7447/<stream_token>`
 - Use 720p substream for inference — 4K wastes GPU cycles
 - OpenCV `VideoCapture` handles RTSP natively; set `cv2.CAP_PROP_BUFFERSIZE` to 1 to reduce frame lag
-- Camera models: G3 Flex and G5 Flex (G3 may be replaced with another G5)
 
-## Service Communication
+## Service communication
 
 - **Between services:** Redis pub/sub. Detector publishes detection events; notifier and web UI subscribe.
 - **Config:** All services read from mounted `config/scarguard.yml` in external data directory. Web UI can write to it. Detector and notifier auto-restart on config file changes.


### PR DESCRIPTION
### Motivation

- Clarify which `scarguard.yml` keys are actually read and enforced by runtime services to avoid user confusion. 
- Surface roadmap/UI-only keys separately so operators know which settings are preserved but not acted on by the current runtime.

### Description

- Updated `CONFIG_REFERENCE.md` to add a `Currently enforced by code` section that lists only keys read by `services/detector/src/main.py`, `services/notifier/src/main.py`, and `services/web/src/config_model.py`.
- Added a `Planned / not yet enforced` section and moved unsupported keys (`web.ssl.*`, `snapshot_retention_days`, `cameras[].exclusion_zones` runtime behavior, `action_rules`, `notifications.webhooks`) there with one-line status tags (`planned`, `UI-preserved only`, or `not implemented in runtime`).
- Added a `Structured config save behavior` note explaining that unknown keys are preserved by the structured-save merge implemented in `services/web/src/routes/config.py`.
- Small editorial tweaks to the example YAML and detection wording for consistency.

### Testing

- Inspected relevant runtime/config sources with `sed` to confirm which keys are read (`services/detector/src/main.py`, `services/notifier/src/main.py`, `services/web/src/config_model.py`).
- Verified the documentation change with `git diff -- CONFIG_REFERENCE.md`, previewed the file with `nl -ba CONFIG_REFERENCE.md`, and confirmed repository status with `git status --short`.
- Committed the change with `git commit` and validated the commit completed successfully; this is a documentation-only change and no runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c5581f5083238a73e944554ae3d8)