### PR TITLE
feat: detection feedback & bbox persistence (Feature 12 foundation)

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -108,11 +108,42 @@ redis:
 3. Filter results by target classes and confidence threshold
 4. Apply cooldown dedup (don't fire 10 events for same heron standing there)
 5. On new detection event:
-   - Save to SQLite (timestamp, class, confidence, camera, snapshot path)
+   - Save to SQLite (timestamp, class, confidence, camera, snapshot path, bbox, frame_size)
    - Publish to Redis pub/sub channel `scarguard:detections`
-   - Save annotated snapshot frame to disk
+   - Save clean snapshot frame to disk (no bbox annotation burned in)
 6. Notifier picks up events from Redis and dispatches to configured channels
 7. Web UI subscribes to Redis for live event feed via SSE
+8. Web UI renders bbox overlay on snapshots using stored coordinates
+
+## Detection Feedback & Training Pipeline
+
+Events can be labeled via the web UI Events page:
+- **Correct**: Detection was accurate
+- **False Positive**: Detection was wrong (no animal present)
+- **Wrong Class**: Animal was present but misidentified (provide corrected class)
+
+Labeled events power the training pipeline:
+- **Training Data** admin page shows per-class feedback stats
+- **Export** generates YOLO-format dataset zip from confirmed detections
+- **Training script** (`training/train.py`) fine-tunes YOLO on exported data
+- **Model Evaluation** page compares two models side-by-side against labeled snapshots
+- **Model Promotion** updates config and triggers hot-reload
+
+### Database Columns (detection_events)
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | INTEGER | Primary key |
+| `timestamp` | TEXT | ISO 8601 UTC |
+| `class_name` | TEXT | Detected class name |
+| `confidence` | REAL | Detection confidence (0-1) |
+| `camera_name` | TEXT | Camera name from config |
+| `snapshot_path` | TEXT | Path to clean snapshot JPEG |
+| `actions_triggered` | TEXT | JSON array of channel names |
+| `bbox` | TEXT | JSON `[x1, y1, x2, y2]` pixel coords |
+| `frame_size` | TEXT | JSON `[width, height]` of original frame |
+| `feedback` | TEXT | `correct`, `false_positive`, `wrong_class`, or NULL |
+| `corrected_class` | TEXT | Class name when feedback is `wrong_class` |
 
 ## RTSP Notes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -273,7 +273,7 @@ System health panel in the web UI showing resource utilization of the host. Usef
 
 ---
 
-## Feature 12: Detection Feedback & Dataset Collection
+## ~~Feature 12: Detection Feedback & Dataset Collection~~ ✓ Complete (v0.7)
 
 Add a feedback mechanism to each detection event so confirmed positives and false positives can be labeled in-app. This is the foundation of the model improvement pipeline (Features 13–15).
 
@@ -284,9 +284,15 @@ Add a feedback mechanism to each detection event so confirmed positives and fals
 - Unfeedback'd events are visually distinct from reviewed ones in the event log (e.g. badge or row highlight)
 - No feedback is required — the system continues to function normally without it; this is purely additive
 
+**Implementation notes:**
+- Schema migration adds `bbox`, `frame_size`, `feedback`, `corrected_class` columns to `detection_events` table
+- Snapshots saved as clean frames (no burned-in bbox); browser renders bbox overlay using stored coordinates
+- Web service writes feedback via UPDATE to `scarguard.db` (SQLite WAL handles concurrent access)
+- HTMX-powered inline feedback buttons on each event row with colored badges
+
 ---
 
-## Feature 13: Dataset Quality Dashboard & Export
+## ~~Feature 13: Dataset Quality Dashboard & Export~~ ✓ Complete (v0.7)
 
 Give visibility into the labeled dataset being built from feedback, and provide a one-click export for use in model training.
 
@@ -302,9 +308,15 @@ Give visibility into the labeled dataset being built from feedback, and provide 
 - Export only includes events with `feedback = correct` — false positives and wrong-class events are excluded from the positive set
 - Export is downloadable directly from the browser
 
+**Implementation notes:**
+- Admin page at `/admin/training` with per-class feedback breakdown, CSS bar charts, low-data warnings
+- YOLO export at `/admin/training/export` streams a zip with `images/train/`, `labels/train/`, `data.yaml`
+- Wrong-class events included using corrected label as ground truth
+- Events without stored bbox (pre-migration) are excluded from export
+
 ---
 
-## Feature 14: Custom Model Training
+## ~~Feature 14: Custom Model Training~~ ✓ Complete (v0.7)
 
 Replace the generic COCO bird model with a fine-tuned model that distinguishes heron species from pond camera imagery. Training is run manually via a committed script; this is not automated.
 
@@ -318,9 +330,14 @@ Replace the generic COCO bird model with a fine-tuned model that distinguishes h
 - Training notebook or equivalent committed under `training/` for reproducibility
 - **Model promotion is always manual** — the script produces a `.pt` file; the user places it in `models/` and selects it in config or the web UI. No automated deployment of trained models.
 
+**Implementation notes:**
+- Self-contained `training/train.py` CLI script with argparse, validates dataset structure
+- Warns if any class has < 500 images (`--force` to override)
+- `training/README.md` with usage, CLI reference, Jetson tips
+
 ---
 
-## Feature 15: Model Evaluation in Web UI
+## ~~Feature 15: Model Evaluation in Web UI~~ ✓ Complete (v0.7)
 
 Before promoting a newly trained model, compare it against the current one using stored snapshots. Prevents deploying a regression.
 
@@ -331,6 +348,14 @@ Before promoting a newly trained model, compare it against the current one using
 - Evaluation runs on-device (Jetson GPU); show a progress indicator for long runs
 - User can promote the candidate model directly from this page (updates `scarguard.yml` and triggers hot-reload per Feature 10)
 - Graceful handling of snapshots where the original annotated bounding box is unavailable (skip or flag)
+
+**Implementation notes:**
+- EvaluationRunner daemon thread in detector subscribes to Redis `scarguard:eval:request`
+- Models loaded sequentially to conserve Jetson GPU memory; GPU cache freed between runs
+- Web UI at `/admin/training/evaluate` with SSE progress bar, side-by-side metrics tables
+- Metrics: per-class precision/recall/F1 at IoU>=0.5 threshold
+- Model promotion from the page updates `scarguard.yml` and triggers hot-reload
+- Busy guard prevents concurrent evaluations; 10-minute SSE timeout
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,12 @@
 - **Scheduled arm/disarm:** Fixed-time schedule (HH:MM) or solar mode (sunrise/sunset) via `astral`; manual dashboard overrides respected until next transition.
 - **Live feed:** Detection-triggered annotated snapshot feed with SSE, offline indicator, and exponential-backoff auto-reconnect.
 - **App auth:** Session-based login gates all web UI routes. First-run setup page, user management admin UI, API bearer tokens, bcrypt passwords, per-user lockout after N failed attempts.
+- **Detection feedback:** Each event can be labeled as Correct, False Positive, or Wrong Class (with corrected class). HTMX-powered inline controls with colored badges. Unreviewed events visually distinct.
+- **BBox persistence:** Bounding box coordinates and frame dimensions stored in database per detection. Snapshots saved as clean frames; browser renders bbox overlay from stored data.
+- **Training data dashboard:** Admin page showing per-class feedback breakdown, CSS bar charts, exportable event count, date range filter.
+- **YOLO dataset export:** One-click zip download with clean images, normalized bbox annotations, and data.yaml. Includes correct and wrong-class (with corrected label) events.
+- **Custom model training:** Self-contained `training/train.py` CLI script for fine-tuning YOLO models on exported datasets.
+- **Model evaluation:** Admin page for side-by-side model comparison. Runs inference on labeled snapshots via detector's GPU, displays per-class precision/recall/F1, sample detections, and model promotion button.
 
 ## Known Issues / Buggy
 
@@ -26,7 +32,7 @@ None currently identified.
 
 ## Not Yet Built
 
-- Custom-trained heron model (currently using generic COCO bird class)
+- Custom-trained heron model (have the tooling now, need labeled data)
 - Valve actuation (ESP32 hardware not wired yet)
 
 ## Completed Work
@@ -56,3 +62,7 @@ None currently identified.
 | v0.4 | Scheduled arm/disarm (fixed-time + solar mode, manual override, hot-reload) | ✅ Complete |
 | v0.5 | GPU/CPU load stats view (live system resource metrics, per-camera inference FPS/latency, mini-charts) | ✅ Complete |
 | v0.6 | App security & user accounts (session auth, first-run setup, user management, API tokens, lockout) | ✅ Complete |
+| v0.7 | Detection feedback & bbox persistence (per-event labeling, clean snapshots, browser bbox overlay) | ✅ Complete |
+| v0.7 | Training data dashboard & YOLO dataset export (admin page, bar charts, zip export) | ✅ Complete |
+| v0.7 | Custom model training script (training/train.py CLI, dataset validation, Jetson tips) | ✅ Complete |
+| v0.7 | Model evaluation in web UI (side-by-side comparison, SSE progress, model promotion) | ✅ Complete |

--- a/services/detector/src/evaluator.py
+++ b/services/detector/src/evaluator.py
@@ -1,0 +1,394 @@
+"""Model evaluation runner — compares two YOLO models against labeled snapshots.
+
+Listens on Redis channel ``scarguard:eval:request`` for evaluation requests from
+the web service.  Runs inference with each model sequentially (to conserve GPU
+memory on the Jetson), computes per-class precision/recall/mAP@0.5, and publishes
+results back via Redis keys.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+from pathlib import Path
+
+import redis
+
+logger = logging.getLogger(__name__)
+
+REQUEST_CHANNEL = "scarguard:eval:request"
+PROGRESS_KEY = "scarguard:eval:progress"
+RESULT_KEY = "scarguard:eval:result"
+RESULT_TTL = 3600  # 1 hour
+
+
+class EvaluationRunner:
+    """Background thread that processes model evaluation requests via Redis."""
+
+    def __init__(
+        self,
+        redis_cfg: dict,
+        db_path: str,
+        snapshot_dir: str,
+    ) -> None:
+        self._redis_cfg = redis_cfg
+        self._db_path = db_path
+        self._snapshot_dir = Path(snapshot_dir)
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+        self._busy = threading.Lock()
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, name="evaluator", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+
+    def _get_redis(self) -> redis.Redis:
+        return redis.Redis(
+            host=self._redis_cfg.get("host", "redis"),
+            port=int(self._redis_cfg.get("port", 6379)),
+            decode_responses=True,
+        )
+
+    def _run(self) -> None:
+        logger.info("EvaluationRunner started — listening on %s", REQUEST_CHANNEL)
+        while not self._stop.is_set():
+            try:
+                client = self._get_redis()
+                pubsub = client.pubsub()
+                pubsub.subscribe(REQUEST_CHANNEL)
+                for message in pubsub.listen():
+                    if self._stop.is_set():
+                        break
+                    if message["type"] != "message":
+                        continue
+                    try:
+                        request = json.loads(message["data"])
+                        if not self._busy.acquire(blocking=False):
+                            self._publish_error(client, "Evaluation already in progress")
+                            continue
+                        try:
+                            self._handle_request(client, request)
+                        finally:
+                            self._busy.release()
+                    except Exception:
+                        logger.exception("Error processing evaluation request")
+                        self._publish_error(client, "Internal error during evaluation")
+                pubsub.unsubscribe(REQUEST_CHANNEL)
+                client.close()
+            except redis.ConnectionError:
+                if not self._stop.is_set():
+                    logger.warning("Redis connection lost in evaluator — retrying in 5s")
+                    self._stop.wait(5)
+            except Exception:
+                logger.exception("Unexpected error in evaluator loop")
+                self._stop.wait(5)
+
+    def _handle_request(self, client: redis.Redis, request: dict) -> None:
+        model_a_path = request.get("model_a", "")
+        model_b_path = request.get("model_b", "")
+        date_from = request.get("date_from")
+        date_to = request.get("date_to")
+
+        logger.info(
+            "Evaluation request: model_a=%s model_b=%s date_from=%s date_to=%s",
+            model_a_path, model_b_path, date_from, date_to,
+        )
+
+        # Load ground truth from DB
+        ground_truth = self._load_ground_truth(date_from, date_to)
+        if not ground_truth:
+            self._publish_error(client, "No labeled snapshots found for the selected date range")
+            return
+
+        self._set_progress(client, "loading", 0, len(ground_truth) * 2)
+
+        # Run model A
+        logger.info("Running model A: %s on %d snapshots", model_a_path, len(ground_truth))
+        preds_a = self._run_model(client, model_a_path, ground_truth, 0, "Model A")
+        if preds_a is None:
+            return
+
+        # Run model B
+        logger.info("Running model B: %s on %d snapshots", model_b_path, len(ground_truth))
+        preds_b = self._run_model(
+            client, model_b_path, ground_truth, len(ground_truth), "Model B",
+        )
+        if preds_b is None:
+            return
+
+        # Compute metrics
+        self._set_progress(client, "computing", len(ground_truth) * 2, len(ground_truth) * 2)
+        metrics_a = self._compute_metrics(ground_truth, preds_a)
+        metrics_b = self._compute_metrics(ground_truth, preds_b)
+
+        # Collect sample detections (up to 10)
+        samples = self._collect_samples(ground_truth, preds_a, preds_b)
+
+        result = {
+            "status": "complete",
+            "model_a": {"path": model_a_path, "metrics": metrics_a},
+            "model_b": {"path": model_b_path, "metrics": metrics_b},
+            "total_snapshots": len(ground_truth),
+            "samples": samples,
+        }
+        client.set(RESULT_KEY, json.dumps(result), ex=RESULT_TTL)
+        self._set_progress(client, "complete", len(ground_truth) * 2, len(ground_truth) * 2)
+        logger.info("Evaluation complete — results published")
+
+    def _load_ground_truth(
+        self,
+        date_from: str | None,
+        date_to: str | None,
+    ) -> list[dict]:
+        """Load labeled events with bbox data from SQLite."""
+        where = (
+            "camera_name != '_system'"
+            " AND feedback IN ('correct', 'wrong_class')"
+            " AND bbox IS NOT NULL"
+            " AND snapshot_path IS NOT NULL"
+        )
+        params: list[object] = []
+        if date_from:
+            where += " AND timestamp >= ?"
+            params.append(date_from)
+        if date_to:
+            where += " AND timestamp < ?"
+            params.append(date_to)
+
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                f"""
+                SELECT id, class_name, confidence, camera_name,
+                       snapshot_path, bbox, frame_size,
+                       feedback, corrected_class
+                FROM detection_events
+                WHERE {where}
+                ORDER BY id
+                """,
+                params,
+            ).fetchall()
+        finally:
+            conn.close()
+
+        result: list[dict] = []
+        for r in rows:
+            row = dict(r)
+            row["bbox"] = json.loads(row["bbox"]) if isinstance(row["bbox"], str) else row["bbox"]
+            row["frame_size"] = json.loads(row["frame_size"]) if isinstance(row["frame_size"], str) else row["frame_size"]
+            # Use corrected class for wrong_class feedback
+            if row.get("feedback") == "wrong_class" and row.get("corrected_class"):
+                row["effective_class"] = row["corrected_class"]
+            else:
+                row["effective_class"] = row["class_name"]
+            # Resolve snapshot path
+            snap_path = Path(row["snapshot_path"])
+            if not snap_path.exists():
+                snap_path = self._snapshot_dir / snap_path.name
+            if snap_path.exists():
+                row["resolved_path"] = str(snap_path)
+                result.append(row)
+            else:
+                logger.debug("Skipping event %d — snapshot not found: %s", row["id"], row["snapshot_path"])
+
+        return result
+
+    def _run_model(
+        self,
+        client: redis.Redis,
+        model_path: str,
+        ground_truth: list[dict],
+        progress_offset: int,
+        model_label: str,
+    ) -> list[list[dict]] | None:
+        """Run a YOLO model against all snapshots. Returns predictions per snapshot."""
+        try:
+            import cv2
+            from ultralytics import YOLO
+        except ImportError as e:
+            self._publish_error(client, f"Missing dependency: {e}")
+            return None
+
+        try:
+            model = YOLO(model_path)
+        except Exception as e:
+            self._publish_error(client, f"Failed to load {model_label} ({model_path}): {e}")
+            return None
+
+        total = len(ground_truth) * 2
+        all_predictions: list[list[dict]] = []
+
+        for i, gt in enumerate(ground_truth):
+            if self._stop.is_set():
+                return None
+
+            self._set_progress(
+                client, f"running {model_label}", progress_offset + i, total,
+            )
+
+            frame = cv2.imread(gt["resolved_path"])
+            if frame is None:
+                all_predictions.append([])
+                continue
+
+            try:
+                results = model.predict(frame, conf=0.1, verbose=False)
+            except Exception:
+                logger.exception("Inference failed for snapshot %s", gt["resolved_path"])
+                all_predictions.append([])
+                continue
+
+            dets: list[dict] = []
+            for result in results:
+                for box in result.boxes:
+                    class_name: str = result.names[int(box.cls)]
+                    dets.append({
+                        "class_name": class_name,
+                        "confidence": float(box.conf),
+                        "bbox": [int(v) for v in box.xyxy[0]],
+                    })
+            all_predictions.append(dets)
+
+        # Explicitly delete model and free GPU memory
+        del model
+        try:
+            import torch
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except ImportError:
+            pass
+        return all_predictions
+
+    def _compute_metrics(
+        self,
+        ground_truth: list[dict],
+        predictions: list[list[dict]],
+    ) -> dict:
+        """Compute per-class precision, recall, and mAP@0.5."""
+        # Collect all class names from ground truth
+        all_classes: set[str] = {gt["effective_class"] for gt in ground_truth}
+
+        per_class: dict[str, dict] = {}
+        for cls in sorted(all_classes):
+            tp = 0
+            fp = 0
+            fn = 0
+            for gt, preds in zip(ground_truth, predictions):
+                gt_cls = gt["effective_class"]
+                gt_bbox = gt["bbox"]
+
+                # Filter predictions to this class
+                cls_preds = [p for p in preds if p["class_name"] == cls]
+
+                if gt_cls == cls:
+                    # There's a ground truth for this class in this image
+                    matched = False
+                    for pred in cls_preds:
+                        if _iou(gt_bbox, pred["bbox"]) >= 0.5:
+                            matched = True
+                            break
+                    if matched:
+                        tp += 1
+                        # Count remaining predictions as FP
+                        fp += max(0, len(cls_preds) - 1)
+                    else:
+                        fn += 1
+                        fp += len(cls_preds)
+                else:
+                    # No ground truth for this class here — all predictions are FP
+                    fp += len(cls_preds)
+
+            precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+            recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+            f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+            per_class[cls] = {
+                "precision": round(precision, 4),
+                "recall": round(recall, 4),
+                "f1": round(f1, 4),
+                "tp": tp,
+                "fp": fp,
+                "fn": fn,
+            }
+
+        # Overall averages (precision at IoU>=0.5 threshold, not full mAP curve)
+        precisions = [m["precision"] for m in per_class.values()]
+        recalls = [m["recall"] for m in per_class.values()]
+        mean_prec = sum(precisions) / len(precisions) if precisions else 0.0
+        mean_rec = sum(recalls) / len(recalls) if recalls else 0.0
+        f1_scores = [m["f1"] for m in per_class.values()]
+        mean_f1 = sum(f1_scores) / len(f1_scores) if f1_scores else 0.0
+
+        return {
+            "per_class": per_class,
+            "mean_precision": round(mean_prec, 4),
+            "mean_recall": round(mean_rec, 4),
+            "mean_f1": round(mean_f1, 4),
+        }
+
+    def _collect_samples(
+        self,
+        ground_truth: list[dict],
+        preds_a: list[list[dict]],
+        preds_b: list[list[dict]],
+        max_samples: int = 10,
+    ) -> list[dict]:
+        """Collect sample detection data with snapshot filenames (not base64).
+
+        Uses snapshot filenames so the web service can serve images from disk
+        via the existing ``/snapshots/`` static mount, avoiding large payloads.
+        """
+        samples: list[dict] = []
+        step = max(1, len(ground_truth) // max_samples)
+        for i in range(0, len(ground_truth), step):
+            if len(samples) >= max_samples:
+                break
+            gt = ground_truth[i]
+            snap_filename = Path(gt["resolved_path"]).name
+            samples.append({
+                "snapshot_filename": snap_filename,
+                "ground_truth": {
+                    "class_name": gt["effective_class"],
+                    "bbox": gt["bbox"],
+                },
+                "predictions_a": preds_a[i] if i < len(preds_a) else [],
+                "predictions_b": preds_b[i] if i < len(preds_b) else [],
+            })
+        return samples
+
+    def _set_progress(
+        self, client: redis.Redis, status: str, current: int, total: int,
+    ) -> None:
+        progress = {
+            "status": status,
+            "current": current,
+            "total": total,
+            "pct": round((current / total) * 100, 1) if total > 0 else 0,
+        }
+        client.set(PROGRESS_KEY, json.dumps(progress), ex=300)
+
+    def _publish_error(self, client: redis.Redis, message: str) -> None:
+        result = {"status": "error", "error": message}
+        client.set(RESULT_KEY, json.dumps(result), ex=RESULT_TTL)
+        self._set_progress(client, "error", 0, 0)
+        logger.error("Evaluation error: %s", message)
+
+
+def _iou(box_a: list[int], box_b: list[int]) -> float:
+    """Compute Intersection over Union for two [x1, y1, x2, y2] boxes."""
+    x1 = max(box_a[0], box_b[0])
+    y1 = max(box_a[1], box_b[1])
+    x2 = min(box_a[2], box_b[2])
+    y2 = min(box_a[3], box_b[3])
+    inter = max(0, x2 - x1) * max(0, y2 - y1)
+    area_a = (box_a[2] - box_a[0]) * (box_a[3] - box_a[1])
+    area_b = (box_b[2] - box_b[0]) * (box_b[3] - box_b[1])
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0

--- a/services/detector/src/events.py
+++ b/services/detector/src/events.py
@@ -57,6 +57,10 @@ class EventProcessor:
         now = time.monotonic()
         events: list[dict] = []
 
+        # Capture frame dimensions (h, w) for bbox normalization at export time.
+        frame_h, frame_w = frame.shape[:2]
+        frame_size = (frame_w, frame_h)
+
         for det in detections:
             key = f"{camera_name}:{det.class_name}"
             with self._cooldown_lock:
@@ -72,7 +76,10 @@ class EventProcessor:
             actions_triggered = (
                 (actions_by_class or {}).get(det.class_name) or []
             )
-            self._persist(timestamp, det, camera_name, snapshot_path, actions_triggered)
+            self._persist(
+                timestamp, det, camera_name, snapshot_path,
+                actions_triggered, frame_size,
+            )
 
             logger.info(
                 "[%s] %s detected (conf=%.2f)",
@@ -80,6 +87,7 @@ class EventProcessor:
                 det.class_name,
                 det.confidence,
             )
+            bbox_list = list(det.bbox) if det.bbox else None
             events.append(
                 {
                     "timestamp": timestamp.isoformat(),
@@ -88,6 +96,8 @@ class EventProcessor:
                     "camera_name": camera_name,
                     "snapshot_path": snapshot_path,
                     "actions_triggered": actions_triggered,
+                    "bbox": bbox_list,
+                    "frame_size": list(frame_size),
                 }
             )
 
@@ -133,28 +143,20 @@ class EventProcessor:
         camera_name: str,
         timestamp: datetime,
     ) -> str | None:
+        """Save a clean (unannotated) snapshot frame to disk.
+
+        BBox data is persisted separately in the database; the browser
+        renders the overlay using stored coordinates.
+        """
         try:
             # Import lazily so unit tests can run in environments without OpenCV system libs.
             import cv2
 
-            annotated = frame.copy()
-            x1, y1, x2, y2 = det.bbox
-            cv2.rectangle(annotated, (x1, y1), (x2, y2), (0, 0, 255), 2)
-            label = f"{det.class_name} {det.confidence:.2f}"
-            cv2.putText(
-                annotated,
-                label,
-                (x1, max(y1 - 8, 0)),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.6,
-                (0, 0, 255),
-                2,
-            )
             filename = (
                 f"{camera_name}_{det.class_name}_{timestamp.strftime('%Y%m%dT%H%M%SZ')}.jpg"
             )
             path = self._snapshot_dir / filename
-            cv2.imwrite(str(path), annotated)
+            cv2.imwrite(str(path), frame)
             logger.debug("Snapshot saved: %s", path)
             return str(path)
         except Exception:
@@ -178,17 +180,23 @@ class EventProcessor:
                 )
                 """
             )
