### PR TITLE
fix: redirect ultralytics runs dir to /tmp for non-root containers

### DIFF
--- a/services/detector/src/detector.py
+++ b/services/detector/src/detector.py
@@ -58,6 +58,7 @@ class YOLODetector:
                 conf=self.confidence_threshold,
                 verbose=False,
                 save=False,
+                project="/tmp/runs",
             )
 
         classes = target_classes if target_classes is not None else self.target_classes

--- a/services/detector/src/evaluator.py
+++ b/services/detector/src/evaluator.py
@@ -240,7 +240,7 @@ class EvaluationRunner:
                 continue
 
             try:
-                results = model.predict(frame, conf=0.1, verbose=False, save=False)
+                results = model.predict(frame, conf=0.1, verbose=False, save=False, project="/tmp/runs")
             except Exception:
                 logger.exception("Inference failed for snapshot %s", gt["resolved_path"])
                 all_predictions.append([])


### PR DESCRIPTION
## Summary
- `save=False` (from PR #79) prevents writing result files, but Ultralytics still creates `runs/detect/predict/` unconditionally in the predictor constructor via `get_save_dir()` → `increment_path(..., mkdir=True)`
- Since `/app` is owned by root and `scarguard` runs as non-root, the `mkdir` fails with `PermissionError`
- Adding `project="/tmp/runs"` redirects directory creation to `/tmp` which is world-writable

Closes #77

## Test plan
- [ ] Rebuild detector image on Jetson
- [ ] Confirm no `PermissionError: 'runs'` in detector logs
- [ ] Confirm detections work normally on all camera threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)