### PR TITLE
feat: v0.7 usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The script will:
 - Offer to generate a self-signed SSL certificate for HTTPS (stored in `${DATA_DIR}/config/certs/`)
 - Offer to download a starter YOLO model (detects generic birds — good for testing the pipeline)
 - Pull all pre-built images from GHCR
+- Prompt you to create the initial admin account
 
 ### 3. Edit your configuration
 
@@ -53,13 +54,61 @@ cameras:
     enabled: true
 ```
 
-Optionally enable Discord notifications:
+For a more complete initial setup, see the examples below or jump to [Feature Guides](#feature-guides).
+
+**Cameras with exclusion zones** (suppress a static decoy or blind spot):
+
+```yaml
+cameras:
+  - name: pond-north
+    rtsp_url: "rtsp://YOUR_UDM_IP:7447/YOUR_STREAM_TOKEN"
+    enabled: true
+    exclusion_zones:
+      - x: 0.72   # normalized 0–1 from left
+        y: 0.10   # normalized 0–1 from top
+        w: 0.12
+        h: 0.18
+        label: "heron decoy"
+```
+
+**Named notification channels** (Discord + email + custom webhook):
 
 ```yaml
 notifications:
-  discord:
+  channels:
+    - name: pond-discord
+      type: discord
+      enabled: true
+      webhook_url: "https://discord.com/api/webhooks/..."
+      include_snapshot: true
+
+    - name: owner-email
+      type: email
+      enabled: true
+      smtp_host: smtp.gmail.com
+      smtp_port: 587
+      smtp_user: you@gmail.com
+      smtp_pass: "your-app-password"
+      to_addresses: [you@gmail.com]
+      include_snapshot: true
+
+    - name: sprinkler-valve
+      type: webhook
+      enabled: true
+      url: "http://192.168.1.50/api/spray"
+      method: POST
+      headers: { "Authorization": "Bearer my-token" }
+```
+
+**Arm/disarm schedule** (solar-based, adjust to your coordinates):
+
+```yaml
+system:
+  schedule:
     enabled: true