-            # Migration: add actions_triggered column to existing databases
+            # Migrations: add columns to existing databases
             existing = {
                 row[1]
                 for row in self._conn.execute(
                     "PRAGMA table_info(detection_events)"
                 ).fetchall()
             }
-            if "actions_triggered" not in existing:
-                self._conn.execute(
-                    "ALTER TABLE detection_events ADD COLUMN actions_triggered TEXT"
-                )
+            migrations: dict[str, str] = {
+                "actions_triggered": "ALTER TABLE detection_events ADD COLUMN actions_triggered TEXT",
+                "bbox": "ALTER TABLE detection_events ADD COLUMN bbox TEXT",
+                "frame_size": "ALTER TABLE detection_events ADD COLUMN frame_size TEXT",
+                "feedback": "ALTER TABLE detection_events ADD COLUMN feedback TEXT",
+                "corrected_class": "ALTER TABLE detection_events ADD COLUMN corrected_class TEXT",
+            }
+            for col, ddl in migrations.items():
+                if col not in existing:
+                    self._conn.execute(ddl)
             self._conn.commit()
 
     def _persist(
@@ -198,10 +206,14 @@ class EventProcessor:
         camera_name: str,
         snapshot_path: str | None,
         actions_triggered: list[str],
+        frame_size: tuple[int, int] | None = None,
     ) -> None:
         with self._db_lock:
             try:
-                self._insert_event(timestamp, det, camera_name, snapshot_path, actions_triggered)
+                self._insert_event(
+                    timestamp, det, camera_name, snapshot_path,
+                    actions_triggered, frame_size,
+                )
                 self._conn.commit()
             except Exception:
                 logger.exception("Failed to persist detection event to database")
@@ -217,13 +229,17 @@ class EventProcessor:
         camera_name: str,
         snapshot_path: str | None,
         actions_triggered: list[str],
+        frame_size: tuple[int, int] | None = None,
     ) -> None:
         actions_json = json.dumps(actions_triggered) if actions_triggered else None
+        bbox_json = json.dumps(list(det.bbox)) if det.bbox else None
+        frame_size_json = json.dumps(list(frame_size)) if frame_size else None
         self._conn.execute(
             """
             INSERT INTO detection_events
-                (timestamp, class_name, confidence, camera_name, snapshot_path, actions_triggered)
-            VALUES (?, ?, ?, ?, ?, ?)
+                (timestamp, class_name, confidence, camera_name, snapshot_path,
+                 actions_triggered, bbox, frame_size)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 timestamp.isoformat(),
@@ -232,6 +248,8 @@ class EventProcessor:
                 camera_name,
                 snapshot_path,
                 actions_json,
+                bbox_json,
+                frame_size_json,
             ),
         )
 

--- a/services/detector/src/main.py
+++ b/services/detector/src/main.py
@@ -21,6 +21,7 @@ import yaml
 from cleanup import SnapshotCleaner
 from config_watcher import ConfigWatcher
 from detector import YOLODetector
+from evaluator import EvaluationRunner
 from events import EventProcessor
 from publisher import RedisPublisher
 from scheduler import ArmScheduler
@@ -336,6 +337,14 @@ def main() -> None:
     )
     stats_collector.start()
 
+    # ---- Model evaluation runner -----------------------------------------------
+    eval_runner = EvaluationRunner(
+        redis_cfg=redis_cfg,
+        db_path=DB_PATH,
+        snapshot_dir=SNAPSHOT_DIR,
+    )
+    eval_runner.start()
+
     # ---- Config hot-reload ----------------------------------------------------
     def _on_config_change(new_cfg: dict) -> None:
         new_sys = new_cfg.get("system", {})
@@ -418,6 +427,7 @@ def main() -> None:
 
     watcher.stop()
     scheduler.stop()
+    eval_runner.stop()
     for name in list(active_cameras.keys()):
         _stop_camera(name)
     event_processor.close()

--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -1,4 +1,8 @@
-"""Read-only SQLite access for detection events."""
+"""SQLite access for detection events.
+
+The detector service is the primary writer (INSERTs).  The web service writes
+only to the ``feedback`` and ``corrected_class`` columns via UPDATE.
+"""
 
 import os
 import sqlite3
@@ -18,7 +22,7 @@ def _date_to_exclusive(date_str: str) -> str:
 
 
 def _connect() -> sqlite3.Connection:
-    conn = sqlite3.connect(DB_PATH)
+    conn = sqlite3.connect(DB_PATH, timeout=5)
     conn.row_factory = sqlite3.Row
     return conn
 
@@ -55,7 +59,8 @@ def get_events(
         return conn.execute(
             f"""
             SELECT id, timestamp, class_name, confidence, camera_name,
-                   snapshot_path, actions_triggered
+                   snapshot_path, actions_triggered, bbox, frame_size,
+                   feedback, corrected_class
             FROM detection_events
             {clause}
             ORDER BY id DESC
@@ -141,3 +146,101 @@ def count_events_today() -> int:
             """
         ).fetchone()
         return row[0] if row else 0
+
+
+# ── Feedback ────────────────────────────────────────────────────────────────
+
+def update_feedback(
+    event_id: int,
+    feedback: str,
+    corrected_class: str | None = None,
+) -> bool:
+    """Set feedback on a detection event.  Returns True on success."""
+    with _connect() as conn:
+        cur = conn.execute(
+            """
+            UPDATE detection_events
+            SET feedback = ?, corrected_class = ?
+            WHERE id = ?
+            """,
+            (feedback, corrected_class, event_id),
+        )
+        conn.commit()
+        return cur.rowcount > 0
+
+
+def get_feedback_stats(
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> dict:
+    """Aggregate feedback counts by class and feedback type.
+
+    Returns::
+
+        {
+            "total_labeled": int,
+            "total_unlabeled": int,
+            "by_class": {
+                "<class_name>": {"correct": N, "false_positive": N, "wrong_class": N}
+            },
+            "date_min": str | None,
+            "date_max": str | None,
+        }
+    """
+    where: list[str] = ["camera_name != '_system'"]
+    params: list[object] = []
+    if date_from:
+        where.append("timestamp >= ?")
+        params.append(date_from)
+    if date_to:
+        where.append("timestamp < ?")
+        params.append(_date_to_exclusive(date_to))
+
+    clause = "WHERE " + " AND ".join(where)
+
+    with _connect() as conn:
+        # Per-class feedback counts
+        rows = conn.execute(
+            f"""
+            SELECT class_name, feedback, COUNT(*) AS cnt
+            FROM detection_events
+            {clause} AND feedback IS NOT NULL
+            GROUP BY class_name, feedback
+            """,
+            params,
+        ).fetchall()
+
+        by_class: dict[str, dict[str, int]] = {}
+        total_labeled = 0
+        for r in rows:
+            cls = r["class_name"]
+            fb = r["feedback"]
+            cnt = r["cnt"]
+            total_labeled += cnt
+            if cls not in by_class:
+                by_class[cls] = {"correct": 0, "false_positive": 0, "wrong_class": 0}
+            if fb in by_class[cls]:
+                by_class[cls][fb] = cnt
+
+        # Total unlabeled
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM detection_events {clause} AND feedback IS NULL",
+            params,
+        ).fetchone()
+        total_unlabeled = row[0] if row else 0
+
+        # Date range coverage
+        row = conn.execute(
+            f"SELECT MIN(timestamp), MAX(timestamp) FROM detection_events {clause} AND feedback IS NOT NULL",
+            params,
+        ).fetchone()
+        date_min = row[0] if row else None
+        date_max = row[1] if row else None
+
+    return {
+        "total_labeled": total_labeled,
+        "total_unlabeled": total_unlabeled,
+        "by_class": by_class,
+        "date_min": date_min,
+        "date_max": date_max,
+    }

--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -244,3 +244,60 @@ def get_feedback_stats(
         "date_min": date_min,
         "date_max": date_max,
     }
+
+
+# ── Export ──────────────────────────────────────────────────────────────────
+
+_EXPORTABLE_WHERE = (
+    "camera_name != '_system'"
+    " AND feedback IN ('correct', 'wrong_class')"
+    " AND bbox IS NOT NULL"
+    " AND snapshot_path IS NOT NULL"
+)
+
+
+def count_exportable_events(
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> int:
+    """Count events eligible for YOLO dataset export."""
+    where = _EXPORTABLE_WHERE
+    params: list[object] = []
+    if date_from:
+        where += " AND timestamp >= ?"
+        params.append(date_from)
+    if date_to:
+        where += " AND timestamp < ?"
+        params.append(_date_to_exclusive(date_to))
+    with _connect() as conn:
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM detection_events WHERE {where}", params
+        ).fetchone()
+        return row[0] if row else 0
+
+
+def get_exportable_events(
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> list[sqlite3.Row]:
+    """Return events eligible for YOLO dataset export."""
+    where = _EXPORTABLE_WHERE
+    params: list[object] = []
+    if date_from:
+        where += " AND timestamp >= ?"
+        params.append(date_from)
+    if date_to:
+        where += " AND timestamp < ?"
+        params.append(_date_to_exclusive(date_to))
+    with _connect() as conn:
+        return conn.execute(
+            f"""
+            SELECT id, class_name, confidence, camera_name,
+                   snapshot_path, bbox, frame_size,
+                   feedback, corrected_class
+            FROM detection_events
+            WHERE {where}
+            ORDER BY id
+            """,
+            params,
+        ).fetchall()

--- a/services/web/src/main.py
+++ b/services/web/src/main.py
@@ -9,7 +9,7 @@ import auth as auth_module
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
-from routes import about, admin, config, dashboard, events, feed, models, stats
+from routes import about, admin, config, dashboard, events, feed, models, stats, training
 from routes import auth as auth_routes
 from routes import users as users_routes
 
@@ -122,3 +122,4 @@ app.include_router(feed.router)
 app.include_router(about.router)
 app.include_router(admin.router)
 app.include_router(stats.router)
+app.include_router(training.router)

--- a/services/web/src/routes/auth.py
+++ b/services/web/src/routes/auth.py
@@ -7,7 +7,7 @@ import os
 import auth as auth_module
 from config_store import load_cached
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from fastapi.templating import Jinja2Templates
 
 _src = os.path.dirname(os.path.dirname(__file__))
@@ -37,7 +37,7 @@ def _safe_next(value: str) -> str:
 
 
 @router.get("/login", response_class=HTMLResponse)
-async def login_get(request: Request, next: str = "/") -> HTMLResponse:
+async def login_get(request: Request, next: str = "/") -> Response:
     # Already authenticated? Go home.
     if getattr(request.state, "user", None) is not None:
         return RedirectResponse("/", status_code=302)
@@ -54,7 +54,7 @@ async def login_post(
     username: str = Form(...),
     password: str = Form(...),
     next: str = Form("/"),
-) -> HTMLResponse:
+) -> Response:
     auth_cfg = _get_auth_cfg()
     max_attempts = auth_cfg.get("max_login_attempts", 5)
     lockout_minutes = auth_cfg.get("lockout_duration_minutes", 15)
@@ -147,7 +147,7 @@ async def logout(request: Request) -> RedirectResponse:
 # ── First-run setup ───────────────────────────────────────────────────────────
 
 @router.get("/setup", response_class=HTMLResponse)
-async def setup_get(request: Request) -> HTMLResponse:
+async def setup_get(request: Request) -> Response:
     # If users already exist, redirect to login
     if auth_module.users_exist(AUTH_DB_PATH):
         return RedirectResponse("/login", status_code=302)
@@ -164,7 +164,7 @@ async def setup_post(
     username: str = Form(...),
     password: str = Form(...),
     confirm_password: str = Form(...),
-) -> HTMLResponse:
+) -> Response:
     # If users already exist, deny
     if auth_module.users_exist(AUTH_DB_PATH):
         return RedirectResponse("/login", status_code=302)

--- a/services/web/src/routes/auth.py
+++ b/services/web/src/routes/auth.py
@@ -40,7 +40,7 @@ def _safe_next(value: str) -> str:
 async def login_get(request: Request, next: str = "/") -> HTMLResponse:
     # Already authenticated? Go home.
     if getattr(request.state, "user", None) is not None:
-        return RedirectResponse("/", status_code=302)  # type: ignore[return-value]
+        return RedirectResponse("/", status_code=302)
     return templates.TemplateResponse(
         request,
         "login.html",
@@ -124,7 +124,7 @@ async def login_post(
         secure=_is_https(request),
         max_age=session_hours * 3600,
     )
-    return response  # type: ignore[return-value]
+    return response
 
 
 # ── Logout ────────────────────────────────────────────────────────────────────
@@ -150,7 +150,7 @@ async def logout(request: Request) -> RedirectResponse:
 async def setup_get(request: Request) -> HTMLResponse:
     # If users already exist, redirect to login
     if auth_module.users_exist(AUTH_DB_PATH):
-        return RedirectResponse("/login", status_code=302)  # type: ignore[return-value]
+        return RedirectResponse("/login", status_code=302)
     return templates.TemplateResponse(
         request,
         "setup.html",
@@ -167,7 +167,7 @@ async def setup_post(
 ) -> HTMLResponse:
     # If users already exist, deny
     if auth_module.users_exist(AUTH_DB_PATH):
-        return RedirectResponse("/login", status_code=302)  # type: ignore[return-value]
+        return RedirectResponse("/login", status_code=302)
 
     # Validate input
     if not username.strip():
@@ -211,4 +211,4 @@ async def setup_post(
         secure=_is_https(request),
         max_age=session_hours * 3600,
     )
-    return response  # type: ignore[return-value]
+    return response

--- a/services/web/src/routes/events.py
+++ b/services/web/src/routes/events.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import config_store
 import db
 import redis.asyncio as aioredis
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 
@@ -39,13 +39,14 @@ def _apply_display_timestamp(events: list[dict]) -> list[dict]:
     tz = _tz_name()
     for e in events:
         e["display_timestamp"] = _to_local(e.get("timestamp", ""), tz)
-        # Deserialize actions_triggered from its JSON string (stored in SQLite).
-        raw = e.get("actions_triggered")
-        if isinstance(raw, str):
-            try:
-                e["actions_triggered"] = json.loads(raw)
-            except (json.JSONDecodeError, TypeError):
-                e["actions_triggered"] = []
+        # Deserialize JSON strings stored in SQLite.
+        for key in ("actions_triggered", "bbox", "frame_size"):
+            raw = e.get(key)
+            if isinstance(raw, str):
+                try:
+                    e[key] = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    e[key] = [] if key == "actions_triggered" else None
     return events
 
 
@@ -92,6 +93,7 @@ async def events_page(
             "filter_class": class_name,
             "filter_date_from": date_from,
             "filter_date_to": date_to,
+            "target_classes": _get_target_classes(),
         },
     )
 
@@ -116,7 +118,38 @@ async def event_rows(
     return templates.TemplateResponse(
         request,
         "partials/event_rows.html",
-        {"events": events},
+        {"events": events, "target_classes": _get_target_classes()},
+    )
+
+
+def _get_target_classes() -> list[str]:
+    """Return target classes from config for the wrong-class dropdown."""
+    return config_store.load_cached().get("detection", {}).get("target_classes", [])
+
+
+@router.post("/{event_id}/feedback", response_class=HTMLResponse)
+async def submit_feedback(
+    request: Request,
+    event_id: int,
+    feedback: str = Form(...),
+    corrected_class: str = Form(""),
+):
+    """Set or update feedback on a detection event.  Returns the updated row."""
+    if feedback not in ("correct", "false_positive", "wrong_class"):
+        feedback = "correct"
+    corr = corrected_class.strip() or None
+    if feedback != "wrong_class":
+        corr = None
+    db.update_feedback(event_id, feedback, corr)
+    row = db.get_event(event_id)
+    if row is None:
+        return HTMLResponse("<tr><td colspan='7'>Event not found</td></tr>")
+    event = dict(row)
+    events = _apply_display_timestamp([event])
+    return templates.TemplateResponse(
+        request,
+        "partials/event_rows.html",
+        {"events": events, "target_classes": _get_target_classes()},
     )
 
 
@@ -154,25 +187,41 @@ async def event_stream(request: Request):
 
 def _render_event_row(event: dict, tz_name: str = "UTC") -> str:
     snap = event.get("snapshot_path")
+    bbox = event.get("bbox")
+    frame_size = event.get("frame_size")
     snap_html = ""
     if snap:
         fname = Path(snap).name
-        snap_html = f'<a href="/snapshots/{fname}" target="_blank"><img src="/snapshots/{fname}" width="80"></a>'
+        data_attrs = ""
+        if bbox and frame_size:
+            data_attrs = (
+                f' data-bbox="{_html.escape(json.dumps(bbox))}"'
+                f' data-frame-size="{_html.escape(json.dumps(frame_size))}"'
+            )
+        snap_html = (
+            f'<a href="/snapshots/{fname}" target="_blank" class="snapshot-link"'
+            f'{data_attrs}>'
+            f'<img src="/snapshots/{fname}" width="80" loading="lazy">'
+            f'</a>'
+        )
     conf = event.get("confidence", 0)
     display_ts = _to_local(event.get("timestamp", ""), tz_name)
     actions: list[str] = event.get("actions_triggered") or []
     actions_html = (
         "".join(f'<span class="tag">{_html.escape(ch)}</span>' for ch in actions)
         if actions
-        else "—"
+        else "\u2014"
     )
+    # New events from SSE have no feedback yet
+    feedback_html = '<span class="muted">\u2014</span>'
     return (
-        f'<tr id="event-live">'
-        f'<td>{display_ts}</td>'
+        f'<tr id="event-live" class="event-unreviewed">'
+        f"<td>{display_ts}</td>"
         f'<td>{event.get("class_name", "").replace("_", " ").title()}</td>'
-        f'<td>{conf:.0%}</td>'
+        f"<td>{conf:.0%}</td>"
         f'<td>{event.get("camera_name", "")}</td>'
         f'<td class="actions-cell">{actions_html}</td>'
-        f'<td>{snap_html}</td>'
-        f'</tr>'
+        f"<td>{snap_html}</td>"
+        f'<td class="feedback-cell">{feedback_html}</td>'
+        f"</tr>"
     )

--- a/services/web/src/routes/feed.py
+++ b/services/web/src/routes/feed.py
@@ -98,6 +98,9 @@ async def feed_stream(request: Request):
                     "snapshot_filename": Path(snap).name if snap else None,
                     "class_name": event.get("class_name", ""),
                     "label": label,
+                    "bbox": event.get("bbox"),
+                    "frame_size": event.get("frame_size"),
+                    "confidence": event.get("confidence", 0),
                 })
                 yield f"event: detection\ndata: {payload}\n\n"
         finally:

--- a/services/web/src/routes/training.py
+++ b/services/web/src/routes/training.py
@@ -1,0 +1,161 @@
+"""Training data dashboard and YOLO-format dataset export."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import zipfile
+from pathlib import Path
+
+import db
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.templating import Jinja2Templates
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/admin/training")
+templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
+
+SNAPSHOT_DIR = os.environ.get("SNAPSHOT_DIR", "/data/snapshots")
+
+
+@router.get("", response_class=HTMLResponse)
+async def training_dashboard(
+    request: Request,
+    date_from: str = "",
+    date_to: str = "",
+) -> HTMLResponse:
+    """Training data quality dashboard."""
+    dfrom = date_from or None
+    dto = date_to or None
+    stats = db.get_feedback_stats(date_from=dfrom, date_to=dto)
+
+    # Build per-class data for the bar chart
+    by_class = stats["by_class"]
+    max_correct = max(
+        (v["correct"] for v in by_class.values()), default=1
+    ) or 1
+
+    class_chart: list[dict] = []
+    for cls_name, counts in sorted(by_class.items()):
+        class_chart.append({
+            "name": cls_name.replace("_", " ").title(),
+            "raw_name": cls_name,
+            "correct": counts["correct"],
+            "false_positive": counts["false_positive"],
+            "wrong_class": counts["wrong_class"],
+            "bar_pct": (counts["correct"] / max_correct) * 100,
+            "low_data": counts["correct"] < 500,
+        })
+
+    # Count exportable events (correct or wrong_class with bbox)
+    exportable = db.count_exportable_events(date_from=dfrom, date_to=dto)
+
+    return templates.TemplateResponse(
+        request,
+        "training.html",
+        {
+            "stats": stats,
+            "class_chart": class_chart,
+            "exportable": exportable,
+            "filter_date_from": date_from,
+            "filter_date_to": date_to,
+        },
+    )
+
+
+@router.get("/export")
+async def export_dataset(
+    request: Request,
+    date_from: str = "",
+    date_to: str = "",
+) -> StreamingResponse:
+    """Generate a YOLO-format dataset zip from confirmed detections."""
+    dfrom = date_from or None
+    dto = date_to or None
+    rows = db.get_exportable_events(date_from=dfrom, date_to=dto)
+
+    if not rows:
+        return StreamingResponse(
+            iter([b"No exportable events found."]),
+            media_type="text/plain",
+            status_code=404,
+        )
+
+    # Build class-to-index mapping from distinct labels
+    class_set: set[str] = set()
+    for r in rows:
+        label = _effective_class(r)
+        class_set.add(label)
+    class_names = sorted(class_set)
+    class_to_idx = {name: idx for idx, name in enumerate(class_names)}
+
+    # Stream a zip file
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        # Write data.yaml
+        data_yaml = _build_data_yaml(class_names)
+        zf.writestr("dataset/data.yaml", data_yaml)
+
+        for r in rows:
+            row = dict(r)
+            event_id = row["id"]
+            snapshot_path = row["snapshot_path"]
+            bbox = json.loads(row["bbox"]) if isinstance(row["bbox"], str) else row["bbox"]
+            frame_size = json.loads(row["frame_size"]) if isinstance(row["frame_size"], str) else row["frame_size"]
+            label = _effective_class(row)
+            class_idx = class_to_idx[label]
+
+            # Copy snapshot image
+            src_path = Path(snapshot_path)
+            if not src_path.exists():
+                # Try in SNAPSHOT_DIR
+                src_path = Path(SNAPSHOT_DIR) / src_path.name
+            if not src_path.exists():
+                logger.warning("Snapshot missing for event %d: %s", event_id, snapshot_path)
+                continue
+
+            img_name = f"{event_id}.jpg"
+            zf.write(str(src_path), f"dataset/images/train/{img_name}")
+
+            # Write YOLO annotation
+            x1, y1, x2, y2 = bbox
+            fw, fh = frame_size
+            x_center = ((x1 + x2) / 2) / fw
+            y_center = ((y1 + y2) / 2) / fh
+            width = (x2 - x1) / fw
+            height = (y2 - y1) / fh
+            annotation = f"{class_idx} {x_center:.6f} {y_center:.6f} {width:.6f} {height:.6f}\n"
+            zf.writestr(f"dataset/labels/train/{event_id}.txt", annotation)
+
+    buf.seek(0)
+    return StreamingResponse(
+        iter([buf.read()]),
+        media_type="application/zip",
+        headers={"Content-Disposition": "attachment; filename=scarguard_dataset.zip"},
+    )
+
+
+def _effective_class(row: object) -> str:
+    """Return the effective class name, using corrected_class for wrong_class feedback."""
+    r: dict = dict(row) if not isinstance(row, dict) else row  # type: ignore[call-overload]
+    if r.get("feedback") == "wrong_class" and r.get("corrected_class"):
+        return r["corrected_class"]
+    return r["class_name"]
+
+
+def _build_data_yaml(class_names: list[str]) -> str:
+    """Generate a YOLO data.yaml file content."""
+    lines = [
+        "# ScarGuard exported dataset",
+        "path: .",
+        "train: images/train",
+        "val: images/train  # split manually if desired",
+        "",
+        f"nc: {len(class_names)}",
+        f"names: {class_names}",
+        "",
+    ]
+    return "\n".join(lines)

--- a/services/web/src/routes/training.py
+++ b/services/web/src/routes/training.py
@@ -1,7 +1,9 @@
-"""Training data dashboard and YOLO-format dataset export."""
+"""Training data dashboard, YOLO-format dataset export, and model evaluation."""
 
 from __future__ import annotations
 
+import asyncio
+import html as _html
 import io
 import json
 import logging
@@ -9,8 +11,10 @@ import os
 import zipfile
 from pathlib import Path
 
+import config_store
 import db
-from fastapi import APIRouter, Request
+import redis.asyncio as aioredis
+from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 
@@ -19,6 +23,12 @@ router = APIRouter(prefix="/admin/training")
 templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
 
 SNAPSHOT_DIR = os.environ.get("SNAPSHOT_DIR", "/data/snapshots")
+MODELS_DIR = Path(os.environ.get("MODELS_DIR", "/models"))
+ALLOWED_MODEL_EXTENSIONS = {".pt", ".engine", ".onnx"}
+
+EVAL_REQUEST_CHANNEL = "scarguard:eval:request"
+EVAL_PROGRESS_KEY = "scarguard:eval:progress"
+EVAL_RESULT_KEY = "scarguard:eval:result"
 
 
 @router.get("", response_class=HTMLResponse)
@@ -159,3 +169,149 @@ def _build_data_yaml(class_names: list[str]) -> str:
         "",
     ]
     return "\n".join(lines)
