### PR TITLE
feat: v0.11 — usability fixes, unified retention, and digest reports

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -7,10 +7,9 @@ system:
   armed: true
   log_level: info
   timezone: "UTC"
-  snapshot_retention_days: 30   # days; 0 = keep forever
+  retention_days: 90             # days; applies to snapshots, events, visits, and metrics; 0 = keep forever (1-365)
   stats_interval: 5             # seconds between system stats collection (1-60)
   visit_timeout_seconds: 300    # gap before a visit session is closed (60-3600)
-  metrics_retention_days: 90    # days to keep historical metrics (1-365)
   training_nudge_threshold: 100 # labeled events before showing training nudge banner (10-10000)
   camera_health:
     alert_threshold_minutes: 10 # minutes offline before alerting (1-1440)
@@ -25,6 +24,11 @@ system:
   #   use_solar: false               # true = arm at sunrise, disarm at sunset
   #   latitude: null                 # required when use_solar is true
   #   longitude: null                # required when use_solar is true
+  # summary_report:                  # optional — scheduled digest notifications
+  #   enabled: false                 # toggle digest on/off (default: disabled)
+  #   frequency: daily               # daily | weekly (Mondays) | monthly (1st)
+  #   time: "07:00"                  # HH:MM in system timezone
+  #   channels: []                   # notification channel names to receive the digest
 
 tls:
   mode: "off"                  # "off", "auto" (Let's Encrypt), or "manual" (own certs)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,46 +1,14 @@
 # ScarGuard — Roadmap
 
-Active and planned features. Each item includes acceptance criteria. Completed features (1–17, 18–22, 24–25) are in [ROADMAP_ARCHIVE.md](ROADMAP_ARCHIVE.md).
-
----
-
-## Feature 23: Scheduled Summary Reports
-
-Daily or weekly email digest summarizing detection activity — the "check over coffee" report.
-
-**Acceptance criteria:**
-- Configurable schedule: daily, weekly, or disabled (default: disabled)
-- Config section: `system.summary_report` with `enabled`, `frequency` (daily/weekly), `channels` (list of notification channel names to send the report to — email and/or Discord)
-- Report contents: total detections by class, detections by camera, longest visit duration (if Feature 19 is implemented), camera uptime summary (if Feature 20 is implemented), system health snapshot (avg CPU/GPU usage)
-- Report covers the previous day (daily) or previous 7 days (weekly)
-- For email channels: formatted HTML email with inline summary table
-- For Discord channels: formatted embed message
-- Report generation runs as a scheduled task in the notifier or web service
-- Configurable via web UI Settings
-
----
-
-## Feature 26: Event Record Pruning & Retention
-
-Extend snapshot retention to also prune old detection event records from SQLite. Prevents unbounded DB growth. Coordinate with the training pipeline to protect labeled data.
-
-**Acceptance criteria:**
-- Change default `system.snapshot_retention_days` from 30 to 90 (training dataset collection needs a longer window)
-- New config field: `system.event_retention_days` (default: matches `snapshot_retention_days`)
-- Pruning deletes event records older than retention period from `detection_events` table
-- **Protected events:** Events with feedback labels (`correct`, `false_positive`, `wrong_class`) are NEVER pruned — they are training data. Only unlabeled events are eligible for pruning.
-- Pruning runs on the same daily schedule as snapshot cleanup
-- Visit records (Feature 19) follow the same retention policy
-- Metrics data (Feature 21) has its own independent retention (`metrics_retention_days`)
-- Dashboard or training page shows count of protected (labeled) vs pruneable events
-- `event_retention_days: 0` disables event pruning (keep forever, matching snapshot behavior)
+Active and planned features. Each item includes acceptance criteria. Completed features (1–17, 18–22, 23–26) are in [ROADMAP_ARCHIVE.md](ROADMAP_ARCHIVE.md).
 
 ---
 
 ## Cleanup / Deprecation
 
 - **Remove legacy SSL→TLS migration** (target x.12.x) — `_migrate_ssl_to_tls()` in `main.py` and the legacy `ssl:` fallback in `caddy-entrypoint.sh`. Added in v0.9 to support users upgrading from the old `ssl:` config section. Safe to remove once enough releases have passed.
-- **Remove legacy flat notification keys** (target x.13.x) — `notifications.discord` and `notifications.email` flat config keys. Deprecated in v0.10 with log warnings. Users should migrate to `notifications.channels` named channel format. Code to remove: fallback branch in `build_notifiers()` (notifier `main.py`), `DiscordConfig`/`EmailConfig` models in web `config_model.py`, legacy form sections in `config.html`, legacy write in `routes/config.py`.
+- **Remove legacy flat notification keys** (target x.13.x)
+- **Remove retention_days migration code** (target x.14.x) — auto-rewrite of `snapshot_retention_days`/`metrics_retention_days` → `retention_days` added in v0.11. Safe to remove once enough releases have passed. — `notifications.discord` and `notifications.email` flat config keys. Deprecated in v0.10 with log warnings. Users should migrate to `notifications.channels` named channel format. Code to remove: fallback branch in `build_notifiers()` (notifier `main.py`), `DiscordConfig`/`EmailConfig` models in web `config_model.py`, legacy form sections in `config.html`, legacy write in `routes/config.py`.
 
 ---
 
@@ -54,7 +22,7 @@ Extend snapshot retention to also prune old detection event records from SQLite.
 
 - Twilio SMS notifications — paid per-message, but works on any phone without an app
 - Per-class cooldown — different cooldown values per detected species (e.g. 30s for squirrels, 5min for herons)
-- Mobile-friendly layout — responsive CSS for phone/tablet use; blocked on solving secure external access (reverse proxy, Tailscale, Cloudflare Tunnel)
+- Mobile-friendly layout — basic nav responsiveness added in v0.11 (admin menu touch support, nav wrapping); full responsive CSS for all pages remains a future item
 - UI polish — logo, favicon, login screen branding. Japanese-inspired koi aesthetic. Use AI image generation for assets. Lowest priority.
 - ONVIF camera auto-discovery — scan local network for RTSP cameras instead of manual URL entry. Helps non-UniFi users.
 - Home Assistant MQTT discovery — auto-register ScarGuard as an HA device, beyond generic webhook
@@ -64,3 +32,4 @@ Extend snapshot retention to also prune old detection event records from SQLite.
 - S3/Minio remote config backup — upload config backups to object storage for off-device redundancy
 - Automated Orin runner/self-updates — CI pushes runner updates to Orin via SSH (parked)
 - Isolated benchmark runner — use concurrency groups or dedicated runner labels at release time to ensure CPU inference benchmarks run without competing workloads skewing FPS numbers
+- CI path filtering — skip full CI on docs-only or benchmark-only PRs using `paths-ignore` in workflow triggers. Needs a lightweight "skip" job if CI becomes a required status check.

--- a/ROADMAP_ARCHIVE.md
+++ b/ROADMAP_ARCHIVE.md
@@ -1,6 +1,18 @@
 # ScarGuard — Completed Features Archive
 
-Features 1–17, 18–22, and 24–25 are fully implemented. Moved here from [ROADMAP.md](ROADMAP.md) to keep the active roadmap focused on upcoming work.
+Features 1–17, 18–26 are fully implemented. Moved here from [ROADMAP.md](ROADMAP.md) to keep the active roadmap focused on upcoming work.
+
+---
+
+## Feature 26: Event Record Pruning & Unified Retention — ✓ Complete (v0.11)
+
+Consolidated `snapshot_retention_days` and `metrics_retention_days` into a single `system.retention_days` field (default: 90). The `RetentionCleaner` in the detector service runs a daily cycle that prunes: snapshot files on disk, unlabeled detection events, visit sessions, and system metrics. Labeled events (with feedback) and `_system` events (arm/disarm) are never pruned — training data is always protected. Legacy config keys are auto-migrated on startup (rewrite `scarguard.yml`); migration code removal targeted for x.14.x. Dashboard shows protected vs pruneable event counts.
+
+---
+
+## Feature 23: Scheduled Summary Reports — ✓ Complete (v0.11)
+
+Configurable daily/weekly/monthly digest notifications. Notifier service owns end-to-end: read-only SQLite access for report data, scheduler thread for timing, and per-notifier formatters (Discord embed, HTML email, webhook JSON, ntfy plain text). Digest content: detection summary with period-over-period comparison, visit highlights, performance stoplight (green/yellow/red with hardcoded CPU/GPU/camera thresholds), camera health, storage usage (snapshots/DB/models), and training data stats. Config section: `system.summary_report` with `enabled`, `frequency`, `time`, and `channels`. Configurable via web UI.
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -37,6 +37,9 @@
 - **Config backup & rollback:** Auto-backup on config change with admin UI for listing, diffing, and restoring backups.
 - **On-demand camera snapshot:** Dashboard button to grab a live frame from any camera via Redis request/response pattern, even when disarmed.
 - **CI/CD hardening:** Container-based pytest, Trivy security scanning, VERSION consistency checks, categorized release notes.
+- **Unified data retention:** Single `system.retention_days` config (default 90) drives cleanup of snapshots, events, visits, and metrics. Labeled training data is never pruned. Legacy config keys auto-migrated.
+- **Scheduled digest reports:** Configurable daily/weekly/monthly digest via any notification channel. Includes detection summary, visit highlights, performance stoplight, storage usage, and training data stats. Notifier-owned with read-only DB access.
+- **Mobile-friendly admin menu:** Admin dropdown works on touch devices (Safari). Nav wraps on small screens.
 
 ## Known Issues / Buggy
 
