### PR TITLE
fix: detector crash loop due to threading type annotations

### DIFF
--- a/services/detector/src/events.py
+++ b/services/detector/src/events.py
@@ -1,5 +1,7 @@
 """Detection event processing: cooldown dedup, snapshot capture, SQLite logging."""
 
+from __future__ import annotations
+
 import json
 import logging
 import sqlite3

--- a/services/detector/src/main.py
+++ b/services/detector/src/main.py
@@ -8,6 +8,8 @@ are shared across threads; both are internally thread-safe.  Each camera thread
 owns its own RTSPStream and RedisPublisher connection.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import signal

--- a/services/detector/src/scheduler.py
+++ b/services/detector/src/scheduler.py
@@ -9,6 +9,8 @@ state on startup or reconfigure to match the current window. If the system resta
 mid-window the armed state remains whatever was last written to config.
 """
 
+from __future__ import annotations
+
 import logging
 import threading
 from collections.abc import Callable

--- a/services/detector/src/stats_collector.py
+++ b/services/detector/src/stats_collector.py
@@ -6,6 +6,8 @@ dict.  Writes a JSON snapshot to a Redis key on each cycle so the web service
 can poll it.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import subprocess

--- a/services/detector/src/stream.py
+++ b/services/detector/src/stream.py
@@ -1,5 +1,7 @@
 """RTSP stream reader with automatic reconnect and exponential backoff."""
 
+from __future__ import annotations
+
 import logging
 import os
 import threading


### PR DESCRIPTION
## Summary

- Fixes the detector service crash loop introduced in v0.5.0 where `threading.Lock | None` type annotations cause a `TypeError` at runtime
- `threading.Lock`, `threading.Event`, and `threading.Thread` are factory functions (not type classes), so PEP 604 union syntax (`X | None`) fails when Python evaluates the annotation at import time
- Adds `from __future__ import annotations` to all detector source files to defer annotation evaluation to string form, preventing the runtime error

## Test plan

- [ ] Verify detector container starts without `TypeError` in logs
- [ ] Confirm detection pipeline works end-to-end (RTSP → YOLO → events)
- [ ] Check web dashboard shows detector as running (no more crash loop)

Fixes #42

https://claude.ai/code/session_01TUR6dGnufgit1sSNeSNewL