+
+
+def _list_models() -> list[dict]:
+    """Return available model files from the models directory."""
+    if not MODELS_DIR.exists():
+        return []
+    return sorted(
+        [
+            {"name": f.name, "size_mb": round(f.stat().st_size / 1_048_576, 1)}
+            for f in MODELS_DIR.iterdir()
+            if f.is_file() and f.suffix in ALLOWED_MODEL_EXTENSIONS
+        ],
+        key=lambda x: str(x["name"]),
+    )
+
+
+# ── Model Evaluation ──────────────────────────────────────────────────────
+
+
+@router.get("/evaluate", response_class=HTMLResponse)
+async def evaluate_page(request: Request) -> HTMLResponse:
+    """Model evaluation comparison page."""
+    models = _list_models()
+    cfg = config_store.load_cached()
+    current_model = cfg.get("detection", {}).get("model_path", "")
+    return templates.TemplateResponse(
+        request,
+        "evaluate.html",
+        {
+            "models": models,
+            "current_model": Path(current_model).name if current_model else "",
+        },
+    )
+
+
+@router.post("/evaluate", response_class=HTMLResponse)
+async def start_evaluation(
+    request: Request,
+    model_a: str = Form(...),
+    model_b: str = Form(...),
+    date_from: str = Form(""),
+    date_to: str = Form(""),
+) -> HTMLResponse:
+    """Publish an evaluation request to Redis for the detector to process."""
+    cfg = config_store.load_cached()
+    redis_cfg = cfg.get("redis", {})
+    host = redis_cfg.get("host", "redis")
+    port = int(redis_cfg.get("port", 6379))
+
+    # Resolve model paths
+    model_a_path = str(MODELS_DIR / model_a) if model_a else ""
+    model_b_path = str(MODELS_DIR / model_b) if model_b else ""
+
+    eval_request = {
+        "model_a": model_a_path,
+        "model_b": model_b_path,
+        "date_from": date_from or None,
+        "date_to": date_to or None,
+    }
+
+    client = aioredis.Redis(host=host, port=port, decode_responses=True)
+    try:
+        await client.publish(EVAL_REQUEST_CHANNEL, json.dumps(eval_request))
+    finally:
+        await client.aclose()  # type: ignore[attr-defined]
+
+    return HTMLResponse(
+        '<div class="alert alert-ok">Evaluation started. Results will appear below.</div>'
+    )
+
+
+@router.get("/evaluate/stream")
+async def evaluate_stream(request: Request) -> StreamingResponse:
+    """SSE stream — polls Redis for evaluation progress and results."""
+    cfg = config_store.load_cached()
+    redis_cfg = cfg.get("redis", {})
+    host = redis_cfg.get("host", "redis")
+    port = int(redis_cfg.get("port", 6379))
+
+    max_poll_seconds = 600  # 10-minute timeout
+
+    async def generator():
+        client = aioredis.Redis(host=host, port=port, decode_responses=True)
+        try:
+            yield ": connected\n\n"
+            elapsed = 0.0
+            while elapsed < max_poll_seconds:
+                if await request.is_disconnected():
+                    break
+
+                # Check progress
+                progress_raw = await client.get(EVAL_PROGRESS_KEY)
+                if progress_raw:
+                    progress = json.loads(progress_raw)
+                    yield f"event: progress\ndata: {json.dumps(progress)}\n\n"
+
+                    if progress.get("status") in ("complete", "error"):
+                        # Fetch final result
+                        result_raw = await client.get(EVAL_RESULT_KEY)
+                        if result_raw:
+                            yield f"event: result\ndata: {result_raw}\n\n"
+                        break
+
+                await asyncio.sleep(1)
+                elapsed += 1.0
+            else:
+                # Timeout reached
+                timeout_msg = json.dumps({"status": "error", "error": "Evaluation timed out"})
+                yield f"event: result\ndata: {timeout_msg}\n\n"
+        finally:
+            await client.aclose()
+
+    return StreamingResponse(generator(), media_type="text/event-stream")
+
+
+@router.post("/promote", response_class=HTMLResponse)
+async def promote_model(
+    request: Request,
+    model_path: str = Form(...),
+) -> HTMLResponse:
+    """Update the active model in scarguard.yml, triggering hot-reload."""
+    safe_name = Path(model_path).name  # strip directory components
+    model_file = MODELS_DIR / safe_name
+
+    # Validate resolved path stays inside MODELS_DIR
+    if not model_file.resolve().is_relative_to(MODELS_DIR.resolve()):
+        return HTMLResponse(
+            '<div class="alert alert-err">Invalid model path.</div>',
+            status_code=400,
+        )
+
+    if not model_file.exists():
+        return HTMLResponse(
+            f'<div class="alert alert-err">Model not found: {_html.escape(safe_name)}</div>',
+            status_code=404,
+        )
+
+    # Update config
+    cfg = config_store.load()
+    cfg.setdefault("detection", {})["model_path"] = f"/models/{safe_name}"
+    config_store.save(cfg)
+
+    return HTMLResponse(
+        f'<div class="alert alert-ok">Model promoted: {_html.escape(safe_name)}. '
+        f"Hot-reload will apply the change.</div>"
+    )

