### PR TITLE
harden: v0.12.3 — base image pins, CI alignment, runtime robustness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,6 +253,7 @@ jobs:
 
       # Uses docker create + cp instead of bind mounts — see comment on Jetson job.
       - name: Inference benchmark (CPU)
+        if: github.event_name != 'push'
         run: |
           cid=$(docker create --user root --entrypoint "" scarguard-detector-x86:build-validate python3 /ci/smoke_inference.py)
           docker cp ${{ github.workspace }}/tests/ci/. "$cid:/ci/"
@@ -262,6 +263,7 @@ jobs:
           exit $rc
 
       - name: Trivy scan — detector-x86
+        if: github.event_name != 'push'
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: scarguard-detector-x86:build-validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: pip
 
       - name: Install ruff
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: pip
 
       - name: Install deps
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: pip
 
       - name: Install deps
@@ -97,7 +97,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: pip
 
       - name: Install deps

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,7 +1,11 @@
 name: Runner Cleanup
 
 # Prunes stale Docker images, stopped containers, and unused build cache
-# on both runner types to prevent disk exhaustion over time.
+# on all runners to prevent disk exhaustion over time.
+#
+# Each x86 job targets a specific runner via its unique label so that all
+# three machines are guaranteed to be pruned (the previous matrix approach
+# could schedule multiple legs on the same runner).
 #
 # Runs weekly automatically, or trigger manually via workflow_dispatch.
 # Note: does NOT prune volumes on the Orin to preserve model weights.
@@ -14,16 +18,33 @@ on:
 jobs:
 
   # ── x86 runner cleanup ─────────────────────────────────────────────────────
-  # Matrix with max-parallel:1 ensures each job is assigned to a different
-  # idle runner.  There are 3 docker-labeled runners: runner-docker,
-  # runner-terraform, runner-packer.
-  cleanup-x86:
-    name: Cleanup x86 runner (${{ matrix.runner-index }}/3)
+  # Three separate jobs pinned by unique labels.  runner-terraform and
+  # runner-packer each have a label no other runner shares.  runner-docker
+  # uses [self-hosted, linux, docker] which matches all three, but the other
+  # two are occupied by their pinned jobs so it lands on runner-docker.
+  cleanup-docker:
+    name: Cleanup runner-docker
     runs-on: [self-hosted, linux, docker]
-    strategy:
-      max-parallel: 1
-      matrix:
-        runner-index: [1, 2, 3]
+    steps:
+      - name: Docker system prune
+        run: docker system prune -f --volumes
+
+      - name: Prune build cache older than 7 days
+        run: docker builder prune -f --keep-storage 5GB
+
+  cleanup-terraform:
+    name: Cleanup runner-terraform
+    runs-on: [self-hosted, linux, terraform]
+    steps:
+      - name: Docker system prune
+        run: docker system prune -f --volumes
+
+      - name: Prune build cache older than 7 days
+        run: docker builder prune -f --keep-storage 5GB
+
+  cleanup-packer:
+    name: Cleanup runner-packer
+    runs-on: [self-hosted, linux, packer]
     steps:
       - name: Docker system prune
         run: docker system prune -f --volumes

--- a/infra/orin-runner/Dockerfile
+++ b/infra/orin-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:eb29ed27b0821dca09c2e28b39135e185fc1302036427d5f4d70a41ce8fd7659
 # Note: Using 22.04 to match JetPack 6.x userspace (Ubuntu 22.04 Jammy)
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/services/caddy/Dockerfile
+++ b/services/caddy/Dockerfile
@@ -1,6 +1,6 @@
 # Caddy reverse proxy with Python for config parsing.
 # Reads tls settings from scarguard.yml and generates a Caddyfile.
-FROM caddy:2-alpine
+FROM caddy:2-alpine@sha256:fce4f15aad23222c0ac78a1220adf63bae7b94355d5ea28eee53910624acedfa
 
 RUN apk add --no-cache python3 py3-yaml
 

--- a/services/detector/Dockerfile
+++ b/services/detector/Dockerfile
@@ -1,6 +1,6 @@
 # Build context: repo root
 # docker build -f services/detector/Dockerfile -t scarguard-detector .
-FROM dustynv/l4t-pytorch:r36.4.0
+FROM dustynv/l4t-pytorch:r36.4.0@sha256:a05c85def9139c21014546451d3baab44052d7cabe854d937f163390bfd5201b
 
 # GStreamer + OpenGL deps required by OpenCV RTSP support on L4T
 # nvidia-l4t-tools provides tegrastats for Jetson GPU stats (aarch64 only).

