### PR TITLE
docs: refresh INFRASTRUCTURE.md service trees

### DIFF
--- a/INFRASTRUCTURE.md
+++ b/INFRASTRUCTURE.md
@@ -1,5 +1,7 @@
 # ScarGuard — Infrastructure
 
+Doc last verified: 2026-03-24
+
 ## Repository Structure
 
 ```
@@ -26,27 +28,42 @@ scarguard/
 │   ├── web/                         # FastAPI + Jinja web UI
 │   │   ├── Dockerfile
 │   │   ├── requirements.txt
-│   │   ├── src/
-│   │   │   ├── main.py
-│   │   │   ├── routes/
-│   │   │   │   ├── dashboard.py
-│   │   │   │   ├── events.py
-│   │   │   │   ├── config.py
-│   │   │   │   ├── models.py
-│   │   │   │   ├── about.py
-│   │   │   │   └── admin.py
-│   │   │   ├── api/
-│   │   │   │   └── v1.py
-│   │   │   └── db.py
-│   │   ├── templates/
-│   │   └── static/
+│   │   └── src/
+│   │       ├── config_model.py
+│   │       ├── config_store.py
+│   │       ├── db.py
+│   │       ├── main.py
+│   │       ├── routes/
+│   │       │   ├── __init__.py
+│   │       │   ├── about.py
+│   │       │   ├── config.py
+│   │       │   ├── dashboard.py
+│   │       │   ├── events.py
+│   │       │   ├── feed.py
+│   │       │   └── models.py
+│   │       ├── static/
+│   │       │   ├── config.js
+│   │       │   └── style.css
+│   │       └── templates/
+│   │           ├── about.html
+│   │           ├── base.html
+│   │           ├── config.html
+│   │           ├── dashboard.html
+│   │           ├── events.html
+│   │           ├── feed.html
+│   │           ├── models.html
+│   │           └── partials/
+│   │               ├── arm_badge.html
+│   │               └── event_rows.html
 │   └── notifier/
 │       ├── Dockerfile
 │       ├── requirements.txt
 │       └── src/
-│           ├── main.py
+│           ├── config_watcher.py
 │           ├── discord.py
-│           └── email.py
+│           ├── email_notifier.py
+│           ├── main.py
+│           └── notification_queue.py
 ├── shared/
 │   └── models.py                    # Shared Pydantic data models
 ├── infra/


### PR DESCRIPTION
### Motivation
- Keep the repository infrastructure documentation in sync with the actual service source trees under `services/web/src/` and `services/notifier/src/`.
- Remove stale references to modules that no longer exist in the codebase and reflect renamed modules in the notifier service.
- Make it explicit when the doc was verified so future changes can be audited against a known verification date.

### Description
- Inserted a `Doc last verified: 2026-03-24` line at the top of `INFRASTRUCTURE.md`.
- Replaced the `services/web/src/` subtree with the current file list including `config_model.py`, `config_store.py`, `db.py`, `main.py`, `routes/__init__.py`, `routes/about.py`, `routes/config.py`, `routes/dashboard.py`, `routes/events.py`, `routes/feed.py`, `routes/models.py`, `static/config.js`, `static/style.css`, and the full `templates/` and `templates/partials/` contents.
- Removed obsolete `routes/admin.py` and `api/v1.py` entries from the web tree.
- Updated `services/notifier/src/` to match current files and renamed the documented email module to `email_notifier.py`, and added `config_watcher.py` and `notification_queue.py` to the notifier tree.

### Testing
- Verified `services/web/src/` contents with `find services/web/src -maxdepth 6 -type f | sort` and the command completed successfully.
- Verified `services/notifier/src/` contents with `find services/notifier/src -maxdepth 6 -type f | sort` and the command completed successfully.
- Reviewed the resulting documentation change with `git diff -- INFRASTRUCTURE.md` and confirmed the updated tree was correct.
- Confirmed working tree state with `git status --short` and observed the documentation file was modified as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c56acc508323b7738adae71ff12a)