--- a/services/web/src/routes/training.py
+++ b/services/web/src/routes/training.py
@@ -233,7 +233,7 @@ async def start_evaluation(
     try:
         await client.publish(EVAL_REQUEST_CHANNEL, json.dumps(eval_request))
     finally:
-        await client.aclose()  # type: ignore[attr-defined]
+        await client.aclose()  # type: ignore[attr-defined,unused-ignore]
 
     return HTMLResponse(
         '<div class="alert alert-ok">Evaluation started. Results will appear below.</div>'

--- a/services/web/src/routes/users.py
+++ b/services/web/src/routes/users.py
@@ -7,7 +7,7 @@ import sqlite3
 
 import auth as auth_module
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from fastapi.templating import Jinja2Templates
 
 _src = os.path.dirname(os.path.dirname(__file__))
@@ -29,7 +29,7 @@ def _require_admin(request: Request) -> dict | None:
 # ── User list ─────────────────────────────────────────────────────────────────
 
 @router.get("", response_class=HTMLResponse)
-async def users_list(request: Request) -> HTMLResponse:
+async def users_list(request: Request) -> Response:
     if _require_admin(request) is None:
         return RedirectResponse("/", status_code=302)
 
@@ -163,7 +163,7 @@ async def delete_user(request: Request, user_id: int) -> RedirectResponse:
 async def create_api_token(
     request: Request,
     name: str = Form(...),
-) -> HTMLResponse:
+) -> Response:
     if _require_admin(request) is None:
         return RedirectResponse("/", status_code=302)
 

--- a/services/web/src/routes/users.py
+++ b/services/web/src/routes/users.py
@@ -31,7 +31,7 @@ def _require_admin(request: Request) -> dict | None:
 @router.get("", response_class=HTMLResponse)
 async def users_list(request: Request) -> HTMLResponse:
     if _require_admin(request) is None:
-        return RedirectResponse("/", status_code=302)  # type: ignore[return-value]
+        return RedirectResponse("/", status_code=302)
 
     db = auth_module.get_db(AUTH_DB_PATH)
     try:
@@ -165,7 +165,7 @@ async def create_api_token(
     name: str = Form(...),
 ) -> HTMLResponse:
     if _require_admin(request) is None:
-        return RedirectResponse("/", status_code=302)  # type: ignore[return-value]
+        return RedirectResponse("/", status_code=302)
 
     current_user = request.state.user
     db = auth_module.get_db(AUTH_DB_PATH)

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -569,3 +569,77 @@ input[type="range"] {
   border-radius: 2px;
   white-space: nowrap;
 }
+
+/* ── Training dashboard ──────────────────────────────────────────────────── */
+.training-stats-row {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+.training-stat-card {
+  flex: 1;
+  text-align: center;
+}
+.training-stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text);
+}
+.training-stat-label {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin-top: 0.2rem;
+}
+.class-chart { margin-bottom: 1.5rem; }
+.class-chart-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+.class-chart-label {
+  min-width: 10rem;
+  font-size: 0.85rem;
+  text-align: right;
+  color: var(--text);
+}
+.class-chart-bars { flex: 1; }
+.class-chart-bar {
+  height: 22px;
+  line-height: 22px;
+  border-radius: 3px;
+  padding: 0 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  min-width: 2rem;
+  text-align: right;
+  color: #fff;
+}
+.bar-correct { background: var(--ok); }
+.class-chart-meta {
+  font-size: 0.75rem;
+  min-width: 5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+.badge-warn {
+  background: rgba(245,166,35,0.18);
+  color: var(--warn);
+  font-size: 0.65rem;
+  padding: 1px 4px;
+  border-radius: 3px;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+.btn-export {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.5em 1.2em;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  margin-top: 0.5rem;
+}
+.btn-export:hover { opacity: 0.88; text-decoration: none; }

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -482,3 +482,90 @@ input[type="range"] {
   max-height: 0;
   opacity: 0;
 }
+
+/* ── Feedback badges ─────────────────────────────────────────────────────── */
+.badge-correct { background: rgba(62,207,142,0.18); color: var(--ok); }
+.badge-fp      { background: rgba(224,92,92,0.18);  color: var(--danger); }
+.badge-wrong   { background: rgba(245,166,35,0.18); color: var(--warn); }
+
+.event-unreviewed td:first-child {
+  border-left: 3px solid var(--border);
+}
+
+.feedback-cell { min-width: 7rem; white-space: nowrap; }
+
+.feedback-btns { display: flex; gap: 3px; }
+
+.btn-fb {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 26px;
+  text-align: center;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+}
+.btn-fb:hover { opacity: 1; }
+.btn-fb-correct:hover { color: var(--ok);     border-color: var(--ok); }
+.btn-fb-fp:hover      { color: var(--danger); border-color: var(--danger); }
+.btn-fb-wrong:hover   { color: var(--warn);   border-color: var(--warn); }
+
+.btn-edit-feedback {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 0.7rem;
+  cursor: pointer;
+  padding: 0 0.3em;
+  text-decoration: underline;
+}
+
+.wrong-class-picker { margin-top: 4px; }
+.wrong-class-picker select {
+  width: auto;
+  min-width: 6rem;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.4rem;
+}
+
+/* ── Snapshot bbox overlay ───────────────────────────────────────────────── */
+.snapshot-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.85);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.snapshot-overlay__inner {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+}
+.snapshot-overlay__inner img {
+  max-width: 90vw;
+  max-height: 90vh;
+  display: block;
+  border-radius: 4px;
+}
+.snapshot-overlay__bbox {
+  position: absolute;
+  border: 2px solid #ff3333;
+  pointer-events: none;
+}
+.snapshot-overlay__label {
+  position: absolute;
+  top: -20px; left: 0;
+  background: #ff3333;
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 1px 6px;
+  border-radius: 2px;
+  white-space: nowrap;
+}

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -643,3 +643,44 @@ input[type="range"] {
   margin-top: 0.5rem;
 }
 .btn-export:hover { opacity: 0.88; text-decoration: none; }
+
+/* ── Model evaluation ────────────────────────────────────────────────────── */
+.eval-progress-bar-outer {
+  width: 100%;
+  height: 20px;
+  background: var(--bg);
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  margin: 0.5rem 0;
+  overflow: hidden;
+}
+.eval-progress-bar-inner {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+.eval-progress-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+.eval-comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+@media (max-width: 700px) { .eval-comparison { grid-template-columns: 1fr; } }
+.eval-model-card h3 {
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+  color: var(--accent);
+}
+.eval-samples-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+.eval-sample-card img { margin-bottom: 0.4rem; }
+.eval-sample-info { font-size: 0.75rem; line-height: 1.4; }

--- a/services/web/src/templates/base.html
+++ b/services/web/src/templates/base.html
@@ -21,6 +21,7 @@
     {% if request.state.user %}
       {% if request.state.user.is_admin %}
     <a href="/admin/users">Users</a>
+    <a href="/admin/training">Training</a>
       {% endif %}
     <span class="muted" style="font-size:0.85rem;margin-left:auto;">{{ request.state.user.username }}</span>
     <form method="post" action="/logout" style="margin:0;">

--- a/services/web/src/templates/evaluate.html
+++ b/services/web/src/templates/evaluate.html
@@ -1,0 +1,213 @@
+{% extends "base.html" %}
+{% block title %}Model Evaluation — ScarGuard{% endblock %}
+{% block content %}
+<h1>Model Evaluation</h1>
+
+<p class="hint">
+  Compare two models side-by-side against labeled snapshots. Evaluation runs on-device
+  using the detector's GPU. Models are loaded sequentially to conserve memory.
+</p>
+
+{% if current_model %}
+<p class="hint">Current active model: <code>{{ current_model }}</code></p>
+{% endif %}
+
+<div class="card">
+  <form id="eval-form"
+        hx-post="/admin/training/evaluate"
+        hx-target="#eval-status"
+        hx-swap="innerHTML">
+    <div class="field-row">
+      <div class="field-group">
+        <label>Model A (baseline)</label>
+        <select name="model_a" required>
+          <option value="">Select model&hellip;</option>
+          {% for m in models %}
+          <option value="{{ m.name }}" {% if m.name == current_model %}selected{% endif %}>
+            {{ m.name }} ({{ m.size_mb }} MB)
+          </option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="field-group">
+        <label>Model B (candidate)</label>
+        <select name="model_b" required>
+          <option value="">Select model&hellip;</option>
+          {% for m in models %}
+          <option value="{{ m.name }}">{{ m.name }} ({{ m.size_mb }} MB)</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+    <div class="field-row">
+      <div class="field-group">
+        <label>Date from</label>
+        <input type="date" name="date_from">
+      </div>
+      <div class="field-group">
+        <label>Date to</label>
+        <input type="date" name="date_to">
+      </div>
+    </div>
+    <button type="submit" id="eval-submit">Run Evaluation</button>
+  </form>
+</div>
+
+<div id="eval-status"></div>
+
+<div id="eval-progress" class="card" style="display:none;">
+  <div class="eval-progress-label" id="progress-label">Starting evaluation&hellip;</div>
+  <div class="eval-progress-bar-outer">
+    <div class="eval-progress-bar-inner" id="progress-bar" style="width:0%"></div>
+  </div>
+  <div class="muted" id="progress-detail"></div>
+</div>
+
+<div id="eval-results" style="display:none;">
+  <h2>Results</h2>
+
+  <div class="eval-comparison">
+    <div class="card eval-model-card" id="results-a">
+      <h3 id="results-a-title">Model A</h3>
+      <table id="results-a-table"></table>
+    </div>
+    <div class="card eval-model-card" id="results-b">
+      <h3 id="results-b-title">Model B</h3>
+      <table id="results-b-table"></table>
+    </div>
+  </div>
+
+  <div id="promote-section" style="display:none;">
+    <form method="post" action="/admin/training/promote" id="promote-form">
+      <input type="hidden" name="model_path" id="promote-model-path">
+      <button type="submit" class="btn-export" id="promote-btn">Promote Model B</button>
+    </form>
+    <div id="promote-result"></div>
+  </div>
+
+  <h2>Sample Detections</h2>
+  <div id="eval-samples" class="eval-samples-grid"></div>
+</div>
+
+<script>
+var evtSource = null;
+
+document.getElementById('eval-form').addEventListener('htmx:afterRequest', function(e) {
+  // Start listening for progress
+  if (evtSource) { evtSource.close(); }
+  document.getElementById('eval-progress').style.display = 'block';
+  document.getElementById('eval-results').style.display = 'none';
+  document.getElementById('eval-submit').disabled = true;
+
+  evtSource = new EventSource('/admin/training/evaluate/stream');
+
+  evtSource.addEventListener('progress', function(e) {
+    var data = JSON.parse(e.data);
+    var bar = document.getElementById('progress-bar');
+    var label = document.getElementById('progress-label');
+    var detail = document.getElementById('progress-detail');
+    bar.style.width = data.pct + '%';
+    label.textContent = data.status.charAt(0).toUpperCase() + data.status.slice(1);
+    detail.textContent = data.current + ' / ' + data.total;
+  });
+
+  evtSource.addEventListener('result', function(e) {
+    evtSource.close();
+    evtSource = null;
+    document.getElementById('eval-submit').disabled = false;
+    var data = JSON.parse(e.data);
+
+    if (data.status === 'error') {
+      document.getElementById('eval-progress').style.display = 'none';
+      document.getElementById('eval-status').innerHTML =
+        '<div class="alert alert-err">' + escHtml(data.error) + '</div>';
+      return;
+    }
+
+    document.getElementById('eval-results').style.display = 'block';
+    renderResults(data);
+  });
+
+  evtSource.onerror = function() {
+    evtSource.close();
+    evtSource = null;
+    document.getElementById('eval-submit').disabled = false;
+  };
+});
+
+function renderResults(data) {
+  var a = data.model_a;
+  var b = data.model_b;
+  document.getElementById('results-a-title').textContent = 'Model A: ' + a.path.split('/').pop();
+  document.getElementById('results-b-title').textContent = 'Model B: ' + b.path.split('/').pop();
+  document.getElementById('results-a-table').innerHTML = metricsTable(a.metrics);
+  document.getElementById('results-b-table').innerHTML = metricsTable(b.metrics);
+
+  // Promote section
+  var bName = b.path.split('/').pop();
+  document.getElementById('promote-model-path').value = bName;
+  document.getElementById('promote-btn').textContent = 'Promote ' + bName;
+  document.getElementById('promote-section').style.display = 'block';
+
+  // Samples
+  var grid = document.getElementById('eval-samples');
+  grid.innerHTML = '';
+  (data.samples || []).forEach(function(s) {
+    var div = document.createElement('div');
+    div.className = 'eval-sample-card card';
+    var img = document.createElement('img');
+    img.src = '/snapshots/' + s.snapshot_filename;
+    img.style.cssText = 'max-width:100%;border-radius:4px;';
+    img.loading = 'lazy';
+    div.appendChild(img);
+    var info = document.createElement('div');
+    info.className = 'eval-sample-info';
+    info.innerHTML =
+      '<strong>GT:</strong> ' + escHtml(s.ground_truth.class_name) +
+      '<br><strong>A:</strong> ' + (s.predictions_a.length ? s.predictions_a.map(function(p){return escHtml(p.class_name)+' '+Math.round(p.confidence*100)+'%';}).join(', ') : 'none') +
+      '<br><strong>B:</strong> ' + (s.predictions_b.length ? s.predictions_b.map(function(p){return escHtml(p.class_name)+' '+Math.round(p.confidence*100)+'%';}).join(', ') : 'none');
+    div.appendChild(info);
+    grid.appendChild(div);
+  });
+}
+
+function metricsTable(metrics) {
+  var html = '<thead><tr><th>Class</th><th>Precision</th><th>Recall</th><th>F1</th><th>TP</th><th>FP</th><th>FN</th></tr></thead><tbody>';
+  var pc = metrics.per_class || {};
+  var classes = Object.keys(pc).sort();
+  classes.forEach(function(cls) {
+    var m = pc[cls];
+    html += '<tr><td>' + escHtml(cls.replace(/_/g,' ')) + '</td>';
+    html += '<td>' + (m.precision * 100).toFixed(1) + '%</td>';
+    html += '<td>' + (m.recall * 100).toFixed(1) + '%</td>';
+    html += '<td>' + (m.f1 * 100).toFixed(1) + '%</td>';
+    html += '<td>' + m.tp + '</td><td>' + m.fp + '</td><td>' + m.fn + '</td></tr>';
+  });
+  html += '</tbody>';
+  html += '<tfoot><tr><td><strong>Mean</strong></td>';
+  html += '<td><strong>' + (metrics.mean_precision * 100).toFixed(1) + '%</strong></td>';
+  html += '<td><strong>' + (metrics.mean_recall * 100).toFixed(1) + '%</strong></td>';
+  html += '<td><strong>' + (metrics.mean_f1 * 100).toFixed(1) + '%</strong></td>';
+  html += '<td colspan="3"></td>';
+  html += '</tr></tfoot>';
+  return html;
+}
+
+function escHtml(s) {
+  var d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+// Handle promote form
+document.getElementById('promote-form').addEventListener('submit', function(e) {
+  e.preventDefault();
+  var form = this;
+  fetch(form.action, {
+    method: 'POST',
+    body: new FormData(form),
+  }).then(function(r) { return r.text(); })
+    .then(function(html) { document.getElementById('promote-result').innerHTML = html; });
+});
+</script>
+{% endblock %}

--- a/services/web/src/templates/events.html
+++ b/services/web/src/templates/events.html
@@ -44,6 +44,7 @@
       <th>Camera</th>
       <th>Actions</th>
       <th>Snapshot</th>
+      <th>Feedback</th>
     </tr>
   </thead>
   <tbody id="event-table-body"
@@ -67,8 +68,50 @@
 </nav>
 {% endif %}
 
-<script>
-  // HTMX SSE extension needs to be loaded separately
-</script>
 <script src="https://unpkg.com/htmx-ext-sse@2.2.1/sse.js" defer></script>
+<script>
+// Snapshot overlay with bbox rendering
+document.addEventListener('click', function(e) {
+  var link = e.target.closest('.snapshot-link');
+  if (!link) return;
+  e.preventDefault();
+  var bbox = link.dataset.bbox ? JSON.parse(link.dataset.bbox) : null;
+  var frameSize = link.dataset.frameSize ? JSON.parse(link.dataset.frameSize) : null;
+  var src = link.querySelector('img').src;
+
+  var overlay = document.createElement('div');
+  overlay.className = 'snapshot-overlay';
+
+  var inner = document.createElement('div');
+  inner.className = 'snapshot-overlay__inner';
+  var img = document.createElement('img');
+  img.src = src;
+  inner.appendChild(img);
+
+  img.onload = function() {
+    if (bbox && frameSize && frameSize[0] > 0 && frameSize[1] > 0) {
+      var scaleX = img.naturalWidth / frameSize[0];
+      var scaleY = img.naturalHeight / frameSize[1];
+      var x1 = bbox[0] * scaleX, y1 = bbox[1] * scaleY;
+      var x2 = bbox[2] * scaleX, y2 = bbox[3] * scaleY;
+      // Convert to percentages relative to displayed image
+      var pctL = (x1 / img.naturalWidth) * 100;
+      var pctT = (y1 / img.naturalHeight) * 100;
+      var pctW = ((x2 - x1) / img.naturalWidth) * 100;
+      var pctH = ((y2 - y1) / img.naturalHeight) * 100;
+      var box = document.createElement('div');
+      box.className = 'snapshot-overlay__bbox';
+      box.style.left = pctL + '%';
+      box.style.top = pctT + '%';
+      box.style.width = pctW + '%';
+      box.style.height = pctH + '%';
+      inner.appendChild(box);
+    }
+  };
+
+  overlay.appendChild(inner);
+  overlay.addEventListener('click', function() { overlay.remove(); });
+  document.body.appendChild(overlay);
+});
+</script>
 {% endblock %}

--- a/services/web/src/templates/feed.html
+++ b/services/web/src/templates/feed.html
@@ -4,8 +4,8 @@
 <h1>Live Feed</h1>
 
 <p class="hint">
-  Displays the latest annotated snapshot each time a detection fires.
-  Bounding boxes are drawn on the detected object.
+  Displays the latest snapshot each time a detection fires.
+  Bounding boxes are overlaid on the detected object.
 </p>
 
 <div id="feed-status" class="feed-status feed-status--connecting">
@@ -23,14 +23,15 @@
     Waiting for first detection…
     {% endif %}
   </div>
-  <div id="feed-frame" style="margin-top:0.75rem;">
+  <div id="feed-frame" style="margin-top:0.75rem;position:relative;display:inline-block;">
     {% if latest and latest.snapshot_path %}
     {% set fname = latest.snapshot_path.split("/")[-1] %}
     <img id="live-snapshot" src="/snapshots/{{ fname }}"
-         style="max-width:100%;border-radius:4px;">
+         style="max-width:100%;border-radius:4px;display:block;">
     {% else %}
     <p id="live-snapshot" class="muted">No snapshot yet.</p>
     {% endif %}
+    <div id="bbox-overlay"></div>
   </div>
 </section>
 
@@ -70,11 +71,41 @@
         if (!img || img.tagName !== "IMG") {
           img = document.createElement("img");
           img.id = "live-snapshot";
-          img.style.cssText = "max-width:100%;border-radius:4px;";
+          img.style.cssText = "max-width:100%;border-radius:4px;display:block;";
+          // Keep bbox-overlay div
+          var overlay = document.getElementById("bbox-overlay");
           frame.replaceChildren(img);
+          if (!overlay) {
+            overlay = document.createElement("div");
+            overlay.id = "bbox-overlay";
+          }
+          frame.appendChild(overlay);
         }
         img.src = "/snapshots/" + data.snapshot_filename;
         img.alt = data.class_name + " detected";
+        // Render bbox overlay
+        var bboxDiv = document.getElementById("bbox-overlay");
+        bboxDiv.innerHTML = "";
+        if (data.bbox && data.frame_size && data.frame_size[0] > 0 && data.frame_size[1] > 0) {
+          img.onload = function() {
+            bboxDiv.innerHTML = "";
+            var pctL = (data.bbox[0] / data.frame_size[0]) * 100;
+            var pctT = (data.bbox[1] / data.frame_size[1]) * 100;
+            var pctW = ((data.bbox[2] - data.bbox[0]) / data.frame_size[0]) * 100;
+            var pctH = ((data.bbox[3] - data.bbox[1]) / data.frame_size[1]) * 100;
+            var box = document.createElement("div");
+            box.className = "snapshot-overlay__bbox";
+            box.style.left = pctL + "%";
+            box.style.top = pctT + "%";
+            box.style.width = pctW + "%";
+            box.style.height = pctH + "%";
+            var label = document.createElement("div");
+            label.className = "snapshot-overlay__label";
+            label.textContent = data.class_name.replace(/_/g," ") + " " + Math.round((data.confidence||0)*100) + "%";
+            box.appendChild(label);
+            bboxDiv.appendChild(box);
+          };
+        }
       }
       document.getElementById("feed-label").textContent = data.label;
     });