@@ -47,7 +50,7 @@ None currently identified.
 - Custom-trained heron model (have the tooling now, need labeled data)
 - Physical deterrence — planned as companion project "Scar's Revenge" (ESP32 valve controller receiving ScarGuard webhooks)
 
-See [ROADMAP.md](ROADMAP.md) for upcoming features (23, 26) and [ROADMAP_ARCHIVE.md](ROADMAP_ARCHIVE.md) for completed feature history.
+See [ROADMAP.md](ROADMAP.md) for upcoming work and [ROADMAP_ARCHIVE.md](ROADMAP_ARCHIVE.md) for completed feature history (1–26).
 
 ## Completed Work
 

--- a/config/scarguard.example.yml
+++ b/config/scarguard.example.yml
@@ -21,10 +21,11 @@ system:
   # Leave as "UTC" to keep the existing behaviour.
   timezone: "UTC"
 
-  # How many days to keep snapshot images on disk.
-  # The detector deletes snapshots older than this at startup and once per day.
+  # How many days to keep snapshots, events, visits, and metrics.
+  # The detector cleans up at startup and once per day.
+  # Labeled events (training data) are never pruned.
   # Set to 0 to disable automatic cleanup.
-  snapshot_retention_days: 30
+  retention_days: 90
 
   # ── Authentication ────────────────────────────────────────────────────────
   # Gate all web UI routes behind a login page.
@@ -63,6 +64,18 @@ system:
   #   use_solar: false
   #   latitude: 37.7749
   #   longitude: -122.4194
+
+  # ── Summary Reports ──────────────────────────────────────────────────────
+  # Scheduled digest notifications summarizing detection activity, system
+  # health, storage usage, and training data stats.
+  #
+  # summary_report:
+  #   enabled: false                 # disabled by default
+  #   frequency: daily               # daily | weekly (Mondays) | monthly (1st)
+  #   time: "07:00"                  # send time in system timezone (HH:MM)
+  #   channels:                      # notification channel names to receive the digest
+  #     - email-digest
+  #     - pond-alerts
 
 
 # ── Cameras ───────────────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,9 +103,13 @@ services:
     environment:
       CONFIG_PATH: /config/scarguard.yml
       NOTIFIER_STATE_DIR: /var/lib/scarguard
+      DB_PATH: /data/scarguard.db       # read-only — digest reports query events/metrics
+      SNAPSHOT_DIR: /data/snapshots
+      MODELS_DIR: /models
     volumes:
       - scarguard-config:/config:ro
-      - scarguard-data:/data:ro         # ro — reads snapshot files for Discord/email attachments
+      - scarguard-models:/models:ro     # ro — digest reports storage size
+      - scarguard-data:/data:ro         # ro — reads SQLite + snapshots for attachments/digests
       - scarguard-notifier:/var/lib/scarguard
     depends_on:
       redis:

--- a/services/detector/src/cleanup.py
+++ b/services/detector/src/cleanup.py
@@ -1,4 +1,4 @@
-"""Snapshot retention — periodically prune old snapshots and clear DB references."""
+"""Data retention — periodically prune old snapshots, events, visits, and metrics."""
 
 import logging
 import sqlite3
@@ -11,34 +11,36 @@ logger = logging.getLogger(__name__)
 _DAILY_SECONDS = 24 * 3600
 
 
-class SnapshotCleaner:
-    """Deletes snapshot files older than *retention_days* and NULLs their DB rows.
+class RetentionCleaner:
+    """Deletes data older than *retention_days* on a daily cycle.
+
+    Prunes: snapshot files on disk, detection_events (unlabeled only),
+    visit_sessions, and system_metrics rows.  Labeled events (training data)
+    and _system events (arm/disarm audit trail) are never pruned.
 
     Runs once at startup then every 24 hours as a daemon thread.  Setting
-    *retention_days* to 0 or a negative value disables cleanup entirely.
+    *retention_days* to 0 or a negative value disables all cleanup.
     """
 
     def __init__(
         self,
         snapshot_dir: str,
         db_path: str,
-        retention_days: int = 30,
+        retention_days: int = 90,
     ) -> None:
         self._snapshot_dir = Path(snapshot_dir)
         self._db_path = db_path
         self.retention_days = retention_days
         self._stop = threading.Event()
         self._thread = threading.Thread(
-            target=self._loop, name="snapshot-cleanup", daemon=True
+            target=self._loop, name="retention-cleanup", daemon=True
         )
 
     def start(self) -> None:
         self._thread.start()
-        logger.info("Snapshot cleaner started — retention=%d days", self.retention_days)
+        logger.info("Retention cleaner started — retention=%d days", self.retention_days)
 
     def stop(self) -> None:
-        # Signal the loop to exit; no join() because the thread is daemon=True
-        # and main() exits shortly after calling stop().
         self._stop.set()
 
     # ------------------------------------------------------------------
@@ -52,12 +54,18 @@ class SnapshotCleaner:
 
     def _run(self) -> None:
         if self.retention_days <= 0:
-            logger.debug("Snapshot retention disabled (retention_days=%d)", self.retention_days)
+            logger.debug("Data retention disabled (retention_days=%d)", self.retention_days)
             return
 
         cutoff = datetime.now(timezone.utc) - timedelta(days=self.retention_days)
-        logger.info("Snapshot cleanup — cutoff=%s", cutoff.date().isoformat())
+        cutoff_iso = cutoff.isoformat()
+        logger.info("Retention cleanup — cutoff=%s", cutoff.date().isoformat())
 
+        self._prune_snapshots(cutoff)
+        self._prune_db(cutoff_iso)
+
+    def _prune_snapshots(self, cutoff: datetime) -> None:
+        """Delete snapshot files older than cutoff and NULL their DB paths."""
         deleted: list[str] = []
         try:
             for f in self._snapshot_dir.iterdir():
@@ -77,17 +85,12 @@ class SnapshotCleaner:
 
         if deleted:
             self._clear_db_paths(deleted)
-            logger.info("Snapshot cleanup: removed %d file(s)", len(deleted))
+            logger.info("Snapshots pruned: %d file(s)", len(deleted))
         else:
-            logger.info("Snapshot cleanup: nothing to remove")
+            logger.info("Snapshots: nothing to prune")
 
     def _clear_db_paths(self, paths: list[str]) -> None:
-        """Set snapshot_path = NULL for any DB rows whose file was deleted.
-
-        Opens its own short-lived connection.  WAL mode allows concurrent readers
-        and one writer; the timeout=30 handles the rare case where EventProcessor
-        is mid-write when cleanup runs (once daily).
-        """
+        """Set snapshot_path = NULL for any DB rows whose file was deleted."""
         try:
             conn = sqlite3.connect(self._db_path, timeout=30)
             try:
@@ -103,3 +106,50 @@ class SnapshotCleaner:
                 conn.close()
         except Exception:
             logger.warning("Failed to clear snapshot paths in database", exc_info=True)
+
+    def _prune_db(self, cutoff_iso: str) -> None:
+        """Prune old events, visits, and metrics from the database."""
+        try:
+            conn = sqlite3.connect(self._db_path, timeout=30)
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+
+                # Events: only unlabeled, non-system events
+                cur = conn.execute(
+                    "DELETE FROM detection_events"
+                    " WHERE timestamp < ?"
+                    " AND feedback IS NULL"
+                    " AND camera_name != '_system'",
+                    (cutoff_iso,),
+                )
+                events_deleted = cur.rowcount
+
+                # Visit sessions
+                cur = conn.execute(
+                    "DELETE FROM visit_sessions WHERE start_time < ?",
+                    (cutoff_iso,),
+                )
+                visits_deleted = cur.rowcount
+
+                # System metrics
+                cur = conn.execute(
+                    "DELETE FROM system_metrics WHERE timestamp < ?",
+                    (cutoff_iso,),
+                )
+                metrics_deleted = cur.rowcount
+
+                conn.commit()
+
+                if events_deleted or visits_deleted or metrics_deleted:
+                    logger.info(
+                        "DB pruned: %d event(s), %d visit(s), %d metric sample(s)",
+                        events_deleted,
+                        visits_deleted,
+                        metrics_deleted,
+                    )
+                else:
+                    logger.info("DB: nothing to prune")
+            finally:
+                conn.close()
+        except Exception:
+            logger.warning("Failed to prune database records", exc_info=True)

--- a/services/detector/src/main.py
+++ b/services/detector/src/main.py
@@ -24,7 +24,7 @@ from datetime import datetime
 
 import yaml
 from camera_health import CameraHealthTracker
-from cleanup import SnapshotCleaner
+from cleanup import RetentionCleaner
 from config_watcher import ConfigWatcher
 from detector import YOLODetector
 from evaluator import EvaluationRunner
@@ -279,10 +279,11 @@ def main() -> None:
         sys.exit(1)
 
     # ---- Config sections -------------------------------------------------------
+    sys_cfg: dict = cfg.get("system", {})
     det_cfg: dict = cfg.get("detection", {})
     redis_cfg: dict = cfg.get("redis", {})
     # Mutable references so hot-reload can update these without restarting threads.
-    armed_ref: list[bool] = [cfg.get("system", {}).get("armed", True)]
+    armed_ref: list[bool] = [sys_cfg.get("armed", True)]
     frame_skip_ref: list[int] = [det_cfg.get("frame_skip", 2)]
 
     # ---- Model pool ------------------------------------------------------------
@@ -298,8 +299,15 @@ def main() -> None:
         db_path=DB_PATH,
     )
 
-    retention_days = int(cfg.get("system", {}).get("snapshot_retention_days", 30))
-    cleaner = SnapshotCleaner(
+    # Unified retention_days; fall back to legacy snapshot_retention_days for
+    # configs that haven't been migrated yet by the web service.
+    _ret = sys_cfg.get("retention_days")
+    if _ret is None:
+        _ret = sys_cfg.get("snapshot_retention_days")
+    if _ret is None:
+        _ret = 90
+    retention_days = int(_ret)
+    cleaner = RetentionCleaner(
         snapshot_dir=SNAPSHOT_DIR,
         db_path=DB_PATH,
         retention_days=retention_days,
@@ -307,7 +315,7 @@ def main() -> None:
     cleaner.start()
 
     # ---- Camera health tracking ---------------------------------------------------
-    health_cfg = cfg.get("system", {}).get("camera_health", {})
+    health_cfg = sys_cfg.get("camera_health", {})
     health_tracker = CameraHealthTracker(
         alert_threshold_seconds=int(health_cfg.get("alert_threshold_minutes", 10)) * 60,
         debounce_seconds=int(health_cfg.get("debounce_seconds", 30)),
@@ -346,13 +354,11 @@ def main() -> None:
         )
 
     scheduler = ArmScheduler(armed_ref, _on_scheduler_transition, get_redis=_make_redis)
-    sys_cfg = cfg.get("system", {})
     scheduler.configure(sys_cfg.get("schedule", {}), sys_cfg.get("timezone", "UTC"))
     scheduler.start()
 
     # ---- Metrics store -----------------------------------------------------------
-    metrics_retention = int(sys_cfg.get("metrics_retention_days", 90))
-    metrics_store = MetricsStore(db_path=DB_PATH, retention_days=metrics_retention)
+    metrics_store = MetricsStore(db_path=DB_PATH)
 
     # ---- Visit tracker -----------------------------------------------------------
     visit_timeout = int(sys_cfg.get("visit_timeout_seconds", 300))
@@ -496,21 +502,6 @@ def main() -> None:
         target=_visit_flush_loop, name="visit-flush", daemon=True
     )
     visit_flush_thread.start()
-
-    # ---- Metrics prune thread ----------------------------------------------------
-    def _metrics_prune_loop() -> None:
-        while not global_stop.wait(3600):
-            try:
-                deleted = metrics_store.prune()
-                if deleted:
-                    logger.info("Pruned %d old metric samples", deleted)
-            except Exception:
-                logger.exception("Metrics prune error")
-
-    metrics_prune_thread = threading.Thread(
-        target=_metrics_prune_loop, name="metrics-prune", daemon=True
-    )
-    metrics_prune_thread.start()
 
     # ---- Model evaluation runner -----------------------------------------------
     eval_runner = EvaluationRunner(

--- a/services/detector/src/metrics_store.py
+++ b/services/detector/src/metrics_store.py
@@ -6,7 +6,7 @@ import json
 import logging
 import sqlite3
 import threading
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -16,11 +16,12 @@ class MetricsStore:
 
     Opens its own SQLite connection (separate from EventProcessor) so it can
     be called safely from the StatsCollector thread.
+
+    Pruning is handled by RetentionCleaner on the daily retention cycle.
     """
 
