### PR TITLE
fix: prevent Compose double-prefixing volume names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,12 @@ services:
 
 volumes:
   redis-data:
+    name: scarguard-redis-data
   scarguard-config:
+    name: scarguard-config
   scarguard-models:
+    name: scarguard-models
   scarguard-data:
+    name: scarguard-data
   scarguard-notifier:
+    name: scarguard-notifier


### PR DESCRIPTION
## Summary
- Adds explicit `name:` to all volume definitions in `docker-compose.yml`
- Prevents Compose from prepending the project name (`scarguard_`) to volumes that already start with `scarguard-`, which was creating duplicates like `scarguard_scarguard-config` alongside `scarguard-config`
- Volume names match what `migrate-to-volumes.sh` creates

## Test plan
- [ ] `docker compose config` shows correct volume names (no double prefix)
- [ ] `docker compose up -d` uses the intended volumes on the Orin
- [ ] Stale `scarguard_scarguard-*` volumes can be removed after verifying

🤖 Generated with [Claude Code](https://claude.com/claude-code)