--- a/services/web/src/templates/partials/event_rows.html
+++ b/services/web/src/templates/partials/event_rows.html
@@ -1,5 +1,5 @@
 {% for e in events %}
-<tr>
+<tr class="{{ '' if e.feedback else 'event-unreviewed' }}">
   <td>{{ e.display_timestamp }}</td>
   <td>{{ e.class_name.replace("_", " ").title() }}</td>
   <td>{{ "%.0f%%"|format(e.confidence * 100) }}</td>
@@ -7,17 +7,71 @@
   <td class="actions-cell">
     {% if e.actions_triggered %}
     {% for ch in e.actions_triggered %}<span class="tag">{{ ch }}</span>{% endfor %}
-    {% else %}—{% endif %}
+    {% else %}&mdash;{% endif %}
   </td>
   <td>
     {% if e.snapshot_path %}
     {% set fname = e.snapshot_path.split("/")[-1] %}
-    <a href="/snapshots/{{ fname }}" target="_blank">
+    <a href="/snapshots/{{ fname }}" target="_blank" class="snapshot-link"
+       {% if e.bbox and e.frame_size %}
+       data-bbox="{{ e.bbox | tojson }}"
+       data-frame-size="{{ e.frame_size | tojson }}"
+       {% endif %}>
       <img src="/snapshots/{{ fname }}" width="80" loading="lazy">
     </a>