-    def __init__(self, db_path: str, retention_days: int = 90) -> None:
+    def __init__(self, db_path: str) -> None:
         self._db_path = db_path
-        self._retention_days = retention_days
         self._lock = threading.Lock()
         self._conn = sqlite3.connect(db_path, check_same_thread=False, timeout=10)
         self._conn.execute("PRAGMA journal_mode=WAL")
@@ -60,14 +61,3 @@ class MetricsStore:
             except Exception:
                 logger.warning("Failed to store metrics sample", exc_info=True)
 
-    def prune(self) -> int:
-        """Delete rows older than retention_days. Returns count deleted."""
-        cutoff = (
-            datetime.now(timezone.utc) - timedelta(days=self._retention_days)
-        ).isoformat()
-        with self._lock:
-            cur = self._conn.execute(
-                "DELETE FROM system_metrics WHERE timestamp < ?", (cutoff,)
-            )
-            self._conn.commit()
-            return cur.rowcount

--- a/services/notifier/src/digest.py
+++ b/services/notifier/src/digest.py
@@ -1,0 +1,324 @@
+"""Digest report generation — assembles summary data for periodic notifications."""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+import digest_db
+
+logger = logging.getLogger(__name__)
+
+# ── Stoplight thresholds (hardcoded) ─────────────────────────────────────────
+
+_CPU_YELLOW = 80.0
+_CPU_RED = 95.0
+_GPU_TEMP_YELLOW = 75.0
+_GPU_TEMP_RED = 85.0
+_CAMERA_OFFLINE_YELLOW = 1  # any offline events = yellow
+_CAMERA_OFFLINE_RED = 10  # sustained outages
+
+
+def _stoplight(cpu: float | None, gpu_temp: float | None, offline_total: int) -> str:
+    """Return overall health status: green, yellow, or red."""
+    status = "green"
+
+    if cpu is not None:
+        if cpu > _CPU_RED:
+            return "red"
+        if cpu > _CPU_YELLOW:
+            status = "yellow"
+
+    if gpu_temp is not None:
+        if gpu_temp > _GPU_TEMP_RED:
+            return "red"
+        if gpu_temp > _GPU_TEMP_YELLOW:
+            status = "yellow"
+
+    if offline_total >= _CAMERA_OFFLINE_RED:
+        return "red"
+    if offline_total >= _CAMERA_OFFLINE_YELLOW:
+        status = "yellow"
+
+    return status
+
+
+def _period_hours(frequency: str) -> int:
+    """Reporting window in hours for the given frequency."""
+    if frequency == "weekly":
+        return 7 * 24
+    if frequency == "monthly":
+        return 30 * 24
+    return 24  # daily
+
+
+def _format_duration(secs: float) -> str:
+    """Format seconds into human-readable duration."""
+    if secs < 60:
+        return f"{secs:.0f}s"
+    if secs < 3600:
+        return f"{secs / 60:.0f}m"
+    hours = int(secs // 3600)
+    mins = int((secs % 3600) // 60)
+    return f"{hours}h {mins}m"
+
+
+def generate(frequency: str) -> dict:
+    """Generate a complete digest report.
+
+    Returns a dict with all sections populated, suitable for formatting
+    by each notifier type.
+    """
+    hours = _period_hours(frequency)
+    since = datetime.now(timezone.utc) - timedelta(hours=hours)
+
+    # ── Detection summary ────────────────────────────────────────────────
+    total = digest_db.total_events(since)
+    by_class = digest_db.count_events_by_class(since)
+    by_camera = digest_db.count_events_by_camera(since)
+
+    # Previous period comparison
+    prev_since = since - timedelta(hours=hours)
+    prev_total = digest_db.total_events(prev_since, until=since)
+    if prev_total > 0:
+        change_pct = round(((total - prev_total) / prev_total) * 100)
+    elif total > 0:
+        change_pct = 100
+    else:
+        change_pct = 0
+
+    # ── Visit highlights ─────────────────────────────────────────────────
+    visit_count = digest_db.total_visits(since)
+    top = digest_db.top_visits(since, limit=3)
+    top_formatted = [
+        {
+            "class": v["class_name"],
+            "camera": v["camera_name"],
+            "duration": _format_duration(v["duration_secs"]),
+            "detections": v["detection_count"],
+        }
+        for v in top
+    ]
+
+    # ── Performance ──────────────────────────────────────────────────────
+    metrics = digest_db.avg_metrics(since)
+    offline = digest_db.camera_offline_count(since)
+    offline_total = sum(offline.values())
+    health_status = _stoplight(metrics["cpu_pct"], metrics["gpu_temp"], offline_total)
+
+    # ── Storage ──────────────────────────────────────────────────────────
+    storage = digest_db.storage_summary()
+
+    # ── Training data ────────────────────────────────────────────────────
+    protected = digest_db.protected_event_count()
+    pruneable = digest_db.pruneable_event_count()
+    feedback = digest_db.feedback_summary(since)
+    fp_count = feedback.get("false_positive", 0)
+    labeled_in_period = sum(v for k, v in feedback.items() if k != "unlabeled")
+    fp_rate = round((fp_count / labeled_in_period) * 100, 1) if labeled_in_period > 0 else None
+
+    report = {
+        "_digest": True,
+        "frequency": frequency,
+        "period_label": f"Last {'24 hours' if frequency == 'daily' else '7 days' if frequency == 'weekly' else '30 days'}",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+
+        "detections": {
+            "total": total,
+            "by_class": by_class,
+            "by_camera": by_camera,
+            "change_pct": change_pct,
+        },
+
+        "visits": {
+            "total": visit_count,
+            "top": top_formatted,
+        },
+
+        "performance": {
+            "status": health_status,
+            "avg_cpu_pct": metrics["cpu_pct"],
+            "avg_gpu_pct": metrics["gpu_pct"],
+            "avg_gpu_temp": metrics["gpu_temp"],
+            "camera_offline_events": offline,
+            "camera_offline_total": offline_total,
+        },
+
+        "storage": storage,
+
+        "training": {
+            "protected_events": protected,
+            "pruneable_events": pruneable,
+            "fp_rate_pct": fp_rate,
+        },
+    }
+
+    logger.info(
+        "Digest generated: %s — %d events, status=%s",
+        frequency, total, health_status,
+    )
+    return report
+
+
+def format_plain_text(report: dict) -> str:
+    """Render digest as plain text (for ntfy and fallback)."""
+    d = report["detections"]
+    p = report["performance"]
+    s = report["storage"]
+    t = report["training"]
+    v = report["visits"]
+
+    lines = [
+        f"ScarGuard Digest — {report['period_label']}",
+        "",
+        f"Health: {'OK' if p['status'] == 'green' else 'WARNING' if p['status'] == 'yellow' else 'CRITICAL'}",
+        "",
+        f"Detections: {d['total']} ({'+' if d['change_pct'] >= 0 else ''}{d['change_pct']}% vs prior period)",
+    ]
+
+    if d["by_class"]:
+        for cls, cnt in d["by_class"].items():
+            lines.append(f"  {cls}: {cnt}")
+
+    lines.append(f"\nVisits: {v['total']}")
+    for vt in v["top"]:
+        lines.append(f"  {vt['class']} on {vt['camera']} — {vt['duration']} ({vt['detections']} detections)")
+
+    lines.append("\nPerformance:")
+    if p["avg_cpu_pct"] is not None:
+        lines.append(f"  CPU: {p['avg_cpu_pct']:.0f}%")
+    if p["avg_gpu_pct"] is not None:
+        lines.append(f"  GPU: {p['avg_gpu_pct']:.0f}%")
+    if p["avg_gpu_temp"] is not None:
+        lines.append(f"  GPU Temp: {p['avg_gpu_temp']:.0f}C")
+    if p["camera_offline_total"] > 0:
+        lines.append(f"  Camera offline events: {p['camera_offline_total']}")
+
+    lines.append(f"\nStorage: {s['total_mb']} MB total")
+    lines.append(f"  Snapshots: {s['snapshots_mb']} MB | DB: {s['database_mb']} MB | Models: {s['models_mb']} MB")
+
+    lines.append(f"\nTraining: {t['protected_events']} labeled (protected) / {t['pruneable_events']} pruneable")
+    if t["fp_rate_pct"] is not None:
+        lines.append(f"  False positive rate: {t['fp_rate_pct']}%")
+
+    return "\n".join(lines)
+
+
+def format_discord_embed(report: dict) -> dict:
+    """Render digest as a Discord embed dict."""
+    d = report["detections"]
+    p = report["performance"]
+    s = report["storage"]
+    t = report["training"]
+    v = report["visits"]
+
+    color = {"green": 0x3ECF8E, "yellow": 0xFFB020, "red": 0xE53E3E}[p["status"]]
+    status_emoji = {"green": "OK", "yellow": "WARNING", "red": "CRITICAL"}[p["status"]]
+
+    # Detection breakdown
+    class_lines = "\n".join(f"**{cls}**: {cnt}" for cls, cnt in d["by_class"].items()) or "None"
+    change = f"{'+' if d['change_pct'] >= 0 else ''}{d['change_pct']}%"
+
+    # Top visits
+    visit_lines = "\n".join(
+        f"{vt['class']} on {vt['camera']} — {vt['duration']}"
+        for vt in v["top"]
+    ) or "None"
+
+    # Performance
+    perf_parts = []
+    if p["avg_cpu_pct"] is not None:
+        perf_parts.append(f"CPU: {p['avg_cpu_pct']:.0f}%")
+    if p["avg_gpu_pct"] is not None:
+        perf_parts.append(f"GPU: {p['avg_gpu_pct']:.0f}%")
+    if p["avg_gpu_temp"] is not None:
+        perf_parts.append(f"Temp: {p['avg_gpu_temp']:.0f}C")
+    perf_text = " | ".join(perf_parts) or "No data"
+
+    fields = [
+        {"name": f"Detections ({change} vs prior)", "value": class_lines, "inline": True},
+        {"name": f"Visits ({v['total']})", "value": visit_lines, "inline": True},
+        {"name": f"Performance ({status_emoji})", "value": perf_text, "inline": False},
+        {
+            "name": "Storage",
+            "value": f"Total: {s['total_mb']} MB (Snap: {s['snapshots_mb']} | DB: {s['database_mb']} | Models: {s['models_mb']})",
+            "inline": False,
+        },
+        {
+            "name": "Training Data",
+            "value": f"{t['protected_events']} labeled / {t['pruneable_events']} pruneable"
+            + (f" | FP rate: {t['fp_rate_pct']}%" if t["fp_rate_pct"] is not None else ""),
+            "inline": False,
+        },
+    ]
+
+    return {
+        "embeds": [{
+            "title": f"ScarGuard Digest — {report['period_label']}",
+            "color": color,
+            "fields": fields,
+            "footer": {"text": f"Generated {report['generated_at'][:19]}Z"},
+        }],
+    }
+
+
+def format_email_html(report: dict) -> str:
+    """Render digest as an HTML email body."""
+    d = report["detections"]
+    p = report["performance"]
+    s = report["storage"]
+    t = report["training"]
+    v = report["visits"]
+
+    status_color = {"green": "#3ECF8E", "yellow": "#FFB020", "red": "#E53E3E"}[p["status"]]
+    status_label = {"green": "OK", "yellow": "WARNING", "red": "CRITICAL"}[p["status"]]
+    change = f"{'+' if d['change_pct'] >= 0 else ''}{d['change_pct']}%"
+
+    class_rows = "".join(
+        f"<tr><td>{cls}</td><td style='text-align:right'>{cnt}</td></tr>"
+        for cls, cnt in d["by_class"].items()
+    ) or "<tr><td colspan='2'>No detections</td></tr>"
+
+    visit_rows = "".join(
+        f"<tr><td>{vt['class']}</td><td>{vt['camera']}</td><td>{vt['duration']}</td></tr>"
+        for vt in v["top"]
+    ) or "<tr><td colspan='3'>No visits</td></tr>"
+
+    return f"""
+    <div style="font-family:sans-serif;max-width:600px;margin:0 auto;color:#e0e0e0;background:#1a1a2e;padding:20px;border-radius:8px;">
+      <h2 style="margin:0 0 4px 0;">ScarGuard Digest</h2>
+      <p style="color:#888;margin:0 0 16px 0;">{report['period_label']}</p>
+
+      <div style="background:{status_color};color:#fff;padding:8px 16px;border-radius:6px;font-weight:bold;margin-bottom:16px;">
+        System Health: {status_label}
+      </div>
+
+      <h3 style="margin:16px 0 8px 0;">Detections: {d['total']} ({change} vs prior)</h3>
+      <table style="width:100%;border-collapse:collapse;">
+        <tr style="border-bottom:1px solid #333;"><th style="text-align:left;padding:4px;">Class</th><th style="text-align:right;padding:4px;">Count</th></tr>
+        {class_rows}
+      </table>
+
+      <h3 style="margin:16px 0 8px 0;">Top Visits ({v['total']} total)</h3>
+      <table style="width:100%;border-collapse:collapse;">
+        <tr style="border-bottom:1px solid #333;"><th style="text-align:left;padding:4px;">Class</th><th style="text-align:left;padding:4px;">Camera</th><th style="text-align:left;padding:4px;">Duration</th></tr>
+        {visit_rows}
+      </table>
+
+      <h3 style="margin:16px 0 8px 0;">Performance</h3>
+      <p style="margin:4px 0;">
+        {'CPU: ' + f"{p['avg_cpu_pct']:.0f}%" if p['avg_cpu_pct'] is not None else ''}
+        {'&nbsp;|&nbsp;GPU: ' + f"{p['avg_gpu_pct']:.0f}%" if p['avg_gpu_pct'] is not None else ''}
+        {'&nbsp;|&nbsp;Temp: ' + f"{p['avg_gpu_temp']:.0f}&deg;C" if p['avg_gpu_temp'] is not None else ''}
+      </p>
+      {f"<p style='color:#FFB020;'>Camera offline events: {p['camera_offline_total']}</p>" if p['camera_offline_total'] > 0 else ''}
+
+      <h3 style="margin:16px 0 8px 0;">Storage</h3>
+      <p style="margin:4px 0;">{s['total_mb']} MB total — Snapshots: {s['snapshots_mb']} MB | DB: {s['database_mb']} MB | Models: {s['models_mb']} MB</p>
+
+      <h3 style="margin:16px 0 8px 0;">Training Data</h3>
+      <p style="margin:4px 0;">{t['protected_events']} labeled (protected) / {t['pruneable_events']} pruneable
+      {f" | FP rate: {t['fp_rate_pct']}%" if t['fp_rate_pct'] is not None else ''}</p>
+
+      <hr style="border:none;border-top:1px solid #333;margin:16px 0;">
+      <p style="color:#666;font-size:0.8em;margin:0;">Generated {report['generated_at'][:19]}Z</p>
+    </div>
+    """

--- a/services/notifier/src/digest_db.py
+++ b/services/notifier/src/digest_db.py
@@ -1,0 +1,209 @@
+"""Read-only SQLite queries for digest report generation."""
+
+import logging
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DB_PATH = os.environ.get("DB_PATH", "/data/scarguard.db")
+SNAPSHOT_DIR = os.environ.get("SNAPSHOT_DIR", "/data/snapshots")
+MODELS_DIR = os.environ.get("MODELS_DIR", "/models")
+
+
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH, timeout=10)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def count_events_by_class(since: datetime) -> dict[str, int]:
+    """Detection counts grouped by class name."""
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT class_name, COUNT(*) as cnt FROM detection_events"
+            " WHERE timestamp >= ? AND camera_name != '_system'"
+            " GROUP BY class_name ORDER BY cnt DESC",
+            (since.isoformat(),),
+        ).fetchall()
+        return {r["class_name"]: r["cnt"] for r in rows}
+    finally:
+        conn.close()
+
+
+def count_events_by_camera(since: datetime) -> dict[str, int]:
+    """Detection counts grouped by camera name."""
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT camera_name, COUNT(*) as cnt FROM detection_events"
+            " WHERE timestamp >= ? AND camera_name != '_system'"
+            " GROUP BY camera_name ORDER BY cnt DESC",
+            (since.isoformat(),),
+        ).fetchall()
+        return {r["camera_name"]: r["cnt"] for r in rows}
+    finally:
+        conn.close()
+
+
+def total_events(since: datetime, until: datetime | None = None) -> int:
+    """Total detection events in period."""
+    conn = _connect()
+    try:
+        if until is not None:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM detection_events"
+                " WHERE timestamp >= ? AND timestamp < ?"
+                " AND camera_name != '_system'",
+                (since.isoformat(), until.isoformat()),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM detection_events"
+                " WHERE timestamp >= ? AND camera_name != '_system'",
+                (since.isoformat(),),
+            ).fetchone()
+        return row[0]
+    finally:
+        conn.close()
+
+
+def top_visits(since: datetime, limit: int = 3) -> list[dict]:
+    """Longest visit sessions in period."""
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT camera_name, class_name, duration_secs, detection_count,"
+            " start_time, end_time"
+            " FROM visit_sessions WHERE start_time >= ?"
+            " ORDER BY duration_secs DESC LIMIT ?",
+            (since.isoformat(), limit),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def total_visits(since: datetime) -> int:
+    """Total visit sessions in period."""
+    conn = _connect()
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM visit_sessions WHERE start_time >= ?",
+            (since.isoformat(),),
+        ).fetchone()
+        return row[0]
+    finally:
+        conn.close()
+
+
+def feedback_summary(since: datetime) -> dict[str, int]:
+    """Feedback label counts: correct, false_positive, wrong_class, unlabeled."""
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT feedback, COUNT(*) as cnt FROM detection_events"
+            " WHERE timestamp >= ? AND camera_name != '_system'"
+            " GROUP BY feedback",
+            (since.isoformat(),),
+        ).fetchall()
+        result: dict[str, int] = {}
+        for r in rows:
+            key = r["feedback"] if r["feedback"] else "unlabeled"
+            result[key] = r["cnt"]
+        return result
+    finally:
+        conn.close()
+
+
+def avg_metrics(since: datetime) -> dict[str, float | None]:
+    """Average CPU%, GPU%, GPU temp over period."""
+    conn = _connect()
+    try:
+        row = conn.execute(
+            "SELECT AVG(cpu_pct) as cpu, AVG(gpu_pct) as gpu,"
+            " AVG(gpu_temp) as temp"
+            " FROM system_metrics WHERE timestamp >= ?",
+            (since.isoformat(),),
+        ).fetchone()
+        return {
+            "cpu_pct": round(row["cpu"], 1) if row["cpu"] is not None else None,
+            "gpu_pct": round(row["gpu"], 1) if row["gpu"] is not None else None,
+            "gpu_temp": round(row["temp"], 1) if row["temp"] is not None else None,
+        }
+    finally:
+        conn.close()
+
+
+def camera_offline_count(since: datetime) -> dict[str, int]:
+    """Count of camera_offline events per camera."""
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT camera_name, COUNT(*) as cnt FROM detection_events"
+            " WHERE timestamp >= ? AND class_name = 'camera_offline'"
+            " GROUP BY camera_name",
+            (since.isoformat(),),
+        ).fetchall()
+        return {r["camera_name"]: r["cnt"] for r in rows}
+    finally:
+        conn.close()
+
+
+def protected_event_count() -> int:
+    """Events with feedback labels (protected from pruning)."""
+    conn = _connect()
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM detection_events WHERE feedback IS NOT NULL"
+        ).fetchone()
+        return row[0]
+    finally:
+        conn.close()
+
+
+def pruneable_event_count() -> int:
+    """Unlabeled, non-system events eligible for pruning."""
+    conn = _connect()
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM detection_events"
+            " WHERE feedback IS NULL AND camera_name != '_system'"
+        ).fetchone()
+        return row[0]
+    finally:
+        conn.close()
+
+
+def dir_size_mb(path: str) -> float:
+    """Total size of directory in MB."""
+    try:
+        total = sum(f.stat().st_size for f in Path(path).rglob("*") if f.is_file())
+        return round(total / (1024 * 1024), 1)
+    except OSError:
+        return 0.0
+
+
+def db_size_mb() -> float:
+    """SQLite database file size in MB."""
+    try:
+        return round(Path(DB_PATH).stat().st_size / (1024 * 1024), 1)
+    except OSError:
+        return 0.0
+
+
+def storage_summary() -> dict[str, float]:
+    """Storage sizes in MB."""
+    snap = dir_size_mb(SNAPSHOT_DIR)
+    db = db_size_mb()
+    models = dir_size_mb(MODELS_DIR)
+    return {
+        "snapshots_mb": snap,
+        "database_mb": db,
+        "models_mb": models,
+        "total_mb": round(snap + db + models, 1),
+    }

