### PR TITLE
Optimize notification queue notifier lookup and add mixed-notifier regression test

### DIFF
--- a/services/notifier/src/notification_queue.py
+++ b/services/notifier/src/notification_queue.py
@@ -137,12 +137,13 @@ class NotificationQueue:
                     datetime.fromtimestamp(dropped.first_failed, tz=timezone.utc).isoformat(),
                 )
             self._entries.append(entry)
+            queue_depth = len(self._entries)
             self._save()
         logger.info(
             "Queued failed %s notification for retry in %ds (queue depth: %d)",
             notifier_type,
             _BACKOFF_STEPS[0],
-            self.depth,
+            queue_depth,
         )
 
     def process_due(self, notifiers: list, notifiers_lock: threading.Lock) -> None:
@@ -155,20 +156,21 @@ class NotificationQueue:
         # Snapshot entries that are due — don't hold the lock during network I/O.
         with self._lock:
             due = [e for e in self._entries if e.next_retry <= now]
+            queue_depth = len(self._entries)
 
         if not due:
             return
 
         with notifiers_lock:
             active_notifiers = list(notifiers)
+            notifiers_by_type = {
+                type(notifier).__name__: notifier for notifier in active_notifiers
+            }
 
         to_remove: list[QueueEntry] = []
 
         for entry in due:
-            target = next(
-                (n for n in active_notifiers if type(n).__name__ == entry.notifier_type),
-                None,
-            )
+            target = notifiers_by_type.get(entry.notifier_type)
             if target is None:
                 # Notifier was disabled in config; leave entry in queue.
                 logger.debug(
@@ -209,7 +211,7 @@ class NotificationQueue:
                         entry.notifier_type,
                         delay,
                         elapsed / 3600,
-                        self.depth,
+                        queue_depth,
                     )
 
         # Commit changes (removals + updated next_retry timestamps) to disk.

--- a/services/notifier/tests/test_notification_queue.py
+++ b/services/notifier/tests/test_notification_queue.py
@@ -1,0 +1,58 @@
+import json
+import threading
+import time
+
+from notification_queue import NotificationQueue, QueueEntry
+
+
+class EnabledNotifier:
+    def __init__(self):
+        self.sent_events = []
+
+    def send(self, event):
+        self.sent_events.append(event)
+
+
+class DisabledNotifier:
+    def send(self, event):
+        raise RuntimeError("should not be called")
+
+
+def test_process_due_keeps_disabled_notifier_entries(tmp_path):
+    queue_path = tmp_path / "notification_queue.json"
+    queue = NotificationQueue(str(queue_path))
+    now = time.time()
+
+    enabled_event = {"id": "enabled"}
+    disabled_event = {"id": "disabled"}
+
+    queue._entries = [
+        QueueEntry(
+            event=enabled_event,
+            notifier_type="EnabledNotifier",
+            attempt=0,
+            next_retry=now - 1,
+            first_failed=now - 20,
+        ),
+        QueueEntry(
+            event=disabled_event,
+            notifier_type="DisabledNotifier",
+            attempt=0,
+            next_retry=now - 1,
+            first_failed=now - 20,
+        ),
+    ]
+    queue._save()
+
+    enabled = EnabledNotifier()
+    queue.process_due([enabled], threading.Lock())
+
+    assert enabled.sent_events == [enabled_event]
+    assert queue.depth == 1
+    assert queue._entries[0].event == disabled_event
+    assert queue._entries[0].notifier_type == "DisabledNotifier"
+
+    persisted = json.loads(queue_path.read_text())
+    assert len(persisted) == 1
+    assert persisted[0]["event"] == disabled_event
+    assert persisted[0]["notifier_type"] == "DisabledNotifier"


### PR DESCRIPTION
### Motivation
- Reduce hot-path cost in `NotificationQueue.process_due` by avoiding a per-entry linear scan for the target notifier.
- Avoid repeated `self.depth` property access in hot logging paths to reduce lock contention and cost.
- Preserve current queue semantics and persistence behavior while adding a regression test for mixed enabled/disabled notifiers.

### Description
- Build a `notifiers_by_type` dictionary once per `process_due` call and replace the per-entry `next((...))` linear search with `notifiers_by_type.get(entry.notifier_type)` for O(1) lookups.
- Cache queue depth in `enqueue` (`queue_depth`) and once at the start of `process_due` to avoid repeated `self.depth` calls in log messages.
- Keep persistence semantics unchanged: the same save/commit logic (`if to_remove or due` then persist) and removal/update flow remain in place.
- Add a new regression test `services/notifier/tests/test_notification_queue.py` that verifies enabled notifier entries are delivered and removed while disabled notifier entries remain in the queue and are persisted.

### Testing
- Ran `PYTHONPATH=services/notifier/src pytest -q services/notifier/tests/test_notification_queue.py services/notifier/tests/test_dispatch.py` and all tests passed (`18 passed`).
- Ran `ruff check services/notifier/src/notification_queue.py services/notifier/tests/test_notification_queue.py` with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cac4345883239b861309ed8d970e)