-    {% else %}—{% endif %}
+    {% else %}&mdash;{% endif %}
+  </td>
+  <td class="feedback-cell">
+    {% if e.feedback == 'correct' %}
+      <span class="badge badge-correct">Correct</span>
+      <button class="btn-edit-feedback"
+              onclick="this.closest('td').querySelector('.feedback-form').style.display='block';this.style.display='none';this.previousElementSibling.style.display='none'">edit</button>
+    {% elif e.feedback == 'false_positive' %}
+      <span class="badge badge-fp">False Positive</span>
+      <button class="btn-edit-feedback"
+              onclick="this.closest('td').querySelector('.feedback-form').style.display='block';this.style.display='none';this.previousElementSibling.style.display='none'">edit</button>
+    {% elif e.feedback == 'wrong_class' %}
+      <span class="badge badge-wrong">Wrong: {{ (e.corrected_class or '?').replace("_"," ").title() }}</span>
+      <button class="btn-edit-feedback"
+              onclick="this.closest('td').querySelector('.feedback-form').style.display='block';this.style.display='none';this.previousElementSibling.style.display='none'">edit</button>
+    {% endif %}
+    <div class="feedback-form" {% if e.feedback %}style="display:none"{% endif %}>
+      <div class="feedback-btns">
+        <form method="post" style="display:inline"
+              hx-post="/events/{{ e.id }}/feedback"
+              hx-target="closest tr"
+              hx-swap="outerHTML">
+          <input type="hidden" name="feedback" value="correct">
+          <button type="submit" class="btn-fb btn-fb-correct" title="Correct detection">&#10003;</button>
+        </form>
+        <form method="post" style="display:inline"
+              hx-post="/events/{{ e.id }}/feedback"
+              hx-target="closest tr"
+              hx-swap="outerHTML">
+          <input type="hidden" name="feedback" value="false_positive">
+          <button type="submit" class="btn-fb btn-fb-fp" title="False positive">&#10007;</button>
+        </form>
+        <button type="button" class="btn-fb btn-fb-wrong" title="Wrong class"
+                onclick="this.closest('.feedback-form').querySelector('.wrong-class-picker').style.display='block'">?</button>
+      </div>
+      <div class="wrong-class-picker" style="display:none">
+        <form method="post"
+              hx-post="/events/{{ e.id }}/feedback"
+              hx-target="closest tr"
+              hx-swap="outerHTML">
+          <input type="hidden" name="feedback" value="wrong_class">
+          <select name="corrected_class" required>
+            <option value="">Select class&hellip;</option>
+            {% for cls in target_classes|default([]) %}
+            <option value="{{ cls }}">{{ cls.replace("_"," ").title() }}</option>
+            {% endfor %}
+          </select>
+          <button type="submit" class="btn-fb btn-fb-wrong">Set</button>
+        </form>
+      </div>
+    </div>
   </td>
 </tr>
 {% else %}
-<tr><td colspan="6" class="muted">No events yet.</td></tr>
+<tr><td colspan="7" class="muted">No events yet.</td></tr>
 {% endfor %}

--- a/services/web/src/templates/training.html
+++ b/services/web/src/templates/training.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+{% block title %}Training Data — ScarGuard{% endblock %}
+{% block content %}
+<h1>Training Data</h1>
+
+<form method="get" action="/admin/training" class="filter-form">
+  <div class="filter-row">
+    <label>
+      From
+      <input type="date" name="date_from" value="{{ filter_date_from }}">
+    </label>
+    <label>
+      To
+      <input type="date" name="date_to" value="{{ filter_date_to }}">
+    </label>
+    <button type="submit">Filter</button>
+    {% if filter_date_from or filter_date_to %}
+    <a href="/admin/training" class="btn-secondary">Clear</a>
+    {% endif %}
+  </div>
+</form>
+
+<div class="training-stats-row">
+  <div class="card training-stat-card">
+    <div class="training-stat-value">{{ stats.total_labeled }}</div>
+    <div class="training-stat-label">Labeled</div>
+  </div>
+  <div class="card training-stat-card">
+    <div class="training-stat-value">{{ stats.total_unlabeled }}</div>
+    <div class="training-stat-label">Unlabeled</div>
+  </div>
+  <div class="card training-stat-card">
+    <div class="training-stat-value">{{ exportable }}</div>
+    <div class="training-stat-label">Exportable</div>
+  </div>
+</div>
+
+{% if stats.date_min and stats.date_max %}
+<p class="hint">Date range: {{ stats.date_min[:10] }} &mdash; {{ stats.date_max[:10] }}</p>
+{% endif %}
+
+<h2>Class Distribution</h2>
+
+{% if class_chart %}
+<div class="class-chart">
+  {% for cls in class_chart %}
+  <div class="class-chart-row">
+    <div class="class-chart-label">
+      {{ cls.name }}
+      {% if cls.low_data %}<span class="badge badge-warn" title="< 500 correct labels">&lt; 500</span>{% endif %}
+    </div>
+    <div class="class-chart-bars">
+      <div class="class-chart-bar bar-correct" style="width: {{ cls.bar_pct }}%" title="Correct: {{ cls.correct }}">
+        {{ cls.correct }}
+      </div>
+    </div>
+    <div class="class-chart-meta">
+      <span class="muted">FP: {{ cls.false_positive }}</span>
+      {% if cls.wrong_class > 0 %}
+      <span class="muted">WC: {{ cls.wrong_class }}</span>
+      {% endif %}
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% else %}
+<p class="muted">No labeled events yet. Use the feedback controls on the <a href="/events">Events</a> page to label detections.</p>
+{% endif %}
+
+<h2>Export</h2>
+
+{% if exportable > 0 %}
+<p>Export <strong>{{ exportable }}</strong> confirmed detections as a YOLO-format dataset (images + annotation .txt files + data.yaml).</p>
+<p class="hint">Only events with feedback (correct or wrong-class with corrected label) and stored bounding box data are included. Pre-migration events without bbox data are excluded.</p>
+<a href="/admin/training/export?date_from={{ filter_date_from | urlencode }}&amp;date_to={{ filter_date_to | urlencode }}"
+   class="btn-export" download>
+  Download Dataset (.zip)
+</a>
+{% else %}
+<p class="muted">No exportable events. Label detections as "Correct" on the <a href="/events">Events</a> page, and ensure events have bounding box data (post-migration only).</p>
+{% endif %}
+
+{% endblock %}

