### PR TITLE
fix: GPU stats via tegrastats on Jetson Orin + stats_interval config UI

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -22,8 +22,7 @@
 
 ## Known Issues / Buggy
 
- - **Performance Stats:** Does not include GPU usage (tegrastats)
- - **Config:** Performace Polling not UI configurable
+None currently identified.
 
 ## Not Yet Built
 

--- a/services/detector/Dockerfile
+++ b/services/detector/Dockerfile
@@ -3,11 +3,14 @@
 FROM dustynv/l4t-pytorch:r36.4.0
 
 # GStreamer + OpenGL deps required by OpenCV RTSP support on L4T
+# nvidia-l4t-tools provides tegrastats for Jetson GPU stats (aarch64 only)
+ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgstreamer1.0-0 \
     libgstreamer-plugins-base1.0-0 \
     libgl1 \
     libglib2.0-0 \
+ && if [ "$TARGETARCH" = "arm64" ]; then apt-get install -y --no-install-recommends nvidia-l4t-tools; fi \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/services/detector/src/stats_collector.py
+++ b/services/detector/src/stats_collector.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+import shutil
 import subprocess
 import threading
 from datetime import datetime, timezone
@@ -54,8 +56,11 @@ class StatsCollector(threading.Thread):
 
     @staticmethod
     def _detect_gpu_platform() -> str | None:
-        """Return 'jetson', 'nvidia-smi', or None."""
-        # Jetson: check for the GPU load sysfs node
+        """Return 'tegrastats', 'jetson', 'nvidia-smi', or None."""
+        # tegrastats: official Jetson tool, covers all JetPack platforms incl. Orin
+        if shutil.which("tegrastats"):
+            return "tegrastats"
+        # Old Jetson sysfs path (pre-Orin boards: Nano, TX2, Xavier)
         if Path("/sys/devices/gpu.0/load").exists():
             return "jetson"
         # x86/generic: check for nvidia-smi binary
@@ -155,11 +160,61 @@ class StatsCollector(threading.Thread):
 
     def _read_gpu_stats(self) -> dict:
         """Return GPU stats dict.  Keys present only if data is available."""
-        if self._gpu_platform == "jetson":
+        if self._gpu_platform == "tegrastats":
+            return self._read_gpu_tegrastats()
+        elif self._gpu_platform == "jetson":
             return self._read_gpu_jetson()
         elif self._gpu_platform == "nvidia-smi":
             return self._read_gpu_nvidia_smi()
         return {}
+
+    def _read_gpu_tegrastats(self) -> dict:
+        """Read GPU stats via tegrastats (all Jetson platforms including Orin).
+
+        Spawns tegrastats, reads one output line, then terminates it.
+        Parses GR3D_FREQ for GPU load % and GPU@XXC for temperature.
+        """
+        try:
+            proc = subprocess.Popen(
+                ["tegrastats", "--interval", "100"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            line = ""
+            try:
+                if proc.stdout is None:
+                    return {}
+                line = proc.stdout.readline()
+            finally:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+        except (FileNotFoundError, OSError):
+            return {}
+        except Exception:
+            logger.debug("tegrastats read failed", exc_info=True)
+            return {}
+
+        if not line:
+            return {}
+
+        stats: dict = {"gpu_available": True}
+
+        # GPU load: "GR3D_FREQ 45%@612" or "GR3D_FREQ 45%"
+        m = re.search(r"GR3D_FREQ\s+(\d+)%", line)
+        if m:
+            stats["gpu_usage_pct"] = float(m.group(1))
+
+        # GPU temp: "GPU@51C" or "GPU@50.5C"
+        m = re.search(r"\bGPU@([\d.]+)C\b", line)
+        if m:
+            stats["gpu_temp_c"] = float(m.group(1))
+
+        return stats
 
     @staticmethod
     def _read_gpu_jetson() -> dict:

--- a/services/web/src/static/config.js
+++ b/services/web/src/static/config.js
@@ -188,6 +188,7 @@ function readForm() {
       log_level: document.getElementById("sys-log-level").value,
       timezone: document.getElementById("sys-timezone").value.trim(),
       snapshot_retention_days: (v => isNaN(v) ? 30 : v)(parseInt(document.getElementById("sys-retention").value, 10)),
+      stats_interval: (v => isNaN(v) || v < 1 ? 5 : Math.min(v, 60))(parseInt(document.getElementById("sys-stats-interval").value, 10)),
       schedule,
       auth: {
         enabled: document.getElementById("auth-enabled").checked,

--- a/services/web/src/templates/config.html
+++ b/services/web/src/templates/config.html
@@ -50,6 +50,13 @@
                    min="0" max="3650">
           </div>
         </div>
+        <div class="field-row">
+          <div class="field-group">
+            <label>Stats polling interval (seconds, 1–60)</label>
+            <input type="number" id="sys-stats-interval" value="{{ cfg.system.stats_interval }}"
+                   min="1" max="60">
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- **GPU stats on Orin:** The stats page GPU section was never appearing because `/sys/devices/gpu.0/load` only exists on pre-Orin Jetson boards, and `nvidia-smi` wasn't accessible in the container. Added `tegrastats` (the official JetPack GPU monitor) as the primary detection method — it works on all Jetson platforms including Orin. `nvidia-l4t-tools` (which ships `tegrastats`) is now installed in the Dockerfile for `arm64` builds via Docker's `TARGETARCH` ARG; x86 builds are unaffected.
- **Config UI gap:** `stats_interval` was already in the Pydantic model and config file, but was never surfaced in the Settings form. Added the number field to the System section.
- **STATUS.md:** Cleared both resolved known issues.

## Changes

| File | Change |
|---|---|
| `services/detector/Dockerfile` | Install `nvidia-l4t-tools` on `arm64` via `TARGETARCH` ARG |
| `services/detector/src/stats_collector.py` | Add `tegrastats` platform + `_read_gpu_tegrastats()` method |
| `services/web/src/templates/config.html` | Add `stats_interval` field to System section |
| `services/web/src/static/config.js` | Wire `stats_interval` into `readForm()` |
| `STATUS.md` | Clear resolved known issues |

## Test plan

- [ ] Rebuild detector image on Orin runner; confirm `nvidia-l4t-tools` installs cleanly
- [ ] Check detector log for `"GPU stats platform detected: tegrastats"`
- [ ] Navigate to `/admin/stats` — GPU card appears with live GR3D% and GPU temp
- [ ] Trigger a detection and watch GPU % climb in the history chart
- [ ] Verify x86 dev build succeeds and GPU card stays hidden (expected — no tegrastats)
- [ ] Open Config → System section, confirm stats_interval field renders and saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)