--- a/services/notifier/src/digest_scheduler.py
+++ b/services/notifier/src/digest_scheduler.py
@@ -1,0 +1,137 @@
+"""Digest scheduler — fires periodic digest report generation and dispatch."""
+
+import logging
+import threading
+from collections.abc import Callable
+from datetime import date, datetime, time
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+logger = logging.getLogger(__name__)
+
+_CHECK_INTERVAL = 60  # seconds
+
+
+class DigestScheduler:
+    """Daemon thread that triggers digest report generation at the configured time.
+
+    Checks every 60 seconds whether the current time (in the configured timezone)
+    has passed the scheduled time and the digest hasn't been sent today.
+
+    Hot-reloadable: call ``configure()`` with new settings at any time.
+    """
+
+    def __init__(
+        self,
+        dispatch_fn: Callable[..., Any],
+        notifiers: list,
+        notifiers_lock: threading.Lock,
+    ) -> None:
+        self._dispatch_fn = dispatch_fn
+        self._notifiers = notifiers
+        self._notifiers_lock = notifiers_lock
+
+        # Config (set via configure())
+        self._enabled = False
+        self._frequency = "daily"
+        self._time_str = "07:00"
+        self._channels: list[str] = []
+        self._tz_name = "UTC"
+
+        self._last_sent_date: date | None = None
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._loop, name="digest-scheduler", daemon=True
+        )
+
+    def configure(self, report_cfg: dict, tz_name: str = "UTC") -> None:
+        """Update schedule configuration (hot-reloadable)."""
+        with self._lock:
+            self._enabled = bool(report_cfg.get("enabled", False))
+            self._frequency = report_cfg.get("frequency", "daily")
+            self._time_str = report_cfg.get("time", "07:00")
+            self._channels = list(report_cfg.get("channels", []))
+            self._tz_name = tz_name
+
+        if self._enabled:
+            logger.info(
+                "Digest scheduler configured: %s at %s → %s",
+                self._frequency, self._time_str,
+                ", ".join(self._channels) if self._channels else "(all channels)",
+            )
+        else:
+            logger.info("Digest scheduler disabled")
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _loop(self) -> None:
+        while not self._stop.wait(timeout=_CHECK_INTERVAL):
+            self._tick()
+
+    def _tick(self) -> None:
+        with self._lock:
+            if not self._enabled or not self._channels:
+                return
+            frequency = self._frequency
+            time_str = self._time_str
+            channels = list(self._channels)
+            tz_name = self._tz_name
+
+        try:
+            tz = ZoneInfo(tz_name)
+        except (ZoneInfoNotFoundError, KeyError):
+            tz = ZoneInfo("UTC")
+
+        now = datetime.now(tz)
+        today = now.date()
+
+        # Parse scheduled time
+        try:
+            parts = time_str.split(":")
+            scheduled = time(int(parts[0]), int(parts[1]))
+        except (ValueError, IndexError):
+            scheduled = time(7, 0)
+
+        # Already sent today?
+        if self._last_sent_date == today:
+            return
+
+        # Check frequency: daily=every day, weekly=Mondays, monthly=1st
+        if frequency == "weekly" and today.weekday() != 0:
+            return
+        if frequency == "monthly" and today.day != 1:
+            return
+
+        # Has the scheduled time passed?
+        if now.time() < scheduled:
+            return
+
+        # Fire!
+        self._last_sent_date = today
+        self._send_digest(frequency, channels)
+
+    def _send_digest(self, frequency: str, channels: list[str]) -> None:
+        """Generate and dispatch the digest report."""
+        try:
+            import digest
+
+            report = digest.generate(frequency)
+            # Route through the normal dispatch pipeline with channel targeting
+            report["actions_triggered"] = channels
+            report["class_name"] = "digest"
+            report["confidence"] = 1.0
+            report["camera_name"] = "_system"
+            report["timestamp"] = report["generated_at"]
+            report["snapshot_path"] = None
+
+            self._dispatch_fn(
+                report, self._notifiers, self._notifiers_lock, None
+            )
+            logger.info("Digest report dispatched to: %s", ", ".join(channels))
+        except Exception:
+            logger.exception("Failed to generate/dispatch digest report")