--- a/shared/models.py
+++ b/shared/models.py
@@ -9,3 +9,7 @@ class DetectionEvent(BaseModel):
     confidence: float
     camera_name: str
     snapshot_path: str | None = None
+    bbox: list[int] | None = None
+    frame_size: list[int] | None = None
+    feedback: str | None = None
+    corrected_class: str | None = None

--- a/training/README.md
+++ b/training/README.md
@@ -1,0 +1,92 @@
+# ScarGuard — Model Training
+
+Fine-tune a YOLO model on detection data collected and labeled through ScarGuard.
+
+## Prerequisites
+
+- Python 3.11+
+- `ultralytics` package: `pip install ultralytics`
+- `pyyaml` package: `pip install pyyaml`
+- NVIDIA GPU recommended (Jetson Orin or x86 with CUDA)
+
+## Workflow
+
+1. **Label detections** in the ScarGuard web UI — mark events as Correct, False Positive, or Wrong Class on the Events page
+2. **Export dataset** from the Training Data admin page — downloads a YOLO-format zip
+3. **Extract the zip** and run the training script
+4. **Evaluate** the trained model against stored snapshots using the Model Evaluation page
+5. **Promote** the model by copying the `.pt` file to your models directory and selecting it in config
+
+## Usage
+
+```bash
+# Extract the exported dataset
+unzip scarguard_dataset.zip -d my_dataset
+
+# Train with defaults (100 epochs, 640px, batch 16)
+python train.py --data my_dataset/dataset/data.yaml --output heron_v1.pt
+
+# Custom hyperparameters
+python train.py \
+    --data my_dataset/dataset/data.yaml \
+    --base-model yolov8s.pt \
+    --epochs 200 \
+    --imgsz 640 \
+    --batch 8 \
+    --patience 30 \
+    --device 0 \
+    --output /var/docker/scarguard/models/heron_v1.pt
+
+# Force training even with < 500 images per class
+python train.py --data my_dataset/dataset/data.yaml --force --output heron_v1.pt
+```
+
+## CLI Arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `--data` | (required) | Path to YOLO `data.yaml` |
+| `--base-model` | `yolov8n.pt` | Pretrained YOLO checkpoint to fine-tune |
+| `--output` | `best.pt` | Output path for trained weights |
+| `--epochs` | `100` | Training epochs |
+| `--imgsz` | `640` | Input image size |
+| `--batch` | `16` | Batch size (reduce for Jetson: try 4 or 8) |
+| `--patience` | `20` | Early stopping patience |
+| `--device` | `0` | Device (`0` for GPU, `cpu` for CPU) |
+| `--force` | off | Proceed even if classes have < 500 images |
+
+## Dataset Format
+
+The exported zip contains a standard YOLO dataset structure:
+
+```
+dataset/
+├── data.yaml          # Class names and paths
+├── images/
+│   └── train/
+│       ├── 123.jpg    # Clean snapshot (no bbox overlay)
+│       ├── 456.jpg
+│       └── ...
+└── labels/
+    └── train/
+        ├── 123.txt    # YOLO annotation: class_id x_center y_center width height
+        ├── 456.txt
+        └── ...
+```
+
+## Jetson Orin Tips
+
+- Use `--batch 4` or `--batch 8` to fit in 8GB GPU memory
+- Use `--imgsz 640` (default) — larger sizes may OOM
+- Training runs significantly slower than x86 GPUs; consider training on a workstation and copying the `.pt` file to the Jetson
+- The trained `.pt` file can be converted to TensorRT `.engine` format for faster inference using `yolo export model=heron_v1.pt format=engine`
+
+## Model Promotion
+
+Training produces a `.pt` file. To use it:
+
+1. Copy the `.pt` file to your ScarGuard models directory (e.g., `/var/docker/scarguard/models/`)
+2. Update `detection.model_path` in `scarguard.yml` to point to the new model, or select it via the web UI Config page
+3. The detector service will hot-reload the new model without a restart
+
+**Model promotion is always manual** — the system never automatically deploys a trained model.

--- a/training/train.py
+++ b/training/train.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""ScarGuard — Fine-tune a YOLO model on an exported dataset.
+
+Usage:
+    python train.py --data /path/to/dataset/data.yaml \
+        --base-model yolov8n.pt \
+        --output /models/heron_v1.pt
+
+All hyperparameters have sensible defaults and can be overridden via CLI.
+The script validates the dataset structure before training starts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Fine-tune a YOLO model on a ScarGuard exported dataset.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--data", type=str, required=True,
+        help="Path to YOLO data.yaml (from ScarGuard export)",
+    )
+    p.add_argument(
+        "--base-model", type=str, default="yolov8n.pt",
+        help="Pretrained YOLO checkpoint to fine-tune from",
+    )
+    p.add_argument(
+        "--output", type=str, default="best.pt",
+        help="Output path for the trained model weights",
+    )
+    p.add_argument("--epochs", type=int, default=100, help="Training epochs")
+    p.add_argument("--imgsz", type=int, default=640, help="Input image size")
+    p.add_argument("--batch", type=int, default=16, help="Batch size")
+    p.add_argument(
+        "--patience", type=int, default=20,
+        help="Early stopping patience (epochs without improvement)",
+    )
+    p.add_argument(
+        "--device", type=str, default="0",
+        help="Device to train on (0 for GPU, cpu for CPU)",
+    )
+    p.add_argument(
+        "--force", action="store_true",
+        help="Proceed even if a class has fewer than 500 images",
+    )
+    return p.parse_args()
+
+
+def _validate_dataset(data_yaml: Path) -> dict:
+    """Validate that the dataset structure is correct.
+
+    Returns the parsed YAML content.
+    """
+    import yaml
+
+    if not data_yaml.exists():
+        print(f"ERROR: data.yaml not found at {data_yaml}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(data_yaml) as f:
+        data = yaml.safe_load(f)
+
+    if not data:
+        print("ERROR: data.yaml is empty", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve paths relative to data.yaml location
+    base_dir = data_yaml.parent
+    train_images = base_dir / (data.get("train", "images/train"))
+
+    if not train_images.exists():
+        print(f"ERROR: Training images directory not found: {train_images}", file=sys.stderr)
+        sys.exit(1)
+
+    # Count images per class from label files
+    labels_dir = base_dir / train_images.name.replace("images", "labels")
+    if not labels_dir.exists():
+        # Try the standard structure
+        labels_dir = base_dir / "labels" / "train"
+
+    class_names: list[str] = data.get("names", [])
+    nc: int = data.get("nc", len(class_names))
+
+    image_files = list(train_images.glob("*.jpg")) + list(train_images.glob("*.png"))
+    print(f"Dataset: {len(image_files)} images, {nc} classes: {class_names}")
+
+    if labels_dir.exists():
+        class_counts: dict[int, int] = {}
+        for lf in labels_dir.glob("*.txt"):
+            for line in lf.read_text().strip().splitlines():
+                parts = line.strip().split()
+                if parts:
+                    cls_id = int(parts[0])
+                    class_counts[cls_id] = class_counts.get(cls_id, 0) + 1
+
+        for idx, name in enumerate(class_names):
+            count = class_counts.get(idx, 0)
+            status = "OK" if count >= 500 else "LOW"
+            print(f"  [{status}] {name}: {count} annotations")
+
+    return data
+
+
+def _count_per_class(data_yaml: Path, class_names: list[str]) -> dict[int, int]:
+    """Count annotations per class from label files."""
+    base_dir = data_yaml.parent
+    labels_dir = base_dir / "labels" / "train"
+    class_counts: dict[int, int] = {}
+    if labels_dir.exists():
+        for lf in labels_dir.glob("*.txt"):
+            for line in lf.read_text().strip().splitlines():
+                parts = line.strip().split()
+                if parts:
+                    cls_id = int(parts[0])
+                    class_counts[cls_id] = class_counts.get(cls_id, 0) + 1
+    return class_counts
+
+
+def main() -> None:
+    args = _parse_args()
+    data_yaml = Path(args.data).resolve()
+
+    print("=" * 60)
+    print("ScarGuard Model Training")
+    print("=" * 60)
+
+    data = _validate_dataset(data_yaml)
+    class_names: list[str] = data.get("names", [])
+
+    # Check minimum image count per class
+    class_counts = _count_per_class(data_yaml, class_names)
+    low_classes = [
+        class_names[idx]
+        for idx in range(len(class_names))
+        if class_counts.get(idx, 0) < 500
+    ]
+    if low_classes and not args.force:
+        print(
+            f"\nWARNING: The following classes have fewer than 500 annotations: "
+            f"{', '.join(low_classes)}",
+            file=sys.stderr,
+        )
+        print("Use --force to proceed anyway.", file=sys.stderr)
+        sys.exit(1)
+
+    # Import ultralytics (heavy import, do it after validation)
+    try:
+        from ultralytics import YOLO
+    except ImportError:
+        print(
+            "ERROR: ultralytics not installed. Run: pip install ultralytics",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"\nBase model: {args.base_model}")
+    print(f"Epochs: {args.epochs}, Image size: {args.imgsz}, Batch: {args.batch}")
+    print(f"Patience: {args.patience}, Device: {args.device}")
+    print()
+
+    # Load base model and train
+    model = YOLO(args.base_model)
+    results = model.train(
+        data=str(data_yaml),
+        epochs=args.epochs,
+        imgsz=args.imgsz,
+        batch=args.batch,
+        patience=args.patience,
+        device=args.device,
+        verbose=True,
+    )
+
+    # Copy best weights to output path
+    output_path = Path(args.output).resolve()
+    best_weights = Path(model.trainer.best)  # type: ignore[union-attr]
+    if best_weights.exists():
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(best_weights), str(output_path))
+        print(f"\nBest weights saved to: {output_path}")
+    else:
+        print("\nWARNING: Best weights file not found", file=sys.stderr)
+
+    # Print summary metrics
+    print("\n" + "=" * 60)
+    print("Training Complete — Summary")
+    print("=" * 60)
+
+    if hasattr(results, "results_dict"):
+        rd = results.results_dict
+        print(f"  mAP@0.5:      {rd.get('metrics/mAP50(B)', 'N/A')}")
+        print(f"  mAP@0.5:0.95: {rd.get('metrics/mAP50-95(B)', 'N/A')}")
+        print(f"  Precision:     {rd.get('metrics/precision(B)', 'N/A')}")
+        print(f"  Recall:        {rd.get('metrics/recall(B)', 'N/A')}")
+
+    print(f"\nModel saved to: {output_path}")
+    print("To use this model, copy it to your models directory and update")
+    print("detection.model_path in scarguard.yml (or select it in the web UI).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add bbox, frame_size, feedback, corrected_class columns to detection_events
  table with backward-compatible ALTER TABLE migrations
- Stop burning bounding boxes into snapshot JPEGs; save clean frames instead.
  Browser renders bbox overlay using stored coordinates (events page full-size
  view + live feed)
- Add POST /events/{id}/feedback endpoint for labeling detections as
  correct / false_positive / wrong_class with optional corrected class
- Feedback UI: inline HTMX buttons on each event row, colored badges for
  reviewed events, visual distinction for unreviewed rows
- Persist bbox (pixel coords) and frame_size (width, height) per detection
  for downstream YOLO export and model evaluation
- Web service writes feedback via UPDATE only; detector remains primary
  INSERT writer. SQLite WAL handles concurrent access safely

https://claude.ai/code/session_01PsrUb6sECrfNu7ZstVZ4Li