-    webhook_url: "https://discord.com/api/webhooks/..."
+    use_solar: true
+    latitude: 39.9526
+    longitude: -75.1652
 ```
 
 ### 4. Add a YOLO model (if you skipped the starter download)
@@ -87,6 +136,8 @@ docker compose up -d
 ```
 http://<your-orin-ip>:8080
 ```
+
+You'll be redirected to the login page. Use the admin account created during setup.
 
 ---
 
@@ -200,6 +251,363 @@ That's all that's needed. HTTP continues to work on your existing port with no c
 
 ---
 
+## Feature Guides
+
+### Notifications & Named Channels
+
+ScarGuard sends alerts through named notification channels. Each channel has a unique name, a type (discord, email, or webhook), and its own settings. You can define multiple instances of the same type — for example, one Discord webhook for the pond camera and a separate one for a home-automation channel.
+
+All channels are defined under `notifications.channels` in `scarguard.yml`:
+
+```yaml
+notifications:
+  channels:
+    # Discord webhook — pond alerts channel
+    - name: pond-discord
+      type: discord
+      enabled: true
+      webhook_url: "https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN"
+      mention_role: "123456789"   # optional: Discord role ID to ping
+      include_snapshot: true      # attach the detection snapshot image
+
+    # Email via SMTP
+    - name: owner-email
+      type: email
+      enabled: true
+      smtp_host: smtp.gmail.com
+      smtp_port: 587
+      smtp_user: you@gmail.com
+      smtp_pass: "your-app-password"
+      to_addresses:
+        - you@gmail.com
+        - partner@gmail.com
+      include_snapshot: true
+
+    # Generic HTTP webhook — trigger a sprinkler valve
+    - name: sprinkler-valve
+      type: webhook
+      enabled: true
+      url: "http://192.168.1.50/api/spray"
+      method: POST
+      headers:
+        Authorization: "Bearer my-device-token"
+      include_snapshot_url: true  # include snapshot URL in the POST body
+
+    # Home Assistant webhook
+    - name: home-assistant
+      type: webhook
+      enabled: true
+      url: "http://homeassistant.local:8123/api/webhook/scarguard-alert"
+      method: POST
+```
+
+All channels can be added, edited, and enabled/disabled from the **Settings → Notification Channels** section of the web UI without editing the YAML directly.
+
+> **Legacy keys:** `notifications.discord` and `notifications.email` flat keys are still supported for backward compatibility, but named channels under `notifications.channels` are the preferred format.
+
+---
+
+### Action Rules
+
+Action rules control which notification channels fire for which detections. Without any rules defined, every detection triggers all enabled channels. With rules, you can route heron detections to the sprinkler valve while routing raccoon detections to Discord only.
+
+Rules are defined at the top level of `scarguard.yml` and matched top-down — the first matching rule wins:
+
+```yaml
+action_rules:
+  # Herons: notify Discord AND trigger the sprinkler valve
+  - class: great_blue_heron
+    actions: [pond-discord, sprinkler-valve]
+
+  # Green herons: Discord only (no valve — too small to warrant it)
+  - class: green_heron
+    actions: [pond-discord]
+
+  # Raccoons: alert the owner but don't spray
+  - class: raccoon
+    actions: [pond-discord, owner-email]
+
+  # Anything else on the pond-north camera: log it only (no notification)
+  - class: "*"
+    camera: pond-north
+    actions: []
+
+  # Catch-all: everything else goes to Discord
+  - class: "*"
+    actions: [pond-discord]
+```
+
+Rule fields:
+- `class` — the detected class name, or `"*"` to match any class
+- `camera` — optional; if set, the rule only applies to detections from that camera
+- `actions` — list of channel names to notify; empty list `[]` means log-only (silent)
+
+The channel names in `actions` must match names defined in `notifications.channels`. Action rules are editable in the web UI under **Settings → Action Rules**.
+
+---
+
+### Detection Exclusion Zones
+
+Exclusion zones suppress detections from specific areas of a camera frame — useful for ignoring a heron decoy statue, a bush that blows in the wind, or any other persistent false-positive source.
+
+**Drawing zones in the web UI:**
+1. Open **Settings → Cameras**
+2. Find the camera and click **Edit Exclusion Zones**
+3. A snapshot from the camera is displayed with an overlay canvas
+4. Click and drag to draw a rectangular zone
+5. Optionally add a label (e.g. "heron decoy") for reference
+6. Click **Save** — the zones are written to `scarguard.yml` and hot-reloaded into the detector
+
+Zones are stored as normalized coordinates (0–1) relative to frame size, so they remain accurate even if resolution changes:
+
+```yaml
+cameras:
+  - name: pond-north
+    rtsp_url: "rtsp://..."
+    exclusion_zones:
+      - x: 0.72    # left edge of zone (fraction of frame width)
+        y: 0.10    # top edge of zone (fraction of frame height)
+        w: 0.12    # zone width
+        h: 0.18    # zone height
+        label: "heron decoy"
+      - x: 0.0
+        y: 0.85
+        w: 1.0
+        h: 0.15
+        label: "pond edge reflection"
+```
+
+Any detection whose bounding box center falls inside an exclusion zone is silently dropped before an event is recorded or any notification is sent.
+
+---
+
+### Arm/Disarm Scheduling
+
+ScarGuard can automatically arm itself at dawn and disarm at dusk, or on any fixed schedule you define. The system checks the schedule every 60 seconds. A manual arm/disarm from the dashboard overrides the schedule until the next scheduled transition.
+
+**Fixed-time schedule:**
+
+```yaml
+system:
+  schedule:
+    enabled: true
+    arm_time: "06:00"    # arm at 6:00 AM
+    disarm_time: "21:00" # disarm at 9:00 PM
+    timezone: "America/New_York"  # set under system.timezone
+```
+
+**Solar-based schedule** (adapts automatically to sunrise/sunset throughout the year):
+
+```yaml
+system:
+  timezone: "America/New_York"
+  schedule:
+    enabled: true
+    use_solar: true
+    latitude: 39.9526    # decimal degrees
+    longitude: -75.1652  # decimal degrees, negative = west
+```
+
+With solar mode enabled, the system arms at sunrise and disarms at sunset each day. No manual adjustment needed as daylight hours shift with the seasons.
+
+The **Dashboard** shows the current arm state, today's scheduled arm/disarm times, and the time until the next transition.
+
+Schedule settings are available in the web UI under **Settings → Schedule**.
+
+---
+
+### Training Pipeline
+
+ScarGuard includes a complete pipeline for collecting labeled training data from live detections and using it to improve the YOLO model. The workflow is:
+
+**Step 1 — Label detections as they happen**
+
+On the **Events** page, each detection has feedback buttons:
+- **Correct** — the detection is accurate (right species, right bounding box)
+- **False Positive** — the system fired on something that isn't a target
+- **Wrong Class** — the detection is real, but the class is wrong (select the correct class from the dropdown)
+
+Unreviewed events have a distinct visual treatment in the table. Feedback can be changed after initial submission.
+
+**Step 2 — Check dataset quality**
+
+Open **Admin → Training Data** to see:
+- How many labeled events exist per class
+- Bar chart of class distribution
+- Count of false positives and wrong-class corrections
+- A warning if any class has fewer than 500 confirmed samples (the minimum for reliable fine-tuning)
+
+Use the date range filter to limit the dashboard to a specific collection period.
+
+**Step 3 — Export the dataset**
+
+Click **Export Dataset** in the Training Data dashboard. This downloads a `.zip` with:
+- `dataset/images/train/` — the detection snapshots
+- `dataset/labels/train/` — YOLO-format annotation files (class index, normalized bounding box)
+- `data.yaml` — class names and dataset structure for Ultralytics training
+
+Only `feedback = correct` events are exported as positive training samples. `wrong_class` events are included with the corrected label as ground truth. False positives are excluded.
+
+**Step 4 — Train a new model**
+
+Run the included training script on a machine with a GPU (the Orin works, but a workstation GPU is faster for training):
+
+```bash
+cd training
+python train.py \
+  --data /path/to/dataset/data.yaml \
+  --output heron-v2.pt \
+  --base-model yolov8n.pt \
+  --epochs 100
+```
+
+See `training/README.md` for the full CLI reference, recommended hyperparameters, and Jetson-specific tips.
+
+**Step 5 — Upload the trained model**
+
+In the web UI, go to **Admin → Models** and upload the `.pt` file produced by training. It will appear in the model list.
+
+**Step 6 — Evaluate before promoting**
+
+Go to **Admin → Model Evaluation** and compare the new model against the current active model:
+1. Select the current model and the candidate model
+2. Choose a date range of labeled snapshots to test against
+3. Click **Run Evaluation** — the detector runs both models on your GPU and streams progress
+4. Review per-class precision, recall, and F1 scores side-by-side
+
+If the new model wins, click **Promote** on the evaluation results page. This updates `scarguard.yml` and triggers a hot-reload — no restart required.
+
+---
+
+### Model Management
+
+ScarGuard supports three model formats:
+- `.pt` — PyTorch/Ultralytics YOLOv8 (best for flexibility and training)
+- `.engine` — TensorRT-optimized (best inference speed on the Jetson)
+- `.onnx` — ONNX Runtime (cross-platform, moderate speed)
+
+**Uploading a model:**
+
+Go to **Admin → Models**. Drag and drop or browse for your model file. The file is stored in the `models/` volume and immediately available for selection.
+
+**Setting the active model:**
+
+Update `detection.model_path` in `scarguard.yml` (or via **Settings → Detection** in the UI) and click Save. The detector hot-reloads the new model within ~10 seconds — no container restart needed.
+
+```yaml
+detection:
+  model_path: /models/heron-v2.engine
+  target_classes:
+    - great_blue_heron
+    - green_heron
+  confidence_threshold: 0.45
+```
+
+**Converting to TensorRT** for best performance on the Orin:
+
+```bash
+# Run inside the detector container
+docker compose exec detector python -c "
+from ultralytics import YOLO
+model = YOLO('/models/heron-v2.pt')
+model.export(format='engine', device=0, half=True)
+"
+```
+
+The exported `.engine` file will appear in `models/` alongside the `.pt`.
+
+---
+
+### User Management
+
+ScarGuard requires authentication — all web UI routes and API endpoints are gated behind login. The first admin account is created during `setup.sh`.
+
+**Adding users:**
+
+Go to **Admin → Users** and click **Add User**. Usernames and passwords are required (minimum 8 characters). Check **Admin** to grant full access including user management, training, and config editing. Non-admin users can view the dashboard and events but cannot change configuration.
+
+**Managing existing users:**
+
+From the Users page you can:
+- **Disable** a user account (they can't log in but their history is preserved)
+- **Change password** (admins can change any user's password; users can change their own)
+- **Delete** a user permanently
+
+**Login security:**
+
+By default, accounts are locked for 15 minutes after 5 consecutive failed login attempts. You can tune this in `scarguard.yml`:
+
+```yaml
+system:
+  auth:
+    enabled: true
+    max_login_attempts: 5
+    lockout_duration_minutes: 15
+    session_timeout_hours: 24
+```
+
+These settings are also available in the web UI under **Settings → Authentication**.
+
+---
+
+### API Tokens
+
+API tokens allow programmatic access to ScarGuard's REST API without a browser session — useful for scripts, Home Assistant automations, or any external integration.
+
+**Creating a token:**
+
+Go to **Admin → Users** and click **Create API Token**. Give it a descriptive name (e.g. "home-assistant-integration"). The token is shown exactly once — copy it and store it securely.
+
+**Using a token:**
+
+Include the token as a Bearer header on any API request:
+
+```bash
+curl -H "Authorization: Bearer YOUR_TOKEN_HERE" \
+  http://your-orin:8080/events
+```
+
+This works for all REST endpoints including the SSE streams, the config API, and the arm/disarm endpoints.
+
+**Revoking a token:**
+
+Tokens are listed under **Admin → Users → API Tokens**. Click **Revoke** next to the token you want to invalidate.
+
+---
+
+### System Stats & Logs
+
+**Stats page** — **Admin → System Stats**
+
+Shows real-time system resource utilization, updated on a configurable interval (default: 5 seconds):
+- CPU usage (%)
+- RAM used / total
+- CPU temperature
+- GPU usage (%) and GPU memory (used / total)
+- GPU temperature
+- Rolling 10-minute mini-charts for CPU and GPU usage
+- Per-camera inference FPS and average latency
+
+GPU stats are auto-detected from the Jetson sysfs, tegrastats, or nvidia-smi — no manual configuration needed.
+
+To change the update interval:
+
+```yaml
+system:
+  stats_interval: 10   # seconds, 1–60
+```
+
+**Logs page** — **Admin → Logs**
+
+Live tail of container logs from the detector, web, and notifier services. Filter by:
+- Service (detector / web / notifier)
+- Log level (All / Debug+ / Info+ / Warning+ / Error only)
+- Tail depth (200–2000 lines)
+
+Auto-scroll and pause/resume controls keep the stream readable during a high-volume debugging session. The stream reconnects automatically if interrupted.
+
+---
+
 ## The Problem
 
 Great blue herons are patient, methodical hunters. A single bird can empty a koi pond in a morning. Traditional deterrents — plastic owls, reflective tape — lose their effectiveness quickly as the birds habituate to them. What works is unpredictability: a deterrent that fires at random times, in random patterns, triggered only when a bird is actually present.
@@ -212,41 +620,54 @@ ScarGuard is that deterrent. It watches the pond around the clock, identifies th
 
 - **Accurate, low-latency detection** — identify herons, ducks, and raccoons from live camera feeds with enough confidence to act, fast enough to matter
 - **Randomized deterrence** — vary the response (which sprinkler valve fires, for how long, with what delay) so wildlife cannot pattern-match around it
-- **Minimal false positives** — don't spray the yard every time a leaf blows past; confidence thresholds and cooldown windows keep the system from crying wolf
+- **Minimal false positives** — don't spray the yard every time a leaf blows past; confidence thresholds, cooldown windows, and exclusion zones keep the system from crying wolf
 - **Always-on, self-healing** — RTSP streams drop; cameras reboot; the system must reconnect gracefully and resume without human intervention
-- **Observable** — a web UI shows live status, recent detections with annotated snapshots, and configuration; Discord and email notifications keep the owner in the loop when away
-- **Maintainable** — the whole stack runs in Docker Compose on the Jetson; deploying a new model or changing config should not require SSH access
+- **Observable** — a web UI shows live status, recent detections with annotated snapshots, and configuration; Discord, email, and webhook notifications keep the owner in the loop
+- **Maintainable** — the whole stack runs in Docker Compose on the Jetson; deploying a new model or changing config requires no SSH access
 
 ---
 
-## Targeted Capabilities
+## Capabilities
 
 ### Detection
-- Real-time inference on live RTSP streams using a YOLO model running on the Jetson GPU (TensorRT-optimized)
-- Target species: great blue heron, green heron, duck, raccoon (extensible via model swap)
-- Per-class confidence thresholds and cooldown windows to suppress duplicate events
-- Annotated snapshot saved on each detection event
+- Real-time inference on live RTSP streams using a YOLO model on the Jetson GPU (TensorRT-optimized)
+- Multi-camera support — each camera runs in its own thread with independent cooldown tracking
+- Target species configurable via `detection.target_classes` (extensible via model swap)
+- Per-camera exclusion zones to suppress detections from static false-positive sources
+- Action rules for per-class, per-camera routing to specific notification channels
+- Configurable confidence threshold, cooldown window, and frame skip
+- Clean snapshots saved per detection with bounding box coordinates stored separately (rendered in browser)
 
 ### Notifications
-- Discord webhook with snapshot image attached
-- Email (SMTP) with snapshot attachment
-- Configurable per-channel enable/disable and mention roles
-- Planned support for webhook notfications
-
+- **Discord** — webhook messages with optional snapshot attachment and role mention
+- **Email** — SMTP with optional snapshot attachment, multiple recipients
+- **Webhooks** — generic HTTP/HTTPS POST or GET to any URL, with custom headers
+- Named, multi-instance channels — run two Discord webhooks, two email addresses, multiple webhooks side-by-side
+- Action-rule routing — route heron detections to the sprinkler valve, raccoon detections to email only, etc.
+- Retry with exponential backoff on transient failures
 
 ### Web UI
-- Dashboard: arm/disarm toggle, live system status
-- Detection event log with snapshot thumbnails and metadata
-- Live camera feed with bounding box overlay (SSE)
-- Model upload and hot-swap
-- Config editor (reads/writes `scarguard.yml`)
-- Admin logs tab: live log tail from each service, filterable by level
-- HTTPS support: self-signed cert or custom cert, HTTP+HTTPS dual-listener
+- **Dashboard** — arm/disarm toggle, latest detection, today's count, schedule status
+- **Events** — paginated detection log with filters (camera, class, date range), snapshot overlays with bounding box rendering, real-time inserts via SSE, per-event feedback
+- **Live Feed** — SSE-driven annotated detection snapshots with offline indicator and auto-reconnect
+- **Settings** — full config editor (form-based and raw YAML), cameras, detection, notifications, channels, action rules, schedule, authentication, SSL
+- **System Stats** — real-time CPU, RAM, GPU usage and temperature, per-camera inference FPS, rolling charts
+- **Logs** — live service log tail with level filtering and pause/resume
+- **Training Data** — per-class feedback breakdown, dataset quality warnings, YOLO export
+- **Model Evaluation** — side-by-side model comparison on labeled snapshots, SSE progress, promotion button
+- **Models** — upload, list, and manage YOLO model files
+- **Users** — add/disable/delete users, change passwords, manage API tokens
+- **About** — version, build date, component health, active model
 
 ### Operations
-- Containerized stack: `docker compose up` is the full deployment
-- CI/CD via GitHub Actions — x86 runners handle linting, tests, and web/notifier image builds; a self-hosted runner on the Orin handles ARM64 detector builds and GPU smoke tests
+- Docker Compose stack — `docker compose up` is the full deployment
+- All config in a single `scarguard.yml` — hot-reloaded by all services without restart
+- CI/CD via GitHub Actions — x86 runners for web/notifier; self-hosted Orin runner for ARM64 detector
 - Images published to GitHub Container Registry (ghcr.io)
+- HTTPS support — self-signed or custom cert, HTTP+HTTPS dual-listener, HTTPS-only option
+- Session-based authentication — bcrypt passwords, configurable session timeout, login lockout
+- Scheduled arm/disarm — fixed time or solar (sunrise/sunset via `astral`)
+- Snapshot retention policy — configurable retention days, daily pruning
 
 ---
 
@@ -267,19 +688,23 @@ ScarGuard is that deterrent. It watches the pond around the clock, identifies th
 |---------|------|-----------|
 | `detector` | RTSP ingestion, YOLO inference, event publishing | `dustynv/l4t-pytorch:r36.4.0` (CUDA + TensorRT) |
 | `web` | FastAPI + Jinja UI, REST API, SQLite access | `python:3.11-slim` |
-| `notifier` | Redis subscriber, Discord + email dispatch | `python:3.11-slim` |
+| `notifier` | Redis subscriber, Discord + email + webhook dispatch | `python:3.11-slim` |
 | `redis` | Internal message bus | `redis:alpine` |
 
-Services communicate over Redis pub/sub. All configuration lives in a single `config/scarguard.yml` file mounted into each container.
+Services communicate over Redis pub/sub. All configuration lives in a single `scarguard.yml` file mounted into each container.
 
 ---
 
 ## Development Status
 
-| Phase | Description | Status |
-|-------|-------------|--------|
-| 1 | Detection engine (RTSP + YOLO + SQLite + Redis) | Complete |
-| 2 | Notifications (Discord + email) | Complete |
-| 3 | Web UI | Complete |
-| 4 | Web hook notifications | Planned |
-| 5 | See Roadmap.md | Planned
+| Version | Description | Status |
+|---------|-------------|--------|
+| v0.1 | Detection engine (RTSP + YOLO + SQLite + Redis) | Complete |
+| v0.2 | Notifications (Discord webhook + Email SMTP), web UI, CI/CD, hot-reload | Complete |
+| v0.3 | Admin logs tab, SSL/TLS, snapshot retention, SSL config UI | Complete |
+| v0.4 | Exclusion zones, enhanced event log, action rules, live feed, named channels, scheduling | Complete |
+| v0.5 | GPU/CPU stats view (live metrics, per-camera FPS, rolling charts) | Complete |
+| v0.6 | App security — session auth, first-run setup, user management, API tokens, lockout | Complete |
+| v0.7 | Detection feedback, training data dashboard, YOLO export, training script, model evaluation | Complete |
+
+See [ROADMAP.md](ROADMAP.md) for planned features and [STATUS.md](STATUS.md) for a detailed breakdown of what's working.

--- a/services/detector/src/main.py
+++ b/services/detector/src/main.py
@@ -257,7 +257,16 @@ def main() -> None:
         _write_armed_to_config(armed)
         event_processor.log_system_event("armed" if armed else "disarmed")
 
-    scheduler = ArmScheduler(armed_ref, _on_scheduler_transition)
+    def _make_redis():  # type: ignore[return]
+        import redis
+
+        return redis.Redis(
+            host=redis_cfg.get("host", "redis"),
+            port=int(redis_cfg.get("port", 6379)),
+            decode_responses=True,
+        )
+
+    scheduler = ArmScheduler(armed_ref, _on_scheduler_transition, get_redis=_make_redis)
     sys_cfg = cfg.get("system", {})
     scheduler.configure(sys_cfg.get("schedule", {}), sys_cfg.get("timezone", "UTC"))
     scheduler.start()

--- a/services/detector/src/scheduler.py
+++ b/services/detector/src/scheduler.py
@@ -167,28 +167,43 @@ class ArmScheduler:
         self._check_pending_rearm()
 
     def _check_pending_rearm(self) -> None:
-        """Re-arm if a non-admin auto-rearm timestamp has been reached."""
+        """Re-arm if a non-admin auto-rearm timestamp has been reached.
+
+        Skips re-arming when the configured schedule currently dictates a
+        disarmed state — this prevents the auto-rearm from overriding a
+        schedule boundary that fired after the non-admin disarm was recorded.
+        The pending key is still deleted so it does not trigger on a later tick.
+        """
         if self._get_redis is None:
             return
         r = None
         try:
             r = self._get_redis()
             val: str | None = r.get("scarguard:rearm_at")
-            if val:
-                parsed = datetime.fromisoformat(val)
-                # Ensure timezone-aware; stored value should always be UTC ISO.
-                if parsed.tzinfo is None:
-                    rearm_time = parsed.replace(tzinfo=timezone.utc)
-                else:
-                    rearm_time = parsed.astimezone(timezone.utc)
-                if datetime.now(timezone.utc) >= rearm_time:
-                    logger.info("Non-admin auto-rearm triggered")
-                    self._armed_ref[0] = True
-                    r.delete("scarguard:rearm_at")
-                    try:
-                        self._on_transition(True)
-                    except Exception:
-                        logger.exception("Error in auto-rearm transition callback")
+            if not val:
+                return
+            parsed = datetime.fromisoformat(val)
+            # Ensure timezone-aware; stored value should always be UTC ISO.
+            if parsed.tzinfo is None:
+                rearm_time = parsed.replace(tzinfo=timezone.utc)
+            else:
+                rearm_time = parsed.astimezone(timezone.utc)
+            if datetime.now(timezone.utc) < rearm_time:
+                return
+            # Delete the key regardless of whether we actually re-arm, so it
+            # does not keep firing once it has expired.
+            r.delete("scarguard:rearm_at")
+            if not self._schedule_allows_rearm():
+                logger.info(
+                    "Auto-rearm suppressed: schedule currently dictates disarmed"
+                )
+                return
+            logger.info("Non-admin auto-rearm triggered")
+            self._armed_ref[0] = True
+            try:
+                self._on_transition(True)
+            except Exception:
+                logger.exception("Error in auto-rearm transition callback")
         except Exception:
             logger.debug("Failed to check pending rearm in Redis", exc_info=True)
         finally:
@@ -197,6 +212,31 @@ class ArmScheduler:
                     r.close()
                 except Exception:
                     pass
+
+    def _schedule_allows_rearm(self) -> bool:
+        """Return True if no schedule is active, or if the schedule currently
+        dictates an armed window.
+
+        Determines the current window by finding the most recent schedule
+        transition in the past 24 hours.  If the last transition was a disarm,
+        the schedule says we should be disarmed right now and auto-rearm must
+        not override it.
+        """
+        with self._cfg_lock:
+            if not self._enabled:
+                return True
+            get_arm = self._get_arm_time
+            get_disarm = self._get_disarm_time
+        now = datetime.now(timezone.utc)
+        recent = transitions_between(now - timedelta(hours=24), now, get_arm, get_disarm)
+        if not recent:
+            # No transition found in the look-back window; cannot determine
+            # current window definitively — allow the rearm.
+            return True
+        # The last item is the most recent past transition.
+        # True = arm transition → schedule says armed → allow rearm.
+        # False = disarm transition → schedule says disarmed → suppress rearm.
+        return recent[-1][1]
 
     def _get_arm_time(self, d: dt_date) -> datetime | None:
         # Called with _cfg_lock held (or from within a locked context).

--- a/services/detector/src/scheduler.py
+++ b/services/detector/src/scheduler.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 from datetime import date as dt_date
 from datetime import datetime, timedelta, timezone
 from datetime import time as dt_time
+from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -31,9 +32,11 @@ class ArmScheduler:
         self,
         armed_ref: list[bool],
         on_transition: Callable[[bool], None],
+        get_redis: Callable[[], Any] | None = None,
     ) -> None:
         self._armed_ref = armed_ref
         self._on_transition = on_transition
+        self._get_redis = get_redis  # Optional factory: () -> redis.Redis
         # All mutable config fields are protected by _cfg_lock so that
         # configure() (config-watcher thread) and _tick() (scheduler thread)
         # can run concurrently without seeing a half-updated config.
@@ -142,24 +145,58 @@ class ArmScheduler:
             enabled = self._enabled
             get_arm = self._get_arm_time
             get_disarm = self._get_disarm_time
-        if not enabled:
+        if enabled:
+            now = datetime.now(timezone.utc)
+            last = self._last_tick
+            self._last_tick = now
+
+            for t_time, t_armed in transitions_between(last, now, get_arm, get_disarm):
+                logger.info(
+                    "Scheduled transition at %s: armed → %s",
+                    t_time.strftime("%Y-%m-%d %H:%M %Z"),
+                    t_armed,
+                )
+                self._armed_ref[0] = t_armed
+                try:
+                    self._on_transition(t_armed)
+                except Exception:
+                    logger.exception("Error in arm/disarm transition callback")
+        else:
+            self._last_tick = datetime.now(timezone.utc)
+
+        self._check_pending_rearm()
+
+    def _check_pending_rearm(self) -> None:
+        """Re-arm if a non-admin auto-rearm timestamp has been reached."""
+        if self._get_redis is None:
             return
-
-        now = datetime.now(timezone.utc)
-        last = self._last_tick
-        self._last_tick = now
-
-        for t_time, t_armed in transitions_between(last, now, get_arm, get_disarm):
-            logger.info(
-                "Scheduled transition at %s: armed → %s",
-                t_time.strftime("%Y-%m-%d %H:%M %Z"),
-                t_armed,
-            )
-            self._armed_ref[0] = t_armed
-            try:
-                self._on_transition(t_armed)
-            except Exception:
-                logger.exception("Error in arm/disarm transition callback")
+        r = None
+        try:
+            r = self._get_redis()
+            val: str | None = r.get("scarguard:rearm_at")
+            if val:
+                parsed = datetime.fromisoformat(val)
+                # Ensure timezone-aware; stored value should always be UTC ISO.
+                if parsed.tzinfo is None:
+                    rearm_time = parsed.replace(tzinfo=timezone.utc)
+                else:
+                    rearm_time = parsed.astimezone(timezone.utc)
+                if datetime.now(timezone.utc) >= rearm_time:
+                    logger.info("Non-admin auto-rearm triggered")
+                    self._armed_ref[0] = True
+                    r.delete("scarguard:rearm_at")
+                    try:
+                        self._on_transition(True)
+                    except Exception:
+                        logger.exception("Error in auto-rearm transition callback")
+        except Exception:
+            logger.debug("Failed to check pending rearm in Redis", exc_info=True)
+        finally:
+            if r is not None:
+                try:
+                    r.close()
+                except Exception:
+                    pass
 
     def _get_arm_time(self, d: dt_date) -> datetime | None:
         # Called with _cfg_lock held (or from within a locked context).

--- a/services/notifier/requirements.txt
+++ b/services/notifier/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 pydantic>=2.0
 requests
 tzdata
+Pillow

--- a/services/notifier/src/discord.py
+++ b/services/notifier/src/discord.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import requests
+from snapshot_utils import annotate_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,8 @@ class DiscordNotifier:
 
         snapshot_bytes: bytes | None = None
         if self._include_snapshot and snapshot_path:
-            snapshot_bytes = _read_snapshot(snapshot_path)
+            data = annotate_snapshot(snapshot_path, event.get("bbox"), event.get("frame_size"))
+            snapshot_bytes = data if data else None
 
         if snapshot_bytes and snapshot_path:
             # Embed the image in a Discord embed so it renders inline.
@@ -75,11 +77,3 @@ class DiscordNotifier:
             )
             resp.raise_for_status()
             logger.info("Discord notification sent (no snapshot)")
-
-
-def _read_snapshot(path: str) -> bytes | None:
-    try:
-        return Path(path).read_bytes()
-    except OSError:
-        logger.warning("Snapshot not found or unreadable: %s", path)
-        return None

--- a/services/notifier/src/email_notifier.py
+++ b/services/notifier/src/email_notifier.py
@@ -10,6 +10,8 @@ from email.mime.text import MIMEText
 from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from snapshot_utils import annotate_snapshot
+
 logger = logging.getLogger(__name__)
 
 
@@ -67,7 +69,7 @@ class EmailNotifier:
         msg.attach(MIMEText(body, "plain"))
 
         if self._include_snapshot and snapshot_path:
-            _attach_snapshot(msg, snapshot_path)
+            _attach_snapshot(msg, snapshot_path, event.get("bbox"), event.get("frame_size"))
 
         self._send_message(msg)
         logger.info("Email notification sent to %s", self._to_addresses)
@@ -95,17 +97,21 @@ class EmailNotifier:
                 server.sendmail(self._smtp_user, self._to_addresses, msg.as_string())
 
 
-def _attach_snapshot(msg: MIMEMultipart, path: str) -> None:
-    try:
-        data = Path(path).read_bytes()
-        part = MIMEBase("image", "jpeg")
-        part.set_payload(data)
-        encoders.encode_base64(part)
-        part.add_header(
-            "Content-Disposition",
-            "attachment",
-            filename=Path(path).name,
-        )
-        msg.attach(part)
-    except OSError:
-        logger.warning("Snapshot not found or unreadable for email: %s", path)
+def _attach_snapshot(
+    msg: MIMEMultipart,
+    path: str,
+    bbox: list[int] | None = None,
+    frame_size: list[int] | None = None,
+) -> None:
+    data = annotate_snapshot(path, bbox, frame_size)
+    if not data:
+        return
+    part = MIMEBase("image", "jpeg")
+    part.set_payload(data)
+    encoders.encode_base64(part)
+    part.add_header(
+        "Content-Disposition",
+        "attachment",
+        filename=Path(path).name,
+    )
+    msg.attach(part)

--- a/services/notifier/src/snapshot_utils.py
+++ b/services/notifier/src/snapshot_utils.py
@@ -1,0 +1,51 @@
+"""Snapshot annotation helpers shared by notifier channels."""
+
+import io
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def annotate_snapshot(
+    path: str,
+    bbox: list[int] | None,
+    frame_size: list[int] | None,
+) -> bytes:
+    """Return JPEG bytes with the detection bounding box drawn in red.
+
+    Falls back to the raw (clean) file bytes if:
+    - The file cannot be read.
+    - bbox / frame_size data is absent or malformed.
+    - Pillow is unavailable or raises an unexpected error.
+    """
+    try:
+        raw = Path(path).read_bytes()
+    except OSError:
+        logger.warning("Snapshot not found or unreadable: %s", path)
+        return b""
+
+    if (
+        not bbox
+        or len(bbox) != 4
+        or not frame_size
+        or len(frame_size) != 2
+    ):
+        return raw
+
+    try:
+        from PIL import Image, ImageDraw
+
+        img = Image.open(io.BytesIO(raw)).convert("RGB")
+        # bbox is stored in the pixel space of the saved snapshot (frame_size).
+        # The snapshot JPEG is always written at native frame resolution by the
+        # detector, so img.size == frame_size and the coords are used directly.
+        x1, y1, x2, y2 = int(bbox[0]), int(bbox[1]), int(bbox[2]), int(bbox[3])
+        draw = ImageDraw.Draw(img)
+        draw.rectangle([x1, y1, x2, y2], outline="#ff3333", width=3)
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=85)
+        return buf.getvalue()
+    except Exception as exc:
+        logger.warning("Failed to annotate snapshot, sending clean image: %s", exc)
+        return raw

--- a/services/web/src/config_model.py
+++ b/services/web/src/config_model.py
@@ -34,6 +34,14 @@ class AuthConfig(BaseModel):
     max_login_attempts: int = 5
     lockout_duration_minutes: int = 15
     require_api_auth: bool = False
+    nonadmin_rearm_minutes: int = 30
+
+    @field_validator("nonadmin_rearm_minutes")
+    @classmethod
+    def rearm_minutes_range(cls, v: int) -> int:
+        if not 0 <= v <= 1440:
+            raise ValueError("nonadmin_rearm_minutes must be between 0 and 1440")
+        return v
 
     @field_validator("session_timeout_hours")
     @classmethod

--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -34,6 +34,7 @@ def get_events(
     class_name: str | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
+    feedback: str | None = None,
     include_system: bool = False,
 ) -> list[sqlite3.Row]:
     where: list[str] = []
@@ -52,6 +53,10 @@ def get_events(
     if date_to:
         where.append("timestamp < ?")
         params.append(_date_to_exclusive(date_to))
+    if feedback == "unreviewed":
+        where.append("feedback IS NULL")
+    elif feedback == "reviewed":
+        where.append("feedback IS NOT NULL")
 
     clause = ("WHERE " + " AND ".join(where)) if where else ""
     params += [limit, offset]
@@ -82,6 +87,7 @@ def count_events(
     class_name: str | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
+    feedback: str | None = None,
     include_system: bool = False,
 ) -> int:
     where: list[str] = []
@@ -100,6 +106,10 @@ def count_events(
     if date_to:
         where.append("timestamp < ?")
         params.append(_date_to_exclusive(date_to))
+    if feedback == "unreviewed":
+        where.append("feedback IS NULL")
+    elif feedback == "reviewed":
+        where.append("feedback IS NOT NULL")
 
     clause = ("WHERE " + " AND ".join(where)) if where else ""
     with _connect() as conn:

--- a/services/web/src/routes/config.py
+++ b/services/web/src/routes/config.py
@@ -1,6 +1,8 @@
 import json
 import logging
+import os
 from pathlib import Path
+from zoneinfo import available_timezones
 
 import config_store
 import db
@@ -21,6 +23,22 @@ from pydantic import ValidationError
 log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/config")
+
+_MODELS_DIR = Path(os.getenv("MODELS_DIR", "/models"))
+_MODEL_EXTENSIONS = {".pt", ".engine", ".onnx"}
+_TIMEZONES: list[str] = sorted(available_timezones())
+
+
+def _list_models() -> list[str]:
+    """Return sorted list of model paths available in MODELS_DIR."""
+    try:
+        return sorted(
+            str(_MODELS_DIR / f.name)
+            for f in _MODELS_DIR.iterdir()
+            if f.is_file() and f.suffix in _MODEL_EXTENSIONS
+        )
+    except OSError:
+        return []
 templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
 
 
@@ -110,6 +128,8 @@ async def config_page(request: Request):
             "cfg": cfg,
             "cameras_json": _cameras_json(cfg.cameras),
             "channels_json": _channels_json(raw_cfg),
+            "timezones": _TIMEZONES,
+            "available_models": _list_models(),
         },
     )
 
@@ -236,5 +256,7 @@ async def save_config(request: Request, raw_yaml: str = Form(...)):
             "cfg": cfg,
             "cameras_json": _cameras_json(cfg.cameras),
             "channels_json": _channels_json(raw_cfg),
+            "timezones": _TIMEZONES,
+            "available_models": _list_models(),
         },
     )

--- a/services/web/src/routes/dashboard.py
+++ b/services/web/src/routes/dashboard.py
@@ -3,6 +3,7 @@ from datetime import date as dt_date
 from datetime import datetime, timedelta, timezone
 from datetime import time as dt_time
 from pathlib import Path
+from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import config_store
@@ -15,6 +16,66 @@ log = logging.getLogger(__name__)
 
 router = APIRouter()
 templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
+
+_REARM_KEY = "scarguard:rearm_at"
+
+
+def _is_admin(request: Request) -> bool:
+    user = getattr(request.state, "user", None)
+    return bool(user and user.get("is_admin"))
+
+
+def _redis_client(cfg: dict) -> Any:
+    try:
+        import redis.asyncio as aioredis
+
+        rc = cfg.get("redis", {})
+        return aioredis.Redis(
+            host=rc.get("host", "redis"),
+            port=int(rc.get("port", 6379)),
+            decode_responses=True,
+        )
+    except Exception:
+        log.warning("Failed to create Redis client")
+        return None
+
+
+async def _get_rearm_at(cfg: dict) -> str | None:
+    r = _redis_client(cfg)
+    if r is None:
+        return None
+    try:
+        val: str | None = await r.get(_REARM_KEY)
+        return val
+    except Exception:
+        log.warning("Failed to read rearm_at from Redis")
+        return None
+    finally:
+        await r.aclose()
+
+
+async def _set_rearm_at(cfg: dict, ts: str) -> None:
+    r = _redis_client(cfg)
+    if r is None:
+        return
+    try:
+        await r.set(_REARM_KEY, ts)
+    except Exception:
+        log.warning("Failed to set rearm_at in Redis")
+    finally:
+        await r.aclose()
+
+
+async def _clear_rearm_at(cfg: dict) -> None:
+    r = _redis_client(cfg)
+    if r is None:
+        return
+    try:
+        await r.delete(_REARM_KEY)
+    except Exception:
+        log.warning("Failed to clear rearm_at in Redis")
+    finally:
+        await r.aclose()
 
 
 def _parse_time(s: str) -> dt_time | None:
@@ -144,11 +205,14 @@ async def dashboard(request: Request):
         latest_dict["display_timestamp"] = _to_local(
             latest_dict.get("timestamp", ""), tz_name
         )
+    rearm_at = await _get_rearm_at(cfg)
     return templates.TemplateResponse(
         request,
         "dashboard.html",
         {
             "armed": cfg.get("system", {}).get("armed", True),
+            "rearm_at": rearm_at,
+            "is_admin": _is_admin(request),
             "cameras": cameras,
             "total_events": total,
             "latest": latest_dict,
@@ -158,22 +222,64 @@ async def dashboard(request: Request):
     )
 
 
+@router.get("/arm-status", response_class=HTMLResponse)
+async def arm_status(request: Request):
+    """Return the arm badge fragment; used by HTMX polling."""
+    cfg = config_store.load()
+    armed = cfg.get("system", {}).get("armed", True)
+    rearm_at = await _get_rearm_at(cfg)
+    return await _arm_badge(request, armed=armed, rearm_at=rearm_at)
+
+
 @router.post("/arm", response_class=HTMLResponse)
 async def arm(request: Request):
+    cfg = config_store.load()
     config_store.set_armed(True)
-    return _arm_badge(request, armed=True)
+    await _clear_rearm_at(cfg)
+    return await _arm_badge(request, armed=True)
 
 
 @router.post("/disarm", response_class=HTMLResponse)
 async def disarm(request: Request):
+    cfg = config_store.load()
     config_store.set_armed(False)
-    return _arm_badge(request, armed=False)
+    rearm_at: str | None = None
+    if _is_admin(request):
+        await _clear_rearm_at(cfg)
+    else:
+        rearm_minutes = (
+            cfg.get("system", {}).get("auth", {}).get("nonadmin_rearm_minutes", 30)
+        )
+        if isinstance(rearm_minutes, int) and rearm_minutes > 0:
+            rearm_time = datetime.now(timezone.utc) + timedelta(minutes=rearm_minutes)
+            rearm_at = rearm_time.isoformat()
+            await _set_rearm_at(cfg, rearm_at)
+    return await _arm_badge(request, armed=False, rearm_at=rearm_at)
 
 
-def _arm_badge(request: Request, *, armed: bool) -> HTMLResponse:
+@router.post("/cancel-rearm", response_class=HTMLResponse)
+async def cancel_rearm(request: Request):
+    """Admin-only: cancel a pending non-admin auto-rearm."""
+    cfg = config_store.load()
+    armed = cfg.get("system", {}).get("armed", True)
+    if not _is_admin(request):
+        return await _arm_badge(request, armed=armed)
+    await _clear_rearm_at(cfg)
+    return await _arm_badge(request, armed=armed)
+
+
+async def _arm_badge(
+    request: Request,
+    *,
+    armed: bool,
+    rearm_at: str | None = None,
+    is_admin: bool | None = None,
+) -> HTMLResponse:
     """Return just the status badge fragment for HTMX swap."""
+    if is_admin is None:
+        is_admin = _is_admin(request)
     return templates.TemplateResponse(
         request,
         "partials/arm_badge.html",
-        {"armed": armed},
+        {"armed": armed, "rearm_at": rearm_at, "is_admin": is_admin},
     )

--- a/services/web/src/routes/events.py
+++ b/services/web/src/routes/events.py
@@ -71,14 +71,16 @@ async def events_page(
     class_name: str = "",
     date_from: str = "",
     date_to: str = "",
+    feedback: str = "",
 ):
     offset = (page - 1) * PAGE_SIZE
     cam = camera or None
     cls = class_name or None
     dfrom = date_from or None
     dto = date_to or None
-    rows = db.get_events(limit=PAGE_SIZE, offset=offset, camera=cam, class_name=cls, date_from=dfrom, date_to=dto)
-    total = db.count_events(camera=cam, class_name=cls, date_from=dfrom, date_to=dto)
+    fb = feedback or None
+    rows = db.get_events(limit=PAGE_SIZE, offset=offset, camera=cam, class_name=cls, date_from=dfrom, date_to=dto, feedback=fb)
+    total = db.count_events(camera=cam, class_name=cls, date_from=dfrom, date_to=dto, feedback=fb)
     events = _apply_display_timestamp([dict(r) for r in rows])
     return templates.TemplateResponse(
         request,
@@ -93,6 +95,7 @@ async def events_page(
             "filter_class": class_name,
             "filter_date_from": date_from,
             "filter_date_to": date_to,
+            "filter_feedback": feedback,
             "target_classes": _get_target_classes(),
         },
     )

--- a/services/web/src/static/config.js
+++ b/services/web/src/static/config.js
@@ -196,6 +196,7 @@ function readForm() {
         max_login_attempts: parseInt(document.getElementById("auth-max-attempts").value, 10) || 5,
         lockout_duration_minutes: parseInt(document.getElementById("auth-lockout-minutes").value, 10) || 15,
         require_api_auth: document.getElementById("auth-require-api").checked,
+        nonadmin_rearm_minutes: parseInt(document.getElementById("auth-rearm-minutes").value, 10) || 0,
       },
     },
     cameras: readCameras(),

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -48,6 +48,49 @@ nav .brand {
 nav a { color: var(--muted); font-size: 0.9rem; }
 nav a:hover { color: var(--text); text-decoration: none; }
 
+/* ── Admin dropdown ────────────────────────────────────────────────────────── */
+.nav-dropdown {
+  position: relative;
+}
+.nav-dropdown__toggle {
+  color: var(--muted);
+  font-size: 0.9rem;
+  cursor: pointer;
+  user-select: none;
+}
+.nav-dropdown__toggle:hover { color: var(--text); }
+.nav-dropdown__menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.35rem 0;
+  min-width: 11rem;
+  z-index: 200;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.45);
+}
+.nav-dropdown:hover .nav-dropdown__menu { display: block; }
+.nav-dropdown__menu a {
+  display: block;
+  padding: 0.4rem 1rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+.nav-dropdown__menu a:hover {
+  color: var(--text);
+  background: rgba(255,255,255,0.04);
+  text-decoration: none;
+}
+.nav-dropdown__sep {
+  height: 1px;
+  background: var(--border);
+  margin: 0.3rem 0;
+}
+
 /* ── Main layout ──────────────────────────────────────────────────────────── */
 main {
   max-width: 960px;
@@ -80,6 +123,23 @@ h2 { font-size: 1.05rem; font-weight: 600; margin-bottom: 0.75rem; }
 }
 .badge-armed    { background: var(--ok);     color: #0a1a12; }
 .badge-disarmed { background: var(--danger); color: #fff; }
+.rearm-countdown {
+  font-size: 0.85rem;
+  color: var(--warn);
+  margin-left: 0.75rem;
+}
+.rearm-timer { font-weight: 600; }
+.btn-cancel-rearm {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+  padding: 0.2em 0.6em;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  border-radius: 3px;
+  cursor: pointer;
+}
+.btn-cancel-rearm:hover { color: var(--text); border-color: var(--text); }
 
 /* ── Buttons ──────────────────────────────────────────────────────────────── */
 button {
@@ -569,6 +629,31 @@ input[type="range"] {
   border-radius: 2px;
   white-space: nowrap;
 }
+
+/* ── Overlay feedback panel ──────────────────────────────────────────────── */
+.overlay-feedback {
+  margin-top: 0.6rem;
+  background: rgba(26,29,39,0.92);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  cursor: default;
+}
+.overlay-feedback-label {
+  color: var(--muted);
+  font-size: 0.78rem;
+  margin-right: 0.25rem;
+  flex-shrink: 0;
+}
+.overlay-fb-btns {
+  display: flex;
+  gap: 4px;
+}
+.wrong-class-picker { display: flex; align-items: center; gap: 4px; margin-top: 0; }
 
 /* ── Training dashboard ──────────────────────────────────────────────────── */
 .training-stats-row {

--- a/services/web/src/templates/base.html
+++ b/services/web/src/templates/base.html
@@ -13,16 +13,24 @@
     <a href="/">Dashboard</a>
     <a href="/events">Events</a>
     <a href="/feed">Live Feed</a>
-    <a href="/models">Models</a>
-    <a href="/config">Config</a>
+    {% if request.state.user and request.state.user.is_admin %}
+    <div class="nav-dropdown">
+      <span class="nav-dropdown__toggle">Admin &#9660;</span>
+      <div class="nav-dropdown__menu">
+        <a href="/config">Config</a>
+        <a href="/models">Models</a>
+        <div class="nav-dropdown__sep"></div>
+        <a href="/admin/stats">Stats</a>
+        <a href="/admin/logs">Logs</a>
+        <div class="nav-dropdown__sep"></div>
+        <a href="/admin/users">Users</a>
+        <a href="/admin/training">Training Data</a>
+        <a href="/admin/training/evaluate">Model Evaluation</a>
+      </div>
+    </div>
+    {% endif %}
     <a href="/about">About</a>
-    <a href="/admin/logs">Logs</a>
-    <a href="/admin/stats">Stats</a>
     {% if request.state.user %}
-      {% if request.state.user.is_admin %}
-    <a href="/admin/users">Users</a>
-    <a href="/admin/training">Training</a>
-      {% endif %}
     <span class="muted" style="font-size:0.85rem;margin-left:auto;">{{ request.state.user.username }}</span>
     <form method="post" action="/logout" style="margin:0;">
       <button type="submit" style="background:none;border:1px solid var(--border);color:var(--muted);padding:0.25em 0.7em;font-size:0.8rem;">Logout</button>

--- a/services/web/src/templates/config.html
+++ b/services/web/src/templates/config.html
@@ -41,8 +41,11 @@
         <div class="field-row">
           <div class="field-group">
             <label>Timezone (IANA name)</label>
-            <input type="text" id="sys-timezone" value="{{ cfg.system.timezone }}"
-                   placeholder="UTC, America/Los_Angeles, Europe/London…">
+            <input list="tz-list" id="sys-timezone" value="{{ cfg.system.timezone }}"
+                   placeholder="Start typing to search…" autocomplete="off">
+            <datalist id="tz-list">
+              {% for tz in timezones %}<option value="{{ tz }}">{% endfor %}
+            </datalist>
           </div>
           <div class="field-group">
             <label>Snapshot retention (days, 0 = keep forever)</label>
@@ -88,7 +91,18 @@
       <div class="card">
         <div class="field-group">
           <label>Model path (inside container)</label>
+          {% if available_models %}
+          <select id="det-model-path">
+            {% for m in available_models %}
+            <option value="{{ m }}" {% if m == cfg.detection.model_path %}selected{% endif %}>{{ m }}</option>
+            {% endfor %}
+            {% if cfg.detection.model_path not in available_models %}
+            <option value="{{ cfg.detection.model_path }}" selected>{{ cfg.detection.model_path }} (current)</option>
+            {% endif %}
+          </select>
+          {% else %}
           <input type="text" id="det-model-path" value="{{ cfg.detection.model_path }}" placeholder="/models/yolov8n.pt">
+          {% endif %}
         </div>
         <div class="field-group">
           <label>Confidence threshold</label>
@@ -337,6 +351,11 @@
             <label>Lockout duration (minutes)</label>
             <input type="number" id="auth-lockout-minutes" value="{{ cfg.system.auth.lockout_duration_minutes }}"
                    min="1" max="1440">
+          </div>
+          <div class="field-group">
+            <label>Non-admin auto-rearm delay (minutes, 0 to disable)</label>
+            <input type="number" id="auth-rearm-minutes" value="{{ cfg.system.auth.nonadmin_rearm_minutes }}"
+                   min="0" max="1440">
           </div>
         </div>
       </div>

--- a/services/web/src/templates/dashboard.html
+++ b/services/web/src/templates/dashboard.html
@@ -5,15 +5,7 @@
 
 <section class="card">
   <h2>System Status</h2>
-  <div id="arm-status">
-    {% if armed %}
-    <span class="badge badge-armed">ARMED</span>
-    <button hx-post="/disarm" hx-target="#arm-status" hx-swap="outerHTML">Disarm</button>
-    {% else %}
-    <span class="badge badge-disarmed">DISARMED</span>
-    <button hx-post="/arm" hx-target="#arm-status" hx-swap="outerHTML">Arm</button>
-    {% endif %}
-  </div>
+  {% include "partials/arm_badge.html" %}
   {% if schedule.enabled %}
   <p class="hint" style="margin-top:0.5rem;">
     Schedule: arm <strong>{{ schedule.arm_time or "sunrise" }}</strong> /
@@ -70,4 +62,19 @@
 </section>
 {% endif %}
 
+<script>
+function _updateRearmTimers() {
+  document.querySelectorAll('.rearm-countdown').forEach(function(el) {
+    var ms = new Date(el.dataset.rearmAt) - Date.now();
+    var t = el.querySelector('.rearm-timer');
+    if (!t) return;
+    if (ms <= 0) { t.textContent = 'now'; return; }
+    var m = Math.floor(ms / 60000);
+    var s = Math.floor((ms % 60000) / 1000);
+    t.textContent = m + ':' + String(s).padStart(2, '0');
+  });
+}
+setInterval(_updateRearmTimers, 1000);
+_updateRearmTimers();
+</script>
 {% endblock %}

--- a/services/web/src/templates/events.html
+++ b/services/web/src/templates/events.html
@@ -137,6 +137,11 @@ document.addEventListener('click', function(e) {
   document.body.appendChild(overlay);
 });
 
+function _escHtml(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;')
+                  .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 function buildOverlayFeedbackHTML(feedback, correctedClass) {
   var html = '<div class="overlay-feedback-label">Feedback</div>';
   if (feedback) {
@@ -144,7 +149,7 @@ function buildOverlayFeedbackHTML(feedback, correctedClass) {
                feedback === 'false_positive' ? 'badge-fp' : 'badge-wrong';
     var bTxt = feedback === 'correct' ? 'Correct' :
                feedback === 'false_positive' ? 'False Positive' :
-               'Wrong: ' + (correctedClass || '?').replace(/_/g, ' ');
+               'Wrong: ' + _escHtml((correctedClass || '?').replace(/_/g, ' '));
     html += '<span class="badge ' + bCls + '">' + bTxt + '</span>';
     html += '<button class="btn-edit-feedback js-overlay-edit">edit</button>';
   }
@@ -156,7 +161,8 @@ function buildOverlayFeedbackHTML(feedback, correctedClass) {
   html += '<div class="wrong-class-picker" style="display:none">';
   html += '<select class="js-wrong-cls"><option value="">Select class\u2026</option>';
   (SCARGUARD_TARGET_CLASSES || []).forEach(function(cls) {
-    html += '<option value="' + cls + '">' + cls.replace(/_/g, ' ') + '</option>';
+    var escaped = _escHtml(cls);
+    html += '<option value="' + escaped + '">' + escaped.replace(/_/g, ' ') + '</option>';
   });
   html += '</select>';
   html += '<button class="btn-fb btn-fb-wrong js-wrong-set">Set</button>';

--- a/services/web/src/templates/events.html
+++ b/services/web/src/templates/events.html
@@ -26,8 +26,16 @@
       To
       <input type="date" name="date_to" value="{{ filter_date_to }}">
     </label>
+    <label>
+      Feedback
+      <select name="feedback">
+        <option value="">All</option>
+        <option value="unreviewed" {% if filter_feedback == "unreviewed" %}selected{% endif %}>Unreviewed</option>
+        <option value="reviewed" {% if filter_feedback == "reviewed" %}selected{% endif %}>Reviewed</option>
+      </select>
+    </label>
     <button type="submit">Filter</button>
-    {% if filter_camera or filter_class or filter_date_from or filter_date_to %}
+    {% if filter_camera or filter_class or filter_date_from or filter_date_to or filter_feedback %}
     <a href="/events" class="btn-secondary">Clear</a>
     {% endif %}
   </div>
@@ -59,24 +67,30 @@
 {% if total_pages > 1 %}
 <nav class="pagination">
   {% if page > 1 %}
-  <a href="/events?page={{ page - 1 }}&amp;camera={{ filter_camera | urlencode }}&amp;class_name={{ filter_class | urlencode }}&amp;date_from={{ filter_date_from | urlencode }}&amp;date_to={{ filter_date_to | urlencode }}">&laquo; Newer</a>
+  <a href="/events?page={{ page - 1 }}&amp;camera={{ filter_camera | urlencode }}&amp;class_name={{ filter_class | urlencode }}&amp;date_from={{ filter_date_from | urlencode }}&amp;date_to={{ filter_date_to | urlencode }}&amp;feedback={{ filter_feedback | urlencode }}">&laquo; Newer</a>
   {% endif %}
   <span>Page {{ page }} / {{ total_pages }}</span>
   {% if page < total_pages %}
-  <a href="/events?page={{ page + 1 }}&amp;camera={{ filter_camera | urlencode }}&amp;class_name={{ filter_class | urlencode }}&amp;date_from={{ filter_date_from | urlencode }}&amp;date_to={{ filter_date_to | urlencode }}">Older &raquo;</a>
+  <a href="/events?page={{ page + 1 }}&amp;camera={{ filter_camera | urlencode }}&amp;class_name={{ filter_class | urlencode }}&amp;date_from={{ filter_date_from | urlencode }}&amp;date_to={{ filter_date_to | urlencode }}&amp;feedback={{ filter_feedback | urlencode }}">Older &raquo;</a>
   {% endif %}
 </nav>
 {% endif %}
 
 <script src="https://unpkg.com/htmx-ext-sse@2.2.1/sse.js" defer></script>
 <script>
-// Snapshot overlay with bbox rendering
+var SCARGUARD_TARGET_CLASSES = {{ target_classes | tojson | safe }};
+
+// Snapshot overlay with bbox rendering and inline feedback
 document.addEventListener('click', function(e) {
   var link = e.target.closest('.snapshot-link');
   if (!link) return;
   e.preventDefault();
+
   var bbox = link.dataset.bbox ? JSON.parse(link.dataset.bbox) : null;
   var frameSize = link.dataset.frameSize ? JSON.parse(link.dataset.frameSize) : null;
+  var eventId = link.dataset.eventId ? parseInt(link.dataset.eventId) : null;
+  var initFeedback = link.dataset.feedback || '';
+  var initCorrected = link.dataset.correctedClass || '';
   var src = link.querySelector('img').src;
 
   var overlay = document.createElement('div');
@@ -84,6 +98,7 @@ document.addEventListener('click', function(e) {
 
   var inner = document.createElement('div');
   inner.className = 'snapshot-overlay__inner';
+
   var img = document.createElement('img');
   img.src = src;
   inner.appendChild(img);
@@ -94,7 +109,6 @@ document.addEventListener('click', function(e) {
       var scaleY = img.naturalHeight / frameSize[1];
       var x1 = bbox[0] * scaleX, y1 = bbox[1] * scaleY;
       var x2 = bbox[2] * scaleX, y2 = bbox[3] * scaleY;
-      // Convert to percentages relative to displayed image
       var pctL = (x1 / img.naturalWidth) * 100;
       var pctT = (y1 / img.naturalHeight) * 100;
       var pctW = ((x2 - x1) / img.naturalWidth) * 100;
@@ -109,9 +123,106 @@ document.addEventListener('click', function(e) {
     }
   };
 
+  if (eventId) {
+    var fbPanel = document.createElement('div');
+    fbPanel.className = 'overlay-feedback';
+    fbPanel.innerHTML = buildOverlayFeedbackHTML(initFeedback, initCorrected);
+    fbPanel.addEventListener('click', function(ev) { ev.stopPropagation(); });
+    wireOverlayFeedback(fbPanel, eventId, link);
+    inner.appendChild(fbPanel);
+  }
+
   overlay.appendChild(inner);
   overlay.addEventListener('click', function() { overlay.remove(); });
   document.body.appendChild(overlay);
 });
+
+function buildOverlayFeedbackHTML(feedback, correctedClass) {
+  var html = '<div class="overlay-feedback-label">Feedback</div>';
+  if (feedback) {
+    var bCls = feedback === 'correct' ? 'badge-correct' :
+               feedback === 'false_positive' ? 'badge-fp' : 'badge-wrong';
+    var bTxt = feedback === 'correct' ? 'Correct' :
+               feedback === 'false_positive' ? 'False Positive' :
+               'Wrong: ' + (correctedClass || '?').replace(/_/g, ' ');
+    html += '<span class="badge ' + bCls + '">' + bTxt + '</span>';
+    html += '<button class="btn-edit-feedback js-overlay-edit">edit</button>';
+  }
+  html += '<div class="overlay-fb-btns"' + (feedback ? ' style="display:none"' : '') + '>';
+  html += '<button class="btn-fb btn-fb-correct js-fb" data-fb="correct" title="Correct detection">&#10003;</button>';
+  html += '<button class="btn-fb btn-fb-fp js-fb" data-fb="false_positive" title="False positive">&#10007;</button>';
+  html += '<button class="btn-fb btn-fb-wrong js-fb-wrong" title="Wrong class">?</button>';
+  html += '</div>';
+  html += '<div class="wrong-class-picker" style="display:none">';
+  html += '<select class="js-wrong-cls"><option value="">Select class\u2026</option>';
+  (SCARGUARD_TARGET_CLASSES || []).forEach(function(cls) {
+    html += '<option value="' + cls + '">' + cls.replace(/_/g, ' ') + '</option>';
+  });
+  html += '</select>';
+  html += '<button class="btn-fb btn-fb-wrong js-wrong-set">Set</button>';
+  html += '</div>';
+  return html;
+}
+
+function wireOverlayFeedback(panel, eventId, sourceLink) {
+  var editBtn = panel.querySelector('.js-overlay-edit');
+  if (editBtn) {
+    editBtn.addEventListener('click', function() {
+      panel.querySelector('.overlay-fb-btns').style.display = 'flex';
+      this.style.display = 'none';
+      var badge = panel.querySelector('.badge');
+      if (badge) badge.style.display = 'none';
+    });
+  }
+
+  panel.querySelectorAll('.js-fb').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      doOverlayFeedback(panel, eventId, btn.dataset.fb, '', sourceLink);
+    });
+  });
+
+  var wrongBtn = panel.querySelector('.js-fb-wrong');
+  if (wrongBtn) {
+    wrongBtn.addEventListener('click', function() {
+      panel.querySelector('.wrong-class-picker').style.display = 'flex';
+    });
+  }
+
+  var setBtn = panel.querySelector('.js-wrong-set');
+  if (setBtn) {
+    setBtn.addEventListener('click', function() {
+      var cls = panel.querySelector('.js-wrong-cls').value;
+      if (cls) doOverlayFeedback(panel, eventId, 'wrong_class', cls, sourceLink);
+    });
+  }
+}
+
+function doOverlayFeedback(panel, eventId, feedback, correctedClass, sourceLink) {
+  var fd = new FormData();
+  fd.append('feedback', feedback);
+  if (correctedClass) fd.append('corrected_class', correctedClass);
+  fetch('/events/' + eventId + '/feedback', { method: 'POST', body: fd })
+    .then(function(r) { return r.text(); })
+    .then(function(html) {
+      // Replace the table row with the updated version
+      var row = document.getElementById('event-row-' + eventId);
+      if (row) {
+        var tmp = document.createElement('tbody');
+        tmp.innerHTML = html;
+        var newRow = tmp.firstElementChild;
+        if (newRow) {
+          row.replaceWith(newRow);
+          htmx.process(newRow);
+        }
+      }
+      // Update source link data attributes so reopening the overlay reflects the new state
+      sourceLink.dataset.feedback = feedback;
+      sourceLink.dataset.correctedClass = correctedClass;
+      // Re-render the feedback panel in the overlay
+      panel.innerHTML = buildOverlayFeedbackHTML(feedback, correctedClass);
+      wireOverlayFeedback(panel, eventId, sourceLink);
+    })
+    .catch(function(err) { console.error('Feedback submit failed:', err); });
+}
 </script>
 {% endblock %}

--- a/services/web/src/templates/partials/arm_badge.html
+++ b/services/web/src/templates/partials/arm_badge.html
@@ -1,7 +1,19 @@
-{% if armed %}
-<span class="badge badge-armed">ARMED</span>
-<button hx-post="/disarm" hx-target="#arm-status" hx-swap="outerHTML">Disarm</button>
-{% else %}
-<span class="badge badge-disarmed">DISARMED</span>
-<button hx-post="/arm" hx-target="#arm-status" hx-swap="outerHTML">Arm</button>
-{% endif %}
+<div id="arm-status"
+     hx-get="/arm-status" hx-trigger="every 30s" hx-target="this" hx-swap="outerHTML">
+  {% if armed %}
+  <span class="badge badge-armed">ARMED</span>
+  <button hx-post="/disarm" hx-target="#arm-status" hx-swap="outerHTML">Disarm</button>
+  {% else %}
+  <span class="badge badge-disarmed">DISARMED</span>
+  <button hx-post="/arm" hx-target="#arm-status" hx-swap="outerHTML">Arm</button>
+  {% if rearm_at %}
+  <span class="rearm-countdown" data-rearm-at="{{ rearm_at }}">
+    Auto-rearming in <span class="rearm-timer">&hellip;</span>
+  </span>
+  {% if is_admin %}
+  <button hx-post="/cancel-rearm" hx-target="#arm-status" hx-swap="outerHTML"
+          class="btn-cancel-rearm">Cancel</button>
+  {% endif %}
+  {% endif %}
+  {% endif %}
+</div>

--- a/services/web/src/templates/partials/event_rows.html
+++ b/services/web/src/templates/partials/event_rows.html
@@ -1,5 +1,5 @@
 {% for e in events %}
-<tr class="{{ '' if e.feedback else 'event-unreviewed' }}">
+<tr id="event-row-{{ e.id }}" class="{{ '' if e.feedback else 'event-unreviewed' }}">
   <td>{{ e.display_timestamp }}</td>
   <td>{{ e.class_name.replace("_", " ").title() }}</td>
   <td>{{ "%.0f%%"|format(e.confidence * 100) }}</td>
@@ -13,6 +13,9 @@
     {% if e.snapshot_path %}
     {% set fname = e.snapshot_path.split("/")[-1] %}
     <a href="/snapshots/{{ fname }}" target="_blank" class="snapshot-link"
+       data-event-id="{{ e.id }}"
+       data-feedback="{{ e.feedback or '' }}"
+       data-corrected-class="{{ e.corrected_class or '' }}"
        {% if e.bbox and e.frame_size %}
        data-bbox="{{ e.bbox | tojson }}"
        data-frame-size="{{ e.frame_size | tojson }}"

--- a/services/web/src/templates/training.html
+++ b/services/web/src/templates/training.html
@@ -80,4 +80,19 @@
 <p class="muted">No exportable events. Label detections as "Correct" on the <a href="/events">Events</a> page, and ensure events have bounding box data (post-migration only).</p>
 {% endif %}
 
+<h2>Training Workflow</h2>
+<div class="card">
+  <p class="hint" style="margin-bottom:0.75rem;">Model training runs offline via a command-line script. This page handles steps 1–2; steps 3–5 use the <a href="/admin/training/evaluate">Model Evaluation</a> page.</p>
+  <ol style="padding-left:1.25rem;line-height:2;">
+    <li><strong>Label detections</strong> — use the feedback controls on the <a href="/events">Events</a> page to mark each detection as Correct, False Positive, or Wrong Class.</li>
+    <li><strong>Export the dataset</strong> — click <em>Download Dataset</em> above to get a YOLO-format zip (images + annotation .txt files + data.yaml).</li>
+    <li><strong>Train a model</strong> — run <code>training/train.py</code> on a GPU machine (the Orin works, but a workstation GPU is faster for training):
+      <pre style="margin:0.4rem 0;padding:0.5rem 0.75rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;font-size:0.82rem;overflow-x:auto;">python train.py --data dataset/data.yaml --output heron-v2.pt --epochs 100</pre>
+      See <code>training/README.md</code> in the repo for the full CLI reference and Jetson tips.
+    </li>
+    <li><strong>Upload the model</strong> — drop the resulting <code>.pt</code> file into the <a href="/models">Models</a> page.</li>
+    <li><strong>Evaluate &amp; promote</strong> — compare the new model against the current one on the <a href="/admin/training/evaluate">Model Evaluation</a> page, then promote the winner. The detector hot-reloads the new model — no restart needed.</li>
+  </ol>
+</div>
+
 {% endblock %}


### PR DESCRIPTION
## Summary

- **Overlay feedback** — feedback controls (correct / false positive / wrong class) now appear directly in the enlarged snapshot overlay, no need to dismiss and click back to the table row
- **Bbox annotations in notifications** — Discord and email alerts now send annotated JPEG images with the detection bounding box drawn in red; uses Pillow in-memory via a new shared `snapshot_utils` module with graceful fallback to clean image
- **Config page UX** — timezone field upgraded to `<datalist>` autocomplete from all IANA zones; model path upgraded to a `<select>` dropdown populated from `MODELS_DIR`; free-text fallback when directory is empty
- **Admin nav dropdown** — Config, Models, Stats, Logs, Users, Training Data, and Model Evaluation grouped under a CSS-only Admin dropdown; hidden entirely from non-admin users
- **Training workflow guide** — 5-step label → export → train → upload → evaluate guide added to the Training Data page
- **Non-admin auto-rearm** — when a non-admin disarms, the system re-arms automatically after an admin-configurable delay (`nonadmin_rearm_minutes`, default 30 min, 0 = disabled); dashboard shows a live countdown; admins can cancel early; detector scheduler polls the `scarguard:rearm_at` Redis key every 60s; admin disarms are permanent
- **Events feedback filter** — new Feedback dropdown (All / Unreviewed / Reviewed) on the events page; stacks with camera/class/date filters, preserved through pagination, included in Clear condition
- **README overhaul** — accurate v0.1–v0.7 feature status table, complete named-channel config examples, full feature guides for all implemented features

## Test plan

- [ ] Open an event snapshot overlay → feedback buttons appear inline; submit feedback → table row updates and overlay panel re-renders
- [ ] Trigger a detection with bbox data → verify Discord/email notification contains annotated image with red bounding box
- [ ] Config page → timezone field shows autocomplete suggestions; model path shows dropdown of available model files
- [ ] Log in as non-admin → Admin dropdown absent from nav; log in as admin → dropdown present with all 7 links
- [ ] Non-admin disarms → countdown appears on dashboard; wait for delay (or shorten `nonadmin_rearm_minutes`) → system re-arms automatically
- [ ] Admin disarms → no countdown; admin cancels a pending non-admin rearm via Cancel button → countdown disappears
- [ ] Events page: select "Unreviewed" → only events without feedback shown; select "Reviewed" → only events with feedback shown; paginate → filter preserved
- [ ] Set `nonadmin_rearm_minutes: 0` in config → non-admin disarm behaves like admin (no auto-rearm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)