--- a/services/notifier/src/digest_scheduler.py
+++ b/services/notifier/src/digest_scheduler.py
@@ -54,12 +54,13 @@ class DigestScheduler:
             self._channels = list(report_cfg.get("channels", []))
             self._tz_name = tz_name
 
-        if self._enabled:
+        if self._enabled and self._channels:
             logger.info(
                 "Digest scheduler configured: %s at %s → %s",
-                self._frequency, self._time_str,
-                ", ".join(self._channels) if self._channels else "(all channels)",
+                self._frequency, self._time_str, ", ".join(self._channels),
             )
+        elif self._enabled:
+            logger.warning("Digest enabled but no channels configured — digest will not send")
         else:
             logger.info("Digest scheduler disabled")
 
@@ -111,12 +112,12 @@ class DigestScheduler:
         if now.time() < scheduled:
             return
 
-        # Fire!
-        self._last_sent_date = today
-        self._send_digest(frequency, channels)
+        # Fire — only mark as sent if dispatch succeeds
+        if self._send_digest(frequency, channels):
+            self._last_sent_date = today
 
-    def _send_digest(self, frequency: str, channels: list[str]) -> None:
-        """Generate and dispatch the digest report."""
+    def _send_digest(self, frequency: str, channels: list[str]) -> bool:
+        """Generate and dispatch the digest report. Returns True on success."""
         try:
             import digest
 