--- a/services/detector/Dockerfile.x86
+++ b/services/detector/Dockerfile.x86
@@ -3,6 +3,8 @@
 #
 # x86/CUDA detector image.  Uses GPU when NVIDIA runtime is available,
 # falls back to CPU inference when it is not.
+# Not digest-pinned: Docker does not support @sha256 with ARG interpolation.
+# Pin is handled by the tag version; override requires explicit tag.
 ARG PYTORCH_TAG=2.6.0-cuda12.4-cudnn9-runtime
 FROM pytorch/pytorch:${PYTORCH_TAG}
 

--- a/services/detector/src/main.py
+++ b/services/detector/src/main.py
@@ -184,6 +184,15 @@ def run_camera(
     _infer_window_start = time.monotonic()
 
     while not stop_event.is_set():
+        frame_count += 1
+        if frame_count % frame_skip_ref[0] != 0:
+            # Advance stream without decoding — saves CPU/GPU on skipped frames
+            if not stream.grab():
+                if health_tracker is not None:
+                    health_tracker.record_failure(name)
+                stop_event.wait(1.0)
+            continue
+
         ret, frame = stream.read()
         if not ret:
             if health_tracker is not None:
@@ -199,10 +208,6 @@ def run_camera(
 
         if health_tracker is not None:
             health_tracker.record_frame(name)
-
-        frame_count += 1
-        if frame_count % frame_skip_ref[0] != 0:
-            continue
 
         if not armed_ref[0]:
             continue

--- a/services/detector/src/model_pool.py
+++ b/services/detector/src/model_pool.py
@@ -17,6 +17,16 @@ from detector import YOLODetector
 logger = logging.getLogger(__name__)
 
 
+def _clear_gpu_cache() -> None:
+    """Release cached GPU memory after model deletion."""
+    try:
+        import torch
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except ImportError:
+        pass
+
+
 class ModelPool:
     """Lazy-loading, ref-counted pool of YOLO detectors."""
 
@@ -69,6 +79,7 @@ class ModelPool:
             if self._refcounts[path] <= 0:
                 del self._models[path]
                 del self._refcounts[path]
+                _clear_gpu_cache()
                 logger.info("ModelPool: unloaded %s (no cameras using it)", path)
 
     def update_defaults(

--- a/services/detector/src/publisher.py
+++ b/services/detector/src/publisher.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections import deque
 
 import redis as redis_lib
 
@@ -9,14 +10,32 @@ logger = logging.getLogger(__name__)
 
 CHANNEL = "scarguard:detections"
 
+# Maximum events to buffer during Redis outages.  Real-time detection
+# events have diminishing value when stale, so a modest bound is fine.
+_BUFFER_MAX = 256
+
 
 class RedisPublisher:
     def __init__(self, host: str, port: int) -> None:
         self._client = redis_lib.Redis(host=host, port=port, decode_responses=True)
+        self._buffer: deque[str] = deque(maxlen=_BUFFER_MAX)
 
     def publish(self, event: dict) -> None:
+        payload = json.dumps(event, default=str)
         try:
-            self._client.publish(CHANNEL, json.dumps(event, default=str))
+            self._flush_buffer()
+            self._client.publish(CHANNEL, payload)
             logger.debug("Published %s event to %s", event.get("class_name"), CHANNEL)
         except redis_lib.RedisError:
-            logger.exception("Failed to publish event to Redis")
+            self._buffer.append(payload)
+            logger.warning(
+                "Redis publish failed — buffered (%d/%d)",
+                len(self._buffer),
+                _BUFFER_MAX,
+            )
+
+    def _flush_buffer(self) -> None:
+        """Re-publish buffered events in FIFO order. Stop on first failure."""
+        while self._buffer:
+            self._client.publish(CHANNEL, self._buffer[0])
+            self._buffer.popleft()

--- a/services/detector/src/stream.py
+++ b/services/detector/src/stream.py
@@ -114,6 +114,27 @@ class RTSPStream:
 
         return True, frame
 
+    def grab(self) -> bool:
+        """Advance the stream by one frame without decoding.
+
+        Returns True on success.  On failure, releases the capture so the
+        next call to :meth:`read` or :meth:`grab` triggers a reconnect.
+        """
+        if self._stop_event.is_set():
+            return False
+        if self._cap is None or not self._cap.isOpened():
+            if not self._reconnect():
+                return False
+
+        ret = self._cap.grab()
+        if not ret:
+            logger.warning("[%s] Grab failed — stream dropped", self.name)
+            self._cap.release()
+            self._cap = None
+            return False
+
+        return True
+
     def release(self) -> None:
         if self._cap is not None:
             self._cap.release()

--- a/services/notifier/Dockerfile
+++ b/services/notifier/Dockerfile
@@ -1,6 +1,6 @@
 # Build context: repo root
 # docker build -f services/notifier/Dockerfile -t scarguard-notifier .
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
 
 WORKDIR /app
 

--- a/services/notifier/src/main.py
+++ b/services/notifier/src/main.py
@@ -205,6 +205,8 @@ def subscribe_loop(
     delay = _REDIS_RECONNECT_DELAY
 
     while not shutdown_flag[0]:
+        client: redis_lib.Redis | None = None
+        pubsub: redis_lib.client.PubSub | None = None
         try:
             client = redis_lib.Redis(host=host, port=port, decode_responses=True)
             pubsub = client.pubsub()
@@ -264,6 +266,18 @@ def subscribe_loop(
             )
             time.sleep(delay)
             delay = min(delay * 2, _REDIS_MAX_RECONNECT_DELAY)
+        finally:
+            if pubsub is not None:
+                try:
+                    pubsub.unsubscribe()
+                    pubsub.close()
+                except Exception:
+                    pass
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    pass
 
     logger.info("Subscription loop exited")
 

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -1,5 +1,5 @@
 # Build context: repo root
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
 
 WORKDIR /app
 

--- a/services/web/src/routes/feed.py
+++ b/services/web/src/routes/feed.py
@@ -1,6 +1,8 @@
 """Live feed page — SSE stream pushes latest annotated snapshot on each detection."""
 
+import asyncio
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -12,10 +14,15 @@ from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/feed")
 templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
 
 CHANNEL = "scarguard:detections"
+
+# Max buffered events per SSE client before dropping oldest.
+_FEED_QUEUE_MAX = 32
 
 
 def _to_local(iso_str: str, tz_name: str) -> str:
@@ -59,32 +66,56 @@ async def feed_page(request: Request):
 
 @router.get("/stream")
 async def feed_stream(request: Request):
-    """
-    SSE stream — pushes an HTML <img> fragment for each new detection.
-    The browser swaps it into the feed container via HTMX hx-swap-oob or
-    a simple EventSource listener in the template.
+    """SSE stream with per-client backpressure via bounded queue.
+
+    A background task reads from Redis pub/sub into a bounded asyncio.Queue.
+    If a slow client can't keep up, the oldest events are dropped so the
+    server is never blocked.
     """
     redis_cfg = config_store.load_cached().get("redis", {})
     host = redis_cfg.get("host", "redis")
     port = int(redis_cfg.get("port", 6379))
 
     async def generator():
+        queue: asyncio.Queue[str | None] = asyncio.Queue(maxsize=_FEED_QUEUE_MAX)
         client = aioredis.Redis(host=host, port=port, decode_responses=True)
         pubsub = client.pubsub()
         await pubsub.subscribe(CHANNEL)
+
+        async def _reader() -> None:
+            """Read from Redis pubsub and enqueue; drop oldest on overflow."""
+            try:
+                while True:
+                    message = await pubsub.get_message(
+                        ignore_subscribe_messages=True, timeout=15.0,
+                    )
+                    if message is None:
+                        await _put_or_drop(queue, None)
+                        continue
+                    if message["type"] != "message":
+                        continue
+                    await _put_or_drop(queue, message["data"])
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                logger.debug("Feed reader error", exc_info=True)
+
+        reader_task = asyncio.create_task(_reader())
         yield ": connected\n\n"
         try:
             while not await request.is_disconnected():
-                message = await pubsub.get_message(
-                    ignore_subscribe_messages=True, timeout=15.0,
-                )
-                if message is None:
+                try:
+                    raw = await asyncio.wait_for(queue.get(), timeout=30.0)
+                except asyncio.TimeoutError:
                     yield ": keepalive\n\n"
                     continue
-                if message["type"] != "message":
+
+                if raw is None:
+                    yield ": keepalive\n\n"
                     continue
+
                 try:
-                    event = json.loads(message["data"])
+                    event = json.loads(raw)
                 except json.JSONDecodeError:
                     continue
 
@@ -107,7 +138,22 @@ async def feed_stream(request: Request):
                 })
                 yield f"event: detection\ndata: {payload}\n\n"
         finally:
+            reader_task.cancel()
+            try:
+                await reader_task
+            except asyncio.CancelledError:
+                pass
             await pubsub.unsubscribe(CHANNEL)
             await client.aclose()
 
     return StreamingResponse(generator(), media_type="text/event-stream")
+
+
+async def _put_or_drop(queue: asyncio.Queue[str | None], item: str | None) -> None:
+    """Put item into queue; if full, drop oldest first."""
+    if queue.full():
+        try:
+            queue.get_nowait()
+        except asyncio.QueueEmpty:
+            pass
+    await queue.put(item)

--- a/services/web/src/routes/feed.py
+++ b/services/web/src/routes/feed.py
@@ -104,6 +104,11 @@ async def feed_stream(request: Request):
         yield ": connected\n\n"
         try:
             while not await request.is_disconnected():
+                # If the reader died (Redis disconnect), close the stream so
+                # the browser EventSource triggers an automatic reconnect.
+                if reader_task.done():
+                    logger.debug("Feed reader exited — closing SSE stream")
+                    return
                 try:
                     raw = await asyncio.wait_for(queue.get(), timeout=30.0)
                 except asyncio.TimeoutError:

--- a/services/web/src/templates/stats.html
+++ b/services/web/src/templates/stats.html
@@ -64,6 +64,16 @@
       <canvas id="gpu-chart" width="440" height="120"></canvas>
     </div>
   </div>
+  <div class="chart-row" style="margin-top:1rem;">
+    <div class="chart-container">
+      <span class="chart-label">Inference ms</span>
+      <canvas id="infer-chart" width="440" height="120"></canvas>
+    </div>
+    <div class="chart-container">
+      <span class="chart-label">FPS</span>
+      <canvas id="fps-chart" width="440" height="120"></canvas>
+    </div>
+  </div>
 </section>
 
 <!-- Per-camera Inference Performance -->
@@ -96,6 +106,16 @@
     <div class="chart-container">
       <span class="chart-label">GPU % & Temp</span>
       <canvas id="hist-gpu-chart"></canvas>
+    </div>
+  </div>
+  <div class="chart-row" style="margin-top:1.5rem;">
+    <div class="chart-container">
+      <span class="chart-label">Inference Time (ms)</span>
+      <canvas id="hist-inference-chart"></canvas>
+    </div>
+    <div class="chart-container">
+      <span class="chart-label">Detection FPS</span>
+      <canvas id="hist-fps-chart"></canvas>
     </div>
   </div>
   <div id="hist-status" class="hint" style="margin-top:0.5rem;">Loading...</div>
@@ -197,6 +217,16 @@ const INTERVAL = {{ interval }} * 1000;
 const MAX_POINTS = Math.ceil(600 / {{ interval }});  // 10 minutes of history
 const cpuHistory = [];
 const gpuHistory = [];
+const inferHistory = {};  // {camera_name: [values...]}
+const fpsHistory = {};    // {camera_name: [values...]}
+const CAM_COLORS = [
+  'rgba(78,159,255,0.8)',   // blue
+  'rgba(62,207,142,0.8)',   // green
+  'rgba(255,159,67,0.8)',   // orange
+  'rgba(207,62,207,0.8)',   // purple
+  'rgba(255,99,132,0.8)',   // red
+  'rgba(255,205,86,0.8)',   // yellow
+];
 let es = null;
 let backoff = 1000;
 
@@ -303,6 +333,24 @@ function updateCharts(d) {
     if (gpuHistory.length > MAX_POINTS) gpuHistory.shift();
     drawChart("gpu-chart", gpuHistory, "rgba(62,207,142,0.8)", "rgba(62,207,142,0.1)");
   }
+
+  // Per-camera inference and FPS
+  const cameras = d.cameras || {};
+  const names = Object.keys(cameras).sort();
+  for (const name of names) {
+    if (!inferHistory[name]) inferHistory[name] = [];
+    if (!fpsHistory[name]) fpsHistory[name] = [];
+    inferHistory[name].push(cameras[name].avg_inference_ms || 0);
+    if (inferHistory[name].length > MAX_POINTS) inferHistory[name].shift();
+    fpsHistory[name].push(cameras[name].fps || 0);
+    if (fpsHistory[name].length > MAX_POINTS) fpsHistory[name].shift();
+  }
+  if (names.length > 0) {
+    const inferSeries = names.map((n, i) => ({data: inferHistory[n], color: CAM_COLORS[i % CAM_COLORS.length], label: n}));
+    const fpsSeries = names.map((n, i) => ({data: fpsHistory[n], color: CAM_COLORS[i % CAM_COLORS.length], label: n}));
+    drawMultiChart("infer-chart", inferSeries);
+    drawMultiChart("fps-chart", fpsSeries);
+  }
 }
 
 function drawChart(canvasId, data, strokeColor, fillColor) {
@@ -366,6 +414,78 @@ function drawChart(canvasId, data, strokeColor, fillColor) {
   ctx.fill();
 }
 
+function drawMultiChart(canvasId, series) {
+  const canvas = document.getElementById(canvasId);
+  const ctx = canvas.getContext("2d");
+  const dpr = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  ctx.scale(dpr, dpr);
+  const w = rect.width;
+  const h = rect.height;
+  const pad = { top: 5, bottom: 14, left: 0, right: 0 };
+  const cw = w - pad.left - pad.right;
+  const ch = h - pad.top - pad.bottom;
+
+  ctx.clearRect(0, 0, w, h);
+
+  // Find max value across all series for auto-scaling
+  let maxVal = 0;
+  for (const s of series) {
+    for (const v of s.data) if (v > maxVal) maxVal = v;
+  }
+  maxVal = maxVal > 0 ? maxVal * 1.15 : 1;  // 15% headroom
+
+  // Grid lines at 25%, 50%, 75%
+  ctx.strokeStyle = "rgba(255,255,255,0.06)";
+  ctx.lineWidth = 1;
+  [0.25, 0.5, 0.75].forEach(pct => {
+    const y = pad.top + ch * (1 - pct);
+    ctx.beginPath();
+    ctx.moveTo(pad.left, y);
+    ctx.lineTo(w - pad.right, y);
+    ctx.stroke();
+  });
+
+  // Grid labels
+  ctx.fillStyle = "rgba(255,255,255,0.2)";
+  ctx.font = "10px system-ui";
+  ctx.textAlign = "right";
+  [0.25, 0.5, 0.75, 1.0].forEach(pct => {
+    const y = pad.top + ch * (1 - pct);
+    ctx.fillText(Math.round(maxVal * pct).toString(), w - 2, y + 3);
+  });
+
+  const step = cw / (MAX_POINTS - 1);
+
+  // Draw each series line
+  for (const s of series) {
+    if (s.data.length < 2) continue;
+    const startX = pad.left + (MAX_POINTS - s.data.length) * step;
+    ctx.beginPath();
+    ctx.moveTo(startX, pad.top + ch - (s.data[0] / maxVal) * ch);
+    for (let i = 1; i < s.data.length; i++) {
+      ctx.lineTo(startX + i * step, pad.top + ch - (s.data[i] / maxVal) * ch);
+    }
+    ctx.strokeStyle = s.color;
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+  }
+
+  // Legend at bottom
+  ctx.font = "9px system-ui";
+  ctx.textAlign = "left";
+  let lx = pad.left + 4;
+  for (let i = 0; i < series.length; i++) {
+    ctx.fillStyle = series[i].color;
+    ctx.fillRect(lx, h - 10, 8, 8);
+    ctx.fillStyle = "rgba(255,255,255,0.5)";
+    ctx.fillText(series[i].label, lx + 11, h - 3);
+    lx += ctx.measureText(series[i].label).width + 20;
+  }
+}
+
 function updateInferenceTable(cameras) {
   const tbody = document.getElementById("inference-tbody");
   const names = Object.keys(cameras).sort();
@@ -397,7 +517,18 @@ connect();
 <script>
 let histCpuChart = null;
 let histGpuChart = null;
+let histInferenceChart = null;
+let histFpsChart = null;
 let currentRange = '1h';
+
+const HIST_CAM_COLORS = [
+  'rgba(78,159,255,0.9)',
+  'rgba(62,207,142,0.9)',
+  'rgba(255,159,67,0.9)',
+  'rgba(207,62,207,0.9)',
+  'rgba(255,99,132,0.9)',
+  'rgba(255,205,86,0.9)',
+];
 
 function loadHistory(range, btn) {
   currentRange = range;
@@ -438,6 +569,8 @@ function renderHistCharts(data) {
 
   if (histCpuChart) histCpuChart.destroy();
   if (histGpuChart) histGpuChart.destroy();
+  if (histInferenceChart) histInferenceChart.destroy();
+  if (histFpsChart) histFpsChart.destroy();
 
   const cpuCtx = document.getElementById('hist-cpu-chart').getContext('2d');
   histCpuChart = new Chart(cpuCtx, {
@@ -481,6 +614,53 @@ function renderHistCharts(data) {
       plugins: {legend: {labels: {color: 'rgba(255,255,255,0.6)', font: {size: 11}}}},
     },
   });
+
+  // Per-camera inference and FPS historical charts
+  const cameraNames = new Set();
+  data.forEach(d => {
+    if (d.cameras) Object.keys(d.cameras).forEach(n => cameraNames.add(n));
+  });
+  const cameras = [...cameraNames].sort();
+
+  if (cameras.length > 0) {
+    const inferDatasets = cameras.map((cam, i) => ({
+      label: cam,
+      data: data.map(d => d.cameras && d.cameras[cam] ? d.cameras[cam].avg_inference_ms : null),
+      borderColor: HIST_CAM_COLORS[i % HIST_CAM_COLORS.length],
+      fill: false, tension: 0.3, pointRadius: 0, spanGaps: true,
+    }));
+
+    const fpsDatasets = cameras.map((cam, i) => ({
+      label: cam,
+      data: data.map(d => d.cameras && d.cameras[cam] ? d.cameras[cam].fps : null),
+      borderColor: HIST_CAM_COLORS[i % HIST_CAM_COLORS.length],
+      fill: false, tension: 0.3, pointRadius: 0, spanGaps: true,
+    }));
+
+    const camChartOpts = (yLabel) => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: {display: true, ticks: {maxTicksLimit: 10, color: 'rgba(255,255,255,0.4)', font: {size: 10}}, grid: {color: 'rgba(255,255,255,0.06)'}},
+        y: {min: 0, title: {display: true, text: yLabel, color: 'rgba(255,255,255,0.4)'}, ticks: {color: 'rgba(255,255,255,0.4)', font: {size: 10}}, grid: {color: 'rgba(255,255,255,0.06)'}},
+      },
+      plugins: {legend: {labels: {color: 'rgba(255,255,255,0.6)', font: {size: 11}}}},
+    });
+
+    const inferCtx = document.getElementById('hist-inference-chart').getContext('2d');
+    histInferenceChart = new Chart(inferCtx, {
+      type: 'line',
+      data: {labels: labels, datasets: inferDatasets},
+      options: camChartOpts('ms'),
+    });
+
+    const fpsCtx = document.getElementById('hist-fps-chart').getContext('2d');
+    histFpsChart = new Chart(fpsCtx, {
+      type: 'line',
+      data: {labels: labels, datasets: fpsDatasets},
+      options: camChartOpts('fps'),
+    });
+  }
 }
 
 loadHistory('1h', document.querySelector('.range-btn[data-range="1h"]'));


### PR DESCRIPTION
## Summary
Batches 8 hardening items plus 2 CI fixes for v0.12.3.

**CI fixes:**
- Pin cleanup workflow jobs to distinct runners via unique labels (previous matrix could schedule all legs on same machine)
- Gate detector-x86 benchmark + Trivy scan behind `event_name != 'push'` (matching web/notifier pattern)

**Hardening:**
- Pin 5 Dockerfile base images to SHA256 digests for reproducible builds (x86 detector excluded — Docker doesn't support `@sha256` with ARG interpolation)
- Align CI Python from 3.12 → 3.11 to match runtime
- Close Redis pubsub/client explicitly on notifier shutdown and reconnect
- Call `torch.cuda.empty_cache()` after ModelPool evicts a model (Jetson VRAM)
- Use `grab()` for skipped RTSP frames — avoids decoding frames that will be discarded
- Bounded `asyncio.Queue` (32) backpressure on feed SSE ��� drop oldest on slow clients
- Bounded `deque` (256) buffer in Redis publisher — replay on reconnect instead of dropping

**Stats UI:**
- Add per-camera inference time and FPS charts (live 10-min rolling + historical Chart.js)
- Backend already stores camera data in `system_metrics.camera_data` — this is frontend-only

## Test plan
- [ ] CI passes (lint, mypy, pytest, Docker builds)
- [ ] On Jetson: confirm detector streams, no permission errors, model swap frees GPU memory
- [ ] `docker stop scarguard-notifier` exits cleanly (no 10s SIGKILL timeout)
- [ ] Stats page shows inference/FPS charts with per-camera lines
- [ ] Trigger cleanup workflow manually, confirm 3 separate runner jobs appear
- [ ] Feed page handles slow client without blocking server

🤖 Generated with [Claude Code](https://claude.com/claude-code)