### PR TITLE
Clarify STATUS.md hot-reload behavior for detector/notifier/web

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -8,7 +8,7 @@
 - **Web UI:** Dashboard, event log, config editor, model upload — functional.
 - **CI/CD:** GitHub Actions workflow builds and pushes images to GHCR. x86 and Orin self-hosted runners operational.
 - **Docker Compose stack:** All four services (redis, detector, web, notifier) start and communicate correctly.
-- **Config hot-reload:** Notifier and detector services automatically restart on config change.
+- **Config hot-reload:** Detector and notifier poll config and apply changes in-process (no service restart required). Detector dynamically updates armed flag, threshold/classes, cooldown, frame_skip, and enabled cameras; notifier dynamically rebuilds its notifier set. Web service reads config on request, so most config display changes do not require restart.
 - **External data directory:** Application assets (config, data, models, snapshots) stored externally to the project repo.
 - **Notifier resilience:** Internet interruptions now handled gracefully
 
@@ -39,7 +39,7 @@
 | — | CI/CD pipeline (GitHub Actions, GHCR, self-hosted runners) | ✅ Complete |
 | — | Docker Compose orchestration + setup.sh installer | ✅ Complete |
 | — | External data directory (config/data/models outside repo) | ✅ Complete |
-| — | Config hot-reload (detector + notifier restart on config change) | ✅ Complete |
+| — | Config hot-reload (detector + notifier poll and apply config in-process) | ✅ Complete |
 | — | Form-based config GUI (initial implementation) | ✅ Complete |
 | — | Multi-camera detection (initial implementation) | ⚠️ Needs hardening |
 | — | About page to display version and service status | ✅ Complete |


### PR DESCRIPTION
### Motivation
- The STATUS.md previously claimed services restart on config changes, which is inaccurate and can mislead operators about runtime behavior.  
- The change aims to document the true in-process config polling behavior and the specific config items that are applied dynamically by each service.

### Description
- Updated the `STATUS.md` hot-reload line to state that detector and notifier `poll config and apply changes in-process` rather than restarting services.  
- Added detector dynamic-scope details listing `armed`, `threshold/classes`, `cooldown`, `frame_skip`, and enabled cameras as values updated at runtime.  
- Noted that the notifier `dynamically rebuilds its notifier set` on config changes.  
- Added a caveat that the web service reads config on request so most config-display changes do not require a restart and updated the Completed Work table entry to match the in-process behavior.

### Testing
- Documentation-only change; no automated tests applicable or required for this edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c573fe6883239c04ca76fdd6603e)