@@ -133,5 +134,7 @@ class DigestScheduler:
                 report, self._notifiers, self._notifiers_lock, None
             )
             logger.info("Digest report dispatched to: %s", ", ".join(channels))
+            return True
         except Exception:
-            logger.exception("Failed to generate/dispatch digest report")
+            logger.exception("Failed to generate/dispatch digest report — will retry next tick")
+            return False

--- a/services/notifier/src/discord.py
+++ b/services/notifier/src/discord.py
@@ -38,6 +38,10 @@ class DiscordNotifier:
         return self._name
 
     def send(self, event: dict) -> None:
+        if event.get("_digest"):
+            self._send_digest(event)
+            return
+
         class_name = event["class_name"]
         confidence = event["confidence"]
         camera_name = event["camera_name"]
@@ -77,3 +81,12 @@ class DiscordNotifier:
             )
             resp.raise_for_status()
             logger.info("Discord notification sent (no snapshot)")
+
+    def _send_digest(self, report: dict) -> None:
+        """Send a digest report as a Discord embed."""
+        from digest import format_discord_embed
+
+        payload = format_discord_embed(report)
+        resp = requests.post(self._webhook_url, json=payload, timeout=15)
+        resp.raise_for_status()
+        logger.info("Discord digest sent")

--- a/services/notifier/src/email_notifier.py
+++ b/services/notifier/src/email_notifier.py
@@ -48,6 +48,10 @@ class EmailNotifier:
             logger.warning("Email notifier: no to_addresses configured, skipping")
             return
 
+        if event.get("_digest"):
+            self._send_digest(event)
+            return
+
         class_name = event["class_name"]
         confidence = event["confidence"]
         camera_name = event["camera_name"]
@@ -95,6 +99,23 @@ class EmailNotifier:
                 if self._smtp_user and self._smtp_pass:
                     server.login(self._smtp_user, self._smtp_pass)
                 server.sendmail(self._smtp_user, self._to_addresses, msg.as_string())
