### PR TITLE
fix: remove CADDY_ADMIN env var causing Caddy restart loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,6 @@ services:
     environment:
       CONFIG_PATH: /config/scarguard.yml
       HTTPS_PORT: ${HTTPS_PORT:-${WEB_HTTPS_PORT:-443}}
-      CADDY_ADMIN: "off"                # Disable admin API (port 2019) — not used
     depends_on:
       - web
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Caddy enters a restart loop because `CADDY_ADMIN=off` in docker-compose.yml is interpreted as a network address, causing Caddy to DNS-resolve the literal string "off" which fails inside Docker
- Removing the env var lets Caddy use its default admin API on `localhost:2019` (not exposed outside the container), which the config watcher's `caddy reload` already depends on

## Test plan
- [ ] `docker compose up caddy` — confirm Caddy starts without restart loop
- [ ] Modify `scarguard.yml` TLS settings — confirm config watcher reloads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)