### PR TITLE
feat: freeform class input for wrong-class feedback

### DIFF
--- a/services/web/src/routes/events.py
+++ b/services/web/src/routes/events.py
@@ -143,6 +143,17 @@ async def submit_feedback(
     corr = corrected_class.strip() or None
     if feedback != "wrong_class":
         corr = None
+    if feedback == "wrong_class" and corr is None:
+        # Refuse to store wrong_class without an actual corrected class
+        row = db.get_event(event_id)
+        if row is None:
+            return HTMLResponse("<tr><td colspan='7'>Event not found</td></tr>")
+        events = _apply_display_timestamp([dict(row)])
+        return templates.TemplateResponse(
+            request,
+            "partials/event_rows.html",
+            {"events": events, "target_classes": _get_target_classes()},
+        )
     db.update_feedback(event_id, feedback, corr)
     row = db.get_event(event_id)
     if row is None:

--- a/services/web/src/routes/events.py
+++ b/services/web/src/routes/events.py
@@ -75,7 +75,7 @@ async def events_page(
 ):
     offset = (page - 1) * PAGE_SIZE
     cam = camera or None
-    cls = class_name or None
+    cls = None if (not class_name or class_name.strip() == "*") else class_name
     dfrom = date_from or None
     dto = date_to or None
     fb = feedback or None

--- a/services/web/src/templates/events.html
+++ b/services/web/src/templates/events.html
@@ -159,12 +159,14 @@ function buildOverlayFeedbackHTML(feedback, correctedClass) {
   html += '<button class="btn-fb btn-fb-wrong js-fb-wrong" title="Wrong class">?</button>';
   html += '</div>';
   html += '<div class="wrong-class-picker" style="display:none">';
-  html += '<select class="js-wrong-cls"><option value="">Select class\u2026</option>';
+  var dlId = 'overlay-class-options-' + Math.random().toString(36).slice(2, 8);
+  html += '<input type="text" class="js-wrong-cls" list="' + dlId + '" placeholder="Select or type class\u2026">';
+  html += '<datalist id="' + dlId + '">';
   (SCARGUARD_TARGET_CLASSES || []).forEach(function(cls) {
     var escaped = _escHtml(cls);
     html += '<option value="' + escaped + '">' + escaped.replace(/_/g, ' ') + '</option>';
   });
-  html += '</select>';
+  html += '</datalist>';
   html += '<button class="btn-fb btn-fb-wrong js-wrong-set">Set</button>';
   html += '</div>';
   return html;
@@ -197,7 +199,7 @@ function wireOverlayFeedback(panel, eventId, sourceLink) {
   var setBtn = panel.querySelector('.js-wrong-set');
   if (setBtn) {
     setBtn.addEventListener('click', function() {
-      var cls = panel.querySelector('.js-wrong-cls').value;
+      var cls = panel.querySelector('.js-wrong-cls').value.trim();
       if (cls) doOverlayFeedback(panel, eventId, 'wrong_class', cls, sourceLink);
     });
   }

--- a/services/web/src/templates/partials/event_rows.html
+++ b/services/web/src/templates/partials/event_rows.html
@@ -64,7 +64,7 @@
               hx-swap="outerHTML">
           <input type="hidden" name="feedback" value="wrong_class">
           <input type="text" name="corrected_class" list="class-options-{{ e.id }}"
-                 placeholder="Select or type class&hellip;" required>
+                 placeholder="Select or type class&hellip;" required pattern="\S.*">
           <datalist id="class-options-{{ e.id }}">
             {% for cls in target_classes|default([]) %}
             <option value="{{ cls }}">{{ cls.replace("_"," ").title() }}</option>

--- a/services/web/src/templates/partials/event_rows.html
+++ b/services/web/src/templates/partials/event_rows.html
@@ -63,12 +63,13 @@
               hx-target="closest tr"
               hx-swap="outerHTML">
           <input type="hidden" name="feedback" value="wrong_class">
-          <select name="corrected_class" required>
-            <option value="">Select class&hellip;</option>
+          <input type="text" name="corrected_class" list="class-options-{{ e.id }}"
+                 placeholder="Select or type class&hellip;" required>
+          <datalist id="class-options-{{ e.id }}">
             {% for cls in target_classes|default([]) %}
             <option value="{{ cls }}">{{ cls.replace("_"," ").title() }}</option>
             {% endfor %}
-          </select>
+          </datalist>
           <button type="submit" class="btn-fb btn-fb-wrong">Set</button>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- Replaces the fixed `<select>` dropdown in the wrong-class feedback picker (both table rows and snapshot overlay) with an `<input type="text">` + `<datalist>` combo — users can pick from configured target classes **or type any class name freeform**
- Supports `*` as a wildcard in the events page class filter (treated same as blank/all classes)
- Better supports the training goal: corrected labels for dataset export are no longer limited to the detection search list

## Test plan
- [ ] Open events page, click `?` on a detection → verify dropdown suggestions appear from target_classes
- [ ] Type a custom class name not in the list → verify it submits and displays correctly
- [ ] Open snapshot overlay, repeat both tests above
- [ ] Enter `*` in the class filter → verify it returns all events (same as blank)
- [ ] Verify training export still uses corrected_class for wrong_class feedback entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)