+
+    def _send_digest(self, report: dict) -> None:
+        """Send a digest report as an HTML email."""
+        from digest import format_email_html
+
+        html = format_email_html(report)
+        period = report.get("period_label", "Summary")
+        subject = f"ScarGuard Digest — {period}"
+
+        msg = MIMEMultipart("alternative")
+        msg["From"] = self._smtp_user
+        msg["To"] = ", ".join(self._to_addresses)
+        msg["Subject"] = subject
+        msg.attach(MIMEText(html, "html"))
+
+        self._send_message(msg)
+        logger.info("Email digest sent to %s", self._to_addresses)
 
 
 def _attach_snapshot(

--- a/services/notifier/src/main.py
+++ b/services/notifier/src/main.py
@@ -13,6 +13,7 @@ from typing import Optional
 import redis as redis_lib
 import yaml
 from config_watcher import ConfigWatcher
+from digest_scheduler import DigestScheduler
 from discord import DiscordNotifier
 from email_notifier import EmailNotifier
 from notification_queue import WORKER_INTERVAL, NotificationQueue
@@ -272,6 +273,16 @@ def main() -> None:
     if queue.depth:
         logger.info("Resuming with %d notification(s) pending in retry queue", queue.depth)
 
+    # ---- Digest scheduler --------------------------------------------------------
+    digest_scheduler = DigestScheduler(
+        dispatch_fn=dispatch,
+        notifiers=notifiers,
+        notifiers_lock=notifiers_lock,
+    )
+    report_cfg = cfg.get("system", {}).get("summary_report", {})
+    digest_scheduler.configure(report_cfg, tz_name)
+    digest_scheduler.start()
+
     # Use a mutable flag so the signal handler can stop the blocking listen loop.
     shutdown_flag = [False]
 
@@ -296,6 +307,10 @@ def main() -> None:
         else:
             logger.info("Config reloaded — no notifiers enabled")
 
+        # Update digest scheduler with new config
+        new_report_cfg = new_cfg.get("system", {}).get("summary_report", {})
+        digest_scheduler.configure(new_report_cfg, new_tz)
+
     watcher = ConfigWatcher(CONFIG_PATH, _on_config_change)
     watcher.start()
 
@@ -304,6 +319,7 @@ def main() -> None:
     subscribe_loop(cfg.get("redis", {}), notifiers, notifiers_lock, shutdown_flag, queue)
 
     watcher.stop()
+    digest_scheduler.stop()
     logger.info("Notifier stopped cleanly")
 
 

--- a/services/notifier/src/ntfy.py
+++ b/services/notifier/src/ntfy.py
@@ -42,6 +42,10 @@ class NtfyNotifier:
         return self._name
 
     def send(self, event: dict) -> None:
+        if event.get("_digest"):
+            self._send_digest(event)
+            return
+
         class_name = event["class_name"]
         confidence = event["confidence"]
         camera_name = event["camera_name"]
@@ -71,6 +75,22 @@ class NtfyNotifier:
 
         resp.raise_for_status()
         logger.info("Ntfy [%s] → %s/%s (%d)", self._name, self._server, self._topic, resp.status_code)
+
+    def _send_digest(self, report: dict) -> None:
+        """Send condensed digest via ntfy."""
+        from digest import format_plain_text
+
+        text = format_plain_text(report)
+        url = f"{self._server}/{self._topic}"
+        headers: dict[str, str] = {
+            "Title": f"ScarGuard Digest — {report.get('period_label', 'Summary')}",
+            "Priority": "3",
+            "Tags": "chart_with_upwards_trend",
+        }
+        self._add_auth_headers(headers)
+        resp = requests.post(url, data=text.encode(), headers=headers, timeout=15)
+        resp.raise_for_status()
+        logger.info("Ntfy [%s] digest sent", self._name)
 
     def _add_auth_headers(self, headers: dict[str, str]) -> None:
         """Add authentication headers if credentials are configured."""

--- a/services/notifier/src/webhook.py
+++ b/services/notifier/src/webhook.py
@@ -40,6 +40,10 @@ class WebhookNotifier:
         return self._name
 
     def send(self, event: dict) -> None:
+        if event.get("_digest"):
+            self._send_digest(event)
+            return
+
         snap = event.get("snapshot_path")
         payload = {
             "timestamp": event.get("timestamp"),
@@ -62,3 +66,23 @@ class WebhookNotifier:
             "Webhook [%s] %s %s → %d",
             self._name, self._method, self._url, resp.status_code,
         )
+
+    def _send_digest(self, report: dict) -> None:
+        """Send digest report as structured JSON."""
+        payload = {
+            "type": "digest",
+            "frequency": report.get("frequency"),
+            "period": report.get("period_label"),
+            "generated_at": report.get("generated_at"),
+            "detections": report.get("detections"),
+            "visits": report.get("visits"),
+            "performance": report.get("performance"),
+            "storage": report.get("storage"),
+            "training": report.get("training"),
+        }
+        resp = requests.request(
+            self._method, self._url, json=payload,
+            headers=self._headers, timeout=15,
+        )
+        resp.raise_for_status()
+        logger.info("Webhook [%s] digest sent → %d", self._name, resp.status_code)

--- a/services/web/src/config_model.py
+++ b/services/web/src/config_model.py
@@ -104,25 +104,46 @@ class BackupConfig(BaseModel):
         return v
 
 
+class SummaryReportConfig(BaseModel):
+    enabled: bool = False
+    frequency: Literal["daily", "weekly", "monthly"] = "daily"
+    time: str = "07:00"
+    channels: list[str] = []
+
+    @field_validator("time")
+    @classmethod
+    def valid_time_format(cls, v: str) -> str:
+        if not v:
+            return "07:00"
+        parts = v.strip().split(":")
+        try:
+            h, m = int(parts[0]), int(parts[1])
+        except (ValueError, IndexError):
+            raise ValueError(f"Time must be in HH:MM format, got {v!r}")
+        if not (0 <= h <= 23 and 0 <= m <= 59):
+            raise ValueError(f"Invalid time {v!r}")
+        return f"{h:02d}:{m:02d}"
+
+
 class SystemConfig(BaseModel):
     armed: bool = True
     log_level: str = "info"
     timezone: str = "UTC"
-    snapshot_retention_days: int = 30
+    retention_days: int = 90
     stats_interval: int = 5
     visit_timeout_seconds: int = 300
     training_nudge_threshold: int = 100
-    metrics_retention_days: int = 90
     schedule: ScheduleConfig = ScheduleConfig()
     auth: AuthConfig = AuthConfig()
     camera_health: CameraHealthConfig = CameraHealthConfig()
     backup: BackupConfig = BackupConfig()
+    summary_report: SummaryReportConfig = SummaryReportConfig()
 
-    @field_validator("metrics_retention_days")
+    @field_validator("retention_days")
     @classmethod
-    def metrics_retention_range(cls, v: int) -> int:
-        if not 1 <= v <= 365:
-            raise ValueError("metrics_retention_days must be between 1 and 365")
+    def retention_days_range(cls, v: int) -> int:
+        if v != 0 and not 1 <= v <= 365:
+            raise ValueError("retention_days must be 0 (disabled) or between 1 and 365")
         return v
 
     @field_validator("visit_timeout_seconds")

--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -258,6 +258,26 @@ def get_feedback_stats(
 
 # ── Export ──────────────────────────────────────────────────────────────────
 
+def count_protected_events() -> int:
+    """Count events with feedback labels (protected from pruning)."""
+    conn = _connect()
+    row = conn.execute(
+        "SELECT COUNT(*) FROM detection_events"
+        " WHERE feedback IS NOT NULL"
+    ).fetchone()
+    return row[0]
+
+
+def count_pruneable_events() -> int:
+    """Count unlabeled, non-system events eligible for pruning."""
+    conn = _connect()
+    row = conn.execute(
+        "SELECT COUNT(*) FROM detection_events"
+        " WHERE feedback IS NULL AND camera_name != '_system'"
+    ).fetchone()
+    return row[0]
+
+
 _EXPORTABLE_WHERE = (
     "camera_name != '_system'"
     " AND feedback IN ('correct', 'wrong_class')"

--- a/services/web/src/main.py
+++ b/services/web/src/main.py
@@ -45,6 +45,7 @@ async def _startup() -> None:
     auth_module.AUTH_DB_PATH = AUTH_DB_PATH
     auth_module.init_db(AUTH_DB_PATH)
     _migrate_ssl_to_tls()
+    _migrate_retention_fields()
     backup_manager = ConfigBackupManager()
     backup_manager.start()
 
@@ -79,6 +80,62 @@ def _migrate_ssl_to_tls() -> None:
         )
     except Exception as exc:
         log.warning("SSL→TLS migration skipped: %s", exc)
+
+
+def _migrate_retention_fields() -> None:
+    """One-time migration: consolidate legacy snapshot_retention_days and
+    metrics_retention_days into a single retention_days field.
+
+    TODO: Remove this migration once enough releases have passed (target x.14.x).
+    """
+    import logging
+
+    import config_store
+    log = logging.getLogger("startup")
+    try:
+        cfg = config_store.load()
+        sys_cfg = cfg.get("system", {})
+        if not isinstance(sys_cfg, dict):
+            return
+
+        old_snap = sys_cfg.get("snapshot_retention_days")
+        old_metrics = sys_cfg.get("metrics_retention_days")
+        has_new = "retention_days" in sys_cfg
+
+        if old_snap is None and old_metrics is None:
+            return  # Nothing to migrate
+
+        if has_new:
+            # New key already present; just clean up old keys
+            changed = False
+            if old_snap is not None:
+                del sys_cfg["snapshot_retention_days"]
+                changed = True
+            if old_metrics is not None:
+                del sys_cfg["metrics_retention_days"]
+                changed = True
+            if changed:
+                config_store.save(cfg)
+                log.info("Removed legacy retention keys (retention_days already set)")
+            return
+
+        # Derive new value: take the larger of the two old values
+        values = [int(v) for v in (old_snap, old_metrics) if v is not None]
+        retention_days = max(values)
+
+        sys_cfg["retention_days"] = retention_days
+        if old_snap is not None:
+            del sys_cfg["snapshot_retention_days"]
+        if old_metrics is not None:
+            del sys_cfg["metrics_retention_days"]
+
+        config_store.save(cfg)
+        log.info(
+            "Migrated snapshot_retention_days/metrics_retention_days → retention_days: %d",
+            retention_days,
+        )
+    except Exception as exc:
+        log.warning("Retention fields migration skipped: %s", exc)
 
 
 # ── Auth middleware ────────────────────────────────────────────────────────────

--- a/services/web/src/routes/config.py
+++ b/services/web/src/routes/config.py
@@ -170,7 +170,7 @@ async def save_structured_config(request: Request) -> JSONResponse:
     if not isinstance(existing_system, dict):
         existing_system = {}
     system_dump = payload.system.model_dump(exclude_unset=True)
-    for nested_key in ("schedule", "auth"):
+    for nested_key in ("schedule", "auth", "summary_report", "backup"):
         if nested_key in system_dump:
             existing_nested = existing_system.get(nested_key, {})
             if not isinstance(existing_nested, dict):

--- a/services/web/src/static/config.js
+++ b/services/web/src/static/config.js
@@ -232,14 +232,17 @@ function readForm() {
       armed: document.getElementById("sys-armed").checked,
       log_level: document.getElementById("sys-log-level").value,
       timezone: document.getElementById("sys-timezone").value.trim(),
-      snapshot_retention_days: (v => isNaN(v) ? 30 : v)(parseInt(document.getElementById("sys-retention").value, 10)),
+      retention_days: (v => isNaN(v) ? 90 : v)(parseInt(document.getElementById("sys-retention").value, 10)),
       stats_interval: (v => isNaN(v) || v < 1 ? 5 : Math.min(v, 60))(parseInt(document.getElementById("sys-stats-interval").value, 10)),
       visit_timeout_seconds: parseInt(document.getElementById('visit_timeout_seconds')?.value || '300'),
       training_nudge_threshold: parseInt(document.getElementById('training_nudge_threshold')?.value || '100'),
-      metrics_retention_days: parseInt(document.getElementById('metrics_retention_days')?.value || '90'),
       camera_health: {
         alert_threshold_minutes: parseInt(document.getElementById('camera_health_alert_threshold_minutes')?.value || '10'),
         debounce_seconds: parseInt(document.getElementById('camera_health_debounce_seconds')?.value || '30'),
+      },
+      backup: {
+        max_backups: parseInt(document.getElementById('backup_max_backups')?.value || '50'),
+        debounce_seconds: parseInt(document.getElementById('backup_debounce_seconds')?.value || '180'),
       },
       schedule,
       auth: {
@@ -249,6 +252,13 @@ function readForm() {
         lockout_duration_minutes: parseInt(document.getElementById("auth-lockout-minutes").value, 10) || 15,
         require_api_auth: document.getElementById("auth-require-api").checked,
         nonadmin_rearm_minutes: parseInt(document.getElementById("auth-rearm-minutes").value, 10) || 0,
+      },
+      summary_report: {
+        enabled: document.getElementById("summary-report-enabled").checked,
+        frequency: document.getElementById("summary-report-frequency").value,
+        time: document.getElementById("summary-report-time").value.trim() || "07:00",
+        channels: (document.getElementById("summary-report-channels").value || "")
+          .split(",").map(s => s.trim()).filter(Boolean),
       },
     },
     cameras: readCameras(),

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -57,6 +57,10 @@ nav a:hover { color: var(--text); text-decoration: none; }
   font-size: 0.9rem;
   cursor: pointer;
   user-select: none;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
 }
 .nav-dropdown__toggle:hover { color: var(--text); }
 .nav-dropdown__menu {
@@ -76,7 +80,8 @@ nav a:hover { color: var(--text); text-decoration: none; }
   padding: 0.35rem 0;
   box-shadow: 0 6px 18px rgba(0,0,0,0.45);
 }
-.nav-dropdown:hover .nav-dropdown__menu { display: block; }
+.nav-dropdown:hover .nav-dropdown__menu,
+.nav-dropdown.open .nav-dropdown__menu { display: block; }
 .nav-dropdown__menu-inner a {
   display: block;
   padding: 0.4rem 1rem;
@@ -93,6 +98,17 @@ nav a:hover { color: var(--text); text-decoration: none; }
   height: 1px;
   background: var(--border);
   margin: 0.3rem 0;
+}
+
+/* ── Mobile nav ──────────────────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  nav {
+    flex-wrap: wrap;
+    gap: 0.6rem 1rem;
+    padding: 0.5rem 1rem;
+  }
+  nav a, .nav-dropdown__toggle { font-size: 0.82rem; }
+  .nav-dropdown__toggle { min-height: 44px; min-width: 44px; }
 }
 
 /* ── Main layout ──────────────────────────────────────────────────────────── */

--- a/services/web/src/templates/base.html
+++ b/services/web/src/templates/base.html
@@ -21,7 +21,7 @@
     <a href="/feed">Live Feed</a>
     {% if request.state.user and request.state.user.is_admin %}
     <div class="nav-dropdown">
-      <span class="nav-dropdown__toggle">Admin &#9660;</span>
+      <button class="nav-dropdown__toggle" aria-expanded="false">Admin &#9660;</button>
       <div class="nav-dropdown__menu">
         <div class="nav-dropdown__menu-inner">
           <a href="/config">Config</a>
@@ -50,5 +50,21 @@
   <main>
     {% block content %}{% endblock %}
   </main>
+  <script>
+  (function(){
+    var dd = document.querySelector('.nav-dropdown');
+    if (!dd) return;
+    var btn = dd.querySelector('.nav-dropdown__toggle');
+    btn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      var open = dd.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open);
+    });
+    document.addEventListener('click', function() {
+      dd.classList.remove('open');
+      btn.setAttribute('aria-expanded', 'false');
+    });
+  })();
+  </script>
 </body>
 </html>

--- a/services/web/src/templates/config.html
+++ b/services/web/src/templates/config.html
@@ -48,9 +48,10 @@
             </datalist>
           </div>
           <div class="field-group">
-            <label>Snapshot retention (days, 0 = keep forever)</label>
-            <input type="number" id="sys-retention" value="{{ cfg.system.snapshot_retention_days }}"
-                   min="0" max="3650">
+            <label>Data retention (days, 0 = keep forever)</label>
+            <input type="number" id="sys-retention" value="{{ cfg.system.retention_days | default(90) }}"
+                   min="0" max="365">
+            <p class="hint">Applies to snapshots, events, visits, and metrics</p>
           </div>
         </div>
         <div class="field-row">
@@ -74,12 +75,6 @@
         </div>
         <div class="field-row">
           <div class="field-group">
-            <label>Metrics retention (days)</label>
-            <input type="number" id="metrics_retention_days" min="1" max="365"
-                   value="{{ cfg.system.metrics_retention_days | default(90) }}">
-            <p class="hint">How long to keep historical metrics data (1-365 days)</p>
-          </div>
-          <div class="field-group">
             <label>Camera offline alert threshold (minutes)</label>
             <input type="number" id="camera_health_alert_threshold_minutes" min="1" max="1440"
                    value="{{ cfg.system.camera_health.alert_threshold_minutes | default(10) }}">
@@ -88,6 +83,62 @@
             <label>Camera health debounce (seconds)</label>
             <input type="number" id="camera_health_debounce_seconds" min="5" max="300"
                    value="{{ cfg.system.camera_health.debounce_seconds | default(30) }}">
+          </div>
+        </div>
+        <div class="field-row">
+          <div class="field-group">
+            <label>Config backup limit</label>
+            <input type="number" id="backup_max_backups" min="5" max="500"
+                   value="{{ cfg.system.backup.max_backups | default(50) }}">
+            <p class="hint">Maximum number of config backups to keep (5-500)</p>
+          </div>
+          <div class="field-group">
+            <label>Backup debounce (seconds)</label>
+            <input type="number" id="backup_debounce_seconds" min="30" max="600"
+                   value="{{ cfg.system.backup.debounce_seconds | default(180) }}">
+            <p class="hint">Delay after config save before taking backup — prevents rapid-fire backups during editing (30-600)</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {# ── Summary Reports ──────────────────────────────────────────────────────── #}
+  <div class="config-section" id="section-summary-report">
+    <div class="config-section-header" onclick="toggleSection('section-summary-report')">
+      <span class="config-section-label">Summary Reports</span>
+      <span class="config-section-chevron">▾</span>
+    </div>
+    <div class="config-section-body">
+      <div class="card">
+        <div class="field-row">
+          <div class="field-group">
+            <label><input type="checkbox" id="summary-report-enabled"
+              {% if cfg.system.summary_report.enabled %}checked{% endif %}> Enable scheduled digest</label>
+          </div>
+        </div>
+        <div class="field-row">
+          <div class="field-group">
+            <label>Frequency</label>
+            <select id="summary-report-frequency">
+              <option value="daily" {% if cfg.system.summary_report.frequency == 'daily' %}selected{% endif %}>Daily</option>
+              <option value="weekly" {% if cfg.system.summary_report.frequency == 'weekly' %}selected{% endif %}>Weekly (Mondays)</option>
+              <option value="monthly" {% if cfg.system.summary_report.frequency == 'monthly' %}selected{% endif %}>Monthly (1st)</option>
+            </select>
+          </div>
+          <div class="field-group">
+            <label>Send at (HH:MM)</label>
+            <input type="text" id="summary-report-time" value="{{ cfg.system.summary_report.time | default('07:00') }}"
+                   placeholder="07:00" maxlength="5">
+          </div>
+        </div>
+        <div class="field-row">
+          <div class="field-group" style="flex:1;">
+            <label>Channels (comma-separated names)</label>
+            <input type="text" id="summary-report-channels"
+                   value="{{ cfg.system.summary_report.channels | join(', ') }}"
+                   placeholder="e.g. pond-alerts, email-digest">
+            <p class="hint">Names of notification channels to receive the digest</p>
           </div>
         </div>
       </div>

--- a/services/web/src/templates/stats.html
+++ b/services/web/src/templates/stats.html
@@ -159,7 +159,7 @@
 }
 @media (max-width: 640px) { .chart-row { grid-template-columns: 1fr; } }
 
-.chart-container { position: relative; }
+.chart-container { position: relative; height: 180px; }
 .chart-label {
   font-size: 0.75rem;
   color: var(--muted);


### PR DESCRIPTION
## Summary

- **Bug: Mobile admin menu** — CSS hover-only dropdown replaced with JS click toggle + `<button>` element + mobile nav breakpoint (flex-wrap at 600px, 44px touch targets)
- **Bug: Stats chart overflow** — fixed `.chart-container` height to 180px, constraining Chart.js canvas expansion
- **Feature 26: Unified data retention** — consolidated `snapshot_retention_days` + `metrics_retention_days` into single `system.retention_days` (default 90). `RetentionCleaner` prunes snapshots, events, visits, and metrics in one daily cycle. Labeled events always protected. Auto-migration rewrites `scarguard.yml` on startup. Backup config (max_backups, debounce) now exposed in UI.
- **Feature 23: Scheduled digest reports** — notifier-owned with read-only SQLite access. Daily/weekly/monthly digest with detection summary, visit highlights, performance stoplight (green/yellow/red), camera health, storage usage, and training data stats. Per-notifier formatters: Discord embed, HTML email, webhook JSON, ntfy text. Config UI section added.

Completes the active roadmap (Features 1–26). Cleanup/deprecation and hardening items remain.

## Files changed (26 files, +1112 / -121)

| Area | Files |
|------|-------|
| Bug fixes | `base.html`, `style.css`, `stats.html` |
| Retention | `cleanup.py`, `main.py` (detector), `metrics_store.py`, `config_model.py`, `db.py`, `main.py` (web), `config.html`, `config.js` |
| Digest | `digest.py`, `digest_db.py`, `digest_scheduler.py` (new), `discord.py`, `email_notifier.py`, `webhook.py`, `ntfy.py`, `main.py` (notifier), `docker-compose.yml` |
| Config | `config_model.py`, `config.html`, `config.js`, `routes/config.py` |
| Docs | `CONFIG_REFERENCE.md`, `ROADMAP.md`, `ROADMAP_ARCHIVE.md`, `STATUS.md`, `scarguard.example.yml` |

## Test plan

- [ ] Desktop browser: admin menu hover still works, click also works, click outside closes
- [ ] Mobile Safari (or responsive mode): tap opens admin menu, tap outside closes, items tappable, nav wraps on narrow screen
- [ ] Stats page: historical charts render at fixed height, don't expand after data loads
- [ ] Set `retention_days: 1`, verify daily cycle prunes snapshots, events, visits, and metrics
- [ ] Verify labeled events (with feedback) are never pruned
- [ ] Test config with legacy `snapshot_retention_days` / `metrics_retention_days` keys — verify auto-migration rewrites to `retention_days`
- [ ] Verify `retention_days: 0` disables all cleanup
- [ ] Configure `system.summary_report` with a test channel, set time to near-future, verify digest arrives
- [ ] Test digest on each notification type (Discord, email, webhook, ntfy)
- [ ] Verify config reload updates digest schedule without restart
- [ ] Verify backup config fields (max_backups, debounce) appear in UI and save correctly
- [ ] `ruff check` + `mypy` pass on all services ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)