### PR TITLE
fix: add explicit volume names to prevent Compose project-name prefixing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,12 @@ services:
 
 volumes:
   redis-data:
+    name: scarguard-redis-data
   scarguard-config:
+    name: scarguard-config
   scarguard-models:
+    name: scarguard-models
   scarguard-data:
+    name: scarguard-data
   scarguard-notifier:
+    name: scarguard-notifier


### PR DESCRIPTION
## Summary
- Adds explicit `name:` to each named volume in `docker-compose.yml`
- Without this, Compose prepends the project name creating duplicates like `scarguard_scarguard-config` alongside the intended `scarguard-config` volumes

Cherry-picked from `fix/volume-name-prefix` (commit 6779948) to isolate this fix from the broader v0.8 feature branch.

## Test plan
- [ ] `docker compose config` shows volume names without project-name prefix
- [ ] `docker compose up -d` creates correctly named volumes

https://claude.ai/code/session_01VKY8VmmVfoRsGDZh3DGwMv