### PR TITLE
harden: v0.12.5 — multi-camera perf, stats fix, setup UX

### DIFF
--- a/services/detector/Dockerfile
+++ b/services/detector/Dockerfile
@@ -41,8 +41,8 @@ ENV YOLO_CONFIG_DIR=/tmp/ultralytics
 # Container starts as root; entrypoint fixes volume ownership then drops
 # to scarguard via gosu.
 RUN useradd -r -m -d /home/scarguard -s /usr/sbin/nologin -G video scarguard && \
-    mkdir -p /data /config /models && \
-    chown scarguard:scarguard /data /config /models
+    mkdir -p /data /config /models /tmp/ultralytics && \
+    chown scarguard:scarguard /data /config /models /tmp/ultralytics
 
 COPY services/detector/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh

--- a/services/detector/Dockerfile.x86
+++ b/services/detector/Dockerfile.x86
@@ -37,8 +37,8 @@ ENV YOLO_CONFIG_DIR=/tmp/ultralytics
 # Container starts as root; entrypoint fixes volume ownership then drops
 # to scarguard via gosu.
 RUN useradd -r -m -d /home/scarguard -s /usr/sbin/nologin -G video scarguard && \
-    mkdir -p /data /config /models && \
-    chown scarguard:scarguard /data /config /models
+    mkdir -p /data /config /models /tmp/ultralytics && \
+    chown scarguard:scarguard /data /config /models /tmp/ultralytics
 
 COPY services/detector/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh

--- a/services/detector/src/detector.py
+++ b/services/detector/src/detector.py
@@ -1,10 +1,10 @@
 """YOLO model wrapper — loads .pt or .engine files and runs inference."""
 
 import logging
-import threading
 from dataclasses import dataclass
 
 import numpy as np
+from fair_lock import FairLock
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ class YOLODetector:
         self.confidence_threshold = confidence_threshold
         self.target_classes = set(target_classes)
         self._model = None
-        self._lock = threading.Lock()
+        self._lock = FairLock()
         self._load()
 
     def _load(self) -> None:
@@ -52,13 +52,23 @@ class YOLODetector:
         If *target_classes* is provided it overrides the instance-level filter,
         allowing cameras that share a model to detect different class subsets.
         """
-        with self._lock:
+        wait_seconds = self._lock.acquire()
+        try:
             results = self._model.predict(
                 frame,
                 conf=self.confidence_threshold,
                 verbose=False,
                 save=False,
                 project="/tmp/runs",
+            )
+        finally:
+            self._lock.release()
+
+        if wait_seconds > 0.5:
+            logger.info(
+                "Inference lock wait: %.0f ms (model=%s)",
+                wait_seconds * 1000,
+                self.model_path,
             )
 
         classes = target_classes if target_classes is not None else self.target_classes

--- a/services/detector/src/fair_lock.py
+++ b/services/detector/src/fair_lock.py
@@ -42,12 +42,16 @@ class FairLock:
             else:
                 self._queue.append(event)
         if not event.wait(timeout=timeout):
-            # Remove ourselves from the queue to avoid a dangling event
+            # Remove ourselves from the queue to avoid a dangling event.
+            # Race: release() may have popped & signaled us between wait()
+            # returning False and us acquiring _lock.  If so the event is
+            # now set and ownership has been handed to us — accept it.
             with self._lock:
                 try:
                     self._queue.remove(event)
                 except ValueError:
-                    pass  # already removed by release()
+                    if event.is_set():
+                        return time.monotonic() - t0
             raise TimeoutError(f"FairLock.acquire timed out after {timeout:.0f}s")
         return time.monotonic() - t0
 

--- a/services/detector/src/fair_lock.py
+++ b/services/detector/src/fair_lock.py
@@ -1,0 +1,61 @@
+"""FIFO fair lock — prevents thread starvation under contention.
+
+Python's ``threading.Lock()`` does not guarantee FIFO ordering, so a
+high-frequency thread can monopolize the lock while slower threads starve.
+``FairLock`` uses an internal queue of ``threading.Event`` objects to ensure
+waiting threads are woken in the order they arrived.
+
+Used by ``YOLODetector`` to ensure fair GPU access across camera threads
+that share the same model.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+
+
+class FairLock:
+    """Lock that guarantees FIFO acquisition order."""
+
+    __slots__ = ("_lock", "_queue", "_held")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._queue: deque[threading.Event] = deque()
+        self._held = False
+
+    def acquire(self, timeout: float = 30.0) -> float:
+        """Acquire the lock, blocking until it is available.
+
+        Returns the wall-clock seconds spent waiting (0.0 if uncontended).
+        Raises ``TimeoutError`` if the lock is not acquired within *timeout*
+        seconds (prevents permanent hangs if a holder crashes).
+        """
+        t0 = time.monotonic()
+        event = threading.Event()
+        with self._lock:
+            if not self._held:
+                self._held = True
+                event.set()
+            else:
+                self._queue.append(event)
+        if not event.wait(timeout=timeout):
+            # Remove ourselves from the queue to avoid a dangling event
+            with self._lock:
+                try:
+                    self._queue.remove(event)
+                except ValueError:
+                    pass  # already removed by release()
+            raise TimeoutError(f"FairLock.acquire timed out after {timeout:.0f}s")
+        return time.monotonic() - t0
+
+    def release(self) -> None:
+        """Release the lock and wake the next waiting thread, if any."""
+        with self._lock:
+            if self._queue:
+                next_event = self._queue.popleft()
+                next_event.set()
+            else:
+                self._held = False

--- a/services/detector/src/main.py
+++ b/services/detector/src/main.py
@@ -140,6 +140,70 @@ def _validate_action_rules(
                 )
 
 
+def _apply_exclusion_zones(
+    detections: list,
+    zones: list[dict],
+    frame_w: int,
+    frame_h: int,
+    camera_name: str,
+) -> list:
+    """Filter detections that fall inside exclusion zones."""
+    if not zones:
+        return detections
+    filtered = [
+        det for det in detections
+        if not _in_exclusion_zone(
+            (det.bbox[0] + det.bbox[2]) // 2,
+            (det.bbox[1] + det.bbox[3]) // 2,
+            frame_w, frame_h, zones,
+        )
+    ]
+    if not filtered and detections:
+        logger.debug("[%s] All detections suppressed by exclusion zones", camera_name)
+    return filtered
+
+
+def _evaluate_action_rules(
+    detections: list,
+    rules: list[dict],
+) -> dict[str, list[str] | None]:
+    """Build a class_name → channel list mapping from action rules."""
+    actions_by_class: dict[str, list[str] | None] = {}
+    if not rules:
+        return actions_by_class
+    for det in detections:
+        if det.class_name not in actions_by_class:
+            actions_by_class[det.class_name] = _match_action_rules(
+                det.class_name, rules
+            )
+    return actions_by_class
+
+
+def _publish_detections(
+    detections: list,
+    camera_name: str,
+    frame: object,
+    event_processor: EventProcessor,
+    publisher: RedisPublisher,
+    visit_tracker: VisitTracker | None,
+    actions_by_class: dict[str, list[str] | None],
+) -> None:
+    """Run cooldown dedup, publish events to Redis, and record visits."""
+    events = event_processor.process(
+        detections, camera_name, frame,
+        actions_by_class=actions_by_class if actions_by_class else None,
+    )
+    for event in events:
+        publisher.publish(event)
+    if visit_tracker is not None:
+        for event in events:
+            visit_tracker.record_detection(
+                camera_name=camera_name,
+                class_name=event["class_name"],
+                timestamp=datetime.fromisoformat(event["timestamp"]),
+            )
+
+
 def run_camera(
     camera_cfg: dict,
     detector: YOLODetector,
@@ -235,45 +299,28 @@ def run_camera(
                 _infer_count = 0
                 _infer_total_ms = 0.0
                 _infer_window_start = time.monotonic()
-        if detections:
-            # Exclusion zones are applied BEFORE cooldown dedup intentionally:
-            # an object permanently in an excluded region should not consume the
-            # cooldown slot for its class on this camera.
-            zones = exclusion_zones_ref.get()
-            if zones:
-                frame_h, frame_w = frame.shape[:2]
-                detections = [
-                    det for det in detections
-                    if not _in_exclusion_zone(
-                        (det.bbox[0] + det.bbox[2]) // 2,
-                        (det.bbox[1] + det.bbox[3]) // 2,
-                        frame_w, frame_h, zones,
-                    )
-                ]
-                if not detections:
-                    logger.debug("[%s] All detections suppressed by exclusion zones", name)
-            if detections:
-                rules = action_rules_ref.get()
-                actions_by_class: dict[str, list[str]] = {}
-                if rules:
-                    for det in detections:
-                        if det.class_name not in actions_by_class:
-                            actions_by_class[det.class_name] = _match_action_rules(
-                                det.class_name, rules
-                            )
-                events = event_processor.process(
-                    detections, name, frame,
-                    actions_by_class=actions_by_class if actions_by_class else None,
-                )
-                for event in events:
-                    publisher.publish(event)
-                if visit_tracker is not None:
-                    for event in events:
-                        visit_tracker.record_detection(
-                            camera_name=name,
-                            class_name=event["class_name"],
-                            timestamp=datetime.fromisoformat(event["timestamp"]),
-                        )
+
+        if not detections:
+            continue
+
+        # Exclusion zones are applied BEFORE cooldown dedup intentionally:
+        # an object permanently in an excluded region should not consume the
+        # cooldown slot for its class on this camera.
+        frame_h, frame_w = frame.shape[:2]
+        detections = _apply_exclusion_zones(
+            detections, exclusion_zones_ref.get(), frame_w, frame_h, name,
+        )
+        if not detections:
+            continue
+
+        actions_by_class = _evaluate_action_rules(
+            detections, action_rules_ref.get(),
+        )
+        _publish_detections(
+            detections, name, frame,
+            event_processor, publisher, visit_tracker,
+            actions_by_class,
+        )
 
     stream.release()
     logger.info("[%s] Camera thread stopped", name)

--- a/services/detector/src/main.py
+++ b/services/detector/src/main.py
@@ -280,7 +280,11 @@ def run_camera(
             continue
 
         t0 = time.monotonic()
-        detections = detector.predict(frame, target_classes=target_classes)
+        try:
+            detections = detector.predict(frame, target_classes=target_classes)
+        except TimeoutError:
+            logger.warning("[%s] Inference lock timed out — skipping frame", name)
+            continue
         infer_ms = (time.monotonic() - t0) * 1000.0
         _infer_count += 1
         _infer_total_ms += infer_ms

--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -526,3 +526,47 @@ def get_metrics(
             ).fetchall()
     except Exception:
         return []
+
+
+# Target number of data points for chart display.
+_CHART_TARGET_POINTS = 2000
+# Collection interval in seconds (must match stats_collector).
+_COLLECTION_INTERVAL = 5
+
+
+def get_metrics_for_chart(range_hours: int = 24) -> list[sqlite3.Row]:
+    """Return metrics for chart display, downsampled for large ranges.
+
+    For short ranges (≤ ~2.7 h at 5 s intervals) raw data is returned.
+    For longer ranges, data is aggregated into time buckets so the response
+    stays around ~2000 data points regardless of range.
+    """
+    raw_point_count = (range_hours * 3600) // _COLLECTION_INTERVAL
+    if raw_point_count <= _CHART_TARGET_POINTS:
+        return get_metrics(range_hours=range_hours, limit=_CHART_TARGET_POINTS)
+
+    cutoff = (
+        datetime.now(timezone.utc) - timedelta(hours=range_hours)
+    ).isoformat()
+    bucket_seconds = (range_hours * 3600) // _CHART_TARGET_POINTS
+
+    try:
+        with _connect() as conn:
+            return conn.execute(
+                """
+                SELECT MIN(timestamp) AS timestamp,
+                       ROUND(AVG(cpu_pct), 1)  AS cpu_pct,
+                       ROUND(AVG(gpu_pct), 1)  AS gpu_pct,
+                       ROUND(AVG(gpu_temp), 1) AS gpu_temp,
+                       ROUND(AVG(ram_used_mb))  AS ram_used_mb,
+                       MAX(ram_total_mb)        AS ram_total_mb,
+                       NULL                     AS camera_data
+                FROM system_metrics
+                WHERE timestamp >= ?
+                GROUP BY CAST(strftime('%s', timestamp) / ? AS INTEGER)
+                ORDER BY timestamp ASC
+                """,
+                (cutoff, bucket_seconds),
+            ).fetchall()
+    except Exception:
+        return []

--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -530,18 +530,22 @@ def get_metrics(
 
 # Target number of data points for chart display.
 _CHART_TARGET_POINTS = 2000
-# Collection interval in seconds (must match stats_collector).
-_COLLECTION_INTERVAL = 5
 
 
-def get_metrics_for_chart(range_hours: int = 24) -> list[sqlite3.Row]:
+def get_metrics_for_chart(
+    range_hours: int = 24,
+    collection_interval: int = 5,
+) -> list[sqlite3.Row]:
     """Return metrics for chart display, downsampled for large ranges.
 
-    For short ranges (≤ ~2.7 h at 5 s intervals) raw data is returned.
-    For longer ranges, data is aggregated into time buckets so the response
-    stays around ~2000 data points regardless of range.
+    *collection_interval* is the stats collection cadence in seconds
+    (from ``system.stats_interval`` config).  It determines whether the
+    raw or downsampled path is used.
+
+    For short ranges where raw point count fits in ~2000, raw data is
+    returned.  For longer ranges, data is aggregated into time buckets.
     """
-    raw_point_count = (range_hours * 3600) // _COLLECTION_INTERVAL
+    raw_point_count = (range_hours * 3600) // max(collection_interval, 1)
     if raw_point_count <= _CHART_TARGET_POINTS:
         return get_metrics(range_hours=range_hours, limit=_CHART_TARGET_POINTS)
 

--- a/services/web/src/routes/stats.py
+++ b/services/web/src/routes/stats.py
@@ -93,7 +93,9 @@ async def stats_history(
 ) -> JSONResponse:
     """Return historical metrics as JSON for Chart.js."""
     hours = _parse_range(range)
-    rows = db.get_metrics_for_chart(range_hours=hours)
+    cfg = config_store.load_cached()
+    interval = max(1, int(cfg.get("system", {}).get("stats_interval", 5)))
+    rows = db.get_metrics_for_chart(range_hours=hours, collection_interval=interval)
     data: list[dict] = []
     for r in rows:
         entry: dict = {

--- a/services/web/src/routes/stats.py
+++ b/services/web/src/routes/stats.py
@@ -93,7 +93,7 @@ async def stats_history(
 ) -> JSONResponse:
     """Return historical metrics as JSON for Chart.js."""
     hours = _parse_range(range)
-    rows = db.get_metrics(range_hours=hours)
+    rows = db.get_metrics_for_chart(range_hours=hours)
     data: list[dict] = []
     for r in rows:
         entry: dict = {

--- a/setup.sh
+++ b/setup.sh
@@ -45,10 +45,22 @@ confirm() {
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$REPO_ROOT"
 
+# Detect upgrade vs fresh install early (before banner)
+IS_UPGRADE=false
+if [[ -f ".env" ]]; then
+    IS_UPGRADE=true
+fi
+
 echo
-echo "${BOLD}╔════════════════════════════════════════╗${RESET}"
-echo "${BOLD}║       ScarGuard — First-Run Setup      ║${RESET}"
-echo "${BOLD}╚════════════════════════════════════════╝${RESET}"
+if [[ "$IS_UPGRADE" == "true" ]]; then
+    echo "${BOLD}╔════════════════════════════════════════╗${RESET}"
+    echo "${BOLD}║       ScarGuard — Upgrade Check        ║${RESET}"
+    echo "${BOLD}╚════════════════════════════════════════╝${RESET}"
+else
+    echo "${BOLD}╔════════════════════════════════════════╗${RESET}"
+    echo "${BOLD}║       ScarGuard — First-Run Setup      ║${RESET}"
+    echo "${BOLD}╚════════════════════════════════════════╝${RESET}"
+fi
 echo "  Running from: $REPO_ROOT"
 
 # ── Step 1: Platform detection ───────────────────────────────────────────────
@@ -241,44 +253,49 @@ step "Preparing data volume (named volume: scarguard-data)"
 docker run --rm -v scarguard-data:/data alpine:3.20 mkdir -p /data/snapshots
 info "scarguard-data volume ready (snapshots directory created)"
 
-# ── Step 7: TLS setup ───────────────────────────────────────────────────────
-step "TLS configuration"
+# ── Step 7: TLS setup (first install only) ──────────────────────────────────
+if [[ "$IS_UPGRADE" == "true" ]]; then
+    step "TLS configuration"
+    info "Existing install detected — TLS settings preserved. Change via Settings > TLS."
+else
+    step "TLS configuration"
 
-echo "  How will you access ScarGuard?"
-echo "    1) LAN only (HTTP, no TLS — default)"
-echo "    2) Internet with automatic HTTPS (Let's Encrypt)"
-echo "    3) Own certificates (manual TLS)"
-echo
-ask "Choice [1]: "
-read -r TLS_CHOICE </dev/tty
-TLS_CHOICE="${TLS_CHOICE:-1}"
+    echo "  How will you access ScarGuard?"
+    echo "    1) LAN only (HTTP, no TLS — default)"
+    echo "    2) Internet with automatic HTTPS (Let's Encrypt)"
+    echo "    3) Own certificates (manual TLS)"
+    echo
+    ask "Choice [1]: "
+    read -r TLS_CHOICE </dev/tty
+    TLS_CHOICE="${TLS_CHOICE:-1}"
 
-case "$TLS_CHOICE" in
-    2)
-        ask "Domain name (e.g. scarguard.example.com): "
-        read -r TLS_DOMAIN </dev/tty
-        if [[ -n "$TLS_DOMAIN" ]]; then
-            # Update tls section in config volume (idempotent — works regardless of current value)
+    case "$TLS_CHOICE" in
+        2)
+            ask "Domain name (e.g. scarguard.example.com): "
+            read -r TLS_DOMAIN </dev/tty
+            if [[ -n "$TLS_DOMAIN" ]]; then
+                # Update tls section in config volume (idempotent — works regardless of current value)
+                docker run --rm -v scarguard-config:/config alpine:3.20 \
+                    sh -c "sed -i 's/mode: \"[^\"]*\"/mode: \"auto\"/' /config/scarguard.yml && \
+                           sed -i 's/domain: \"[^\"]*\"/domain: \"${TLS_DOMAIN}\"/' /config/scarguard.yml"
+                info "TLS mode set to auto (Let's Encrypt) with domain: ${TLS_DOMAIN}"
+                warn "Ports 80 and 443 must be reachable from the internet for ACME challenges."
+            else
+                warn "No domain provided — keeping TLS off. Change in Settings > TLS later."
+            fi
+            ;;
+        3)
+            info "TLS mode: manual. Place cert.pem and key.pem in the config volume's certs/ directory."
             docker run --rm -v scarguard-config:/config alpine:3.20 \
-                sh -c "sed -i 's/mode: \"[^\"]*\"/mode: \"auto\"/' /config/scarguard.yml && \
-                       sed -i 's/domain: \"[^\"]*\"/domain: \"${TLS_DOMAIN}\"/' /config/scarguard.yml"
-            info "TLS mode set to auto (Let's Encrypt) with domain: ${TLS_DOMAIN}"
-            warn "Ports 80 and 443 must be reachable from the internet for ACME challenges."
-        else
-            warn "No domain provided — keeping TLS off. Change in Settings > TLS later."
-        fi
-        ;;
-    3)
-        info "TLS mode: manual. Place cert.pem and key.pem in the config volume's certs/ directory."
-        docker run --rm -v scarguard-config:/config alpine:3.20 \
-            sh -c "sed -i 's/mode: \"[^\"]*\"/mode: \"manual\"/' /config/scarguard.yml"
-        info "Set TLS mode to manual in scarguard.yml."
-        warn "HTTPS will activate once cert and key files are present at the configured paths."
-        ;;
-    *)
-        info "TLS disabled (HTTP only). You can enable it later in Settings > TLS."
-        ;;
-esac
+                sh -c "sed -i 's/mode: \"[^\"]*\"/mode: \"manual\"/' /config/scarguard.yml"
+            info "Set TLS mode to manual in scarguard.yml."
+            warn "HTTPS will activate once cert and key files are present at the configured paths."
+            ;;
+        *)
+            info "TLS disabled (HTTP only). You can enable it later in Settings > TLS."
+            ;;
+    esac
+fi
 
 # ── Step 8: Model check / starter model download ──────────────────────────────
 step "Checking for YOLO model"
@@ -292,6 +309,8 @@ if [[ -n "$MODEL_FILES" ]]; then
     while IFS= read -r f; do
         info "  $(basename "$f")"
     done <<< "$MODEL_FILES"
+elif [[ "$IS_UPGRADE" == "true" ]]; then
+    warn "No model file found. Upload via the web UI Models page."
 else
     warn "No model file found in models volume."
     echo
@@ -381,106 +400,122 @@ else
     fi
 fi
 
-# ── Step 10: Create initial admin account ─────────────────────────────────────
-echo
-step "Creating initial admin account"
-echo "  If you skip this, visit the web UI on first launch to create an account."
-echo
-
-WEB_IMAGE=$(docker compose config --format json 2>/dev/null | \
-    python3 -c "import sys,json; d=json.load(sys.stdin); print(d['services']['web']['image'])" 2>/dev/null || echo "")
-
-if [[ -z "$WEB_IMAGE" ]]; then
-    warn "Could not determine web image name. Skipping admin account creation."
-    warn "Create your admin account via the web UI on first launch."
+# ── Step 10: Create initial admin account (first install only) ────────────────
+if [[ "$IS_UPGRADE" == "true" ]]; then
+    # Skip admin account creation on upgrade — account already exists
+    :
 else
-    if [[ -t 0 ]] && confirm "Create admin account now?" "y"; then
-        read -rp "  Admin username: " ADMIN_USER
-        while [[ -z "$ADMIN_USER" ]]; do
-            warn "Username cannot be empty."
-            read -rp "  Admin username: " ADMIN_USER
-        done
-        while true; do
-            read -rsp "  Admin password (min 8 characters): " ADMIN_PASS
-            echo
-            if [[ ${#ADMIN_PASS} -ge 8 ]]; then
-                break
-            fi
-            warn "Password must be at least 8 characters."
-        done
+    echo
+    step "Creating initial admin account"
+    echo "  If you skip this, visit the web UI on first launch to create an account."
+    echo
 
-        if docker run --rm \
-                -e AUTH_DB_PATH=/data/auth.db \
-                -v scarguard-data:/data \
-                "$WEB_IMAGE" \
-                python /app/src/auth.py create-admin "$ADMIN_USER" "$ADMIN_PASS"; then
-            info "Admin account '${ADMIN_USER}' created."
-        else
-            warn "Account creation failed. Create it via the web UI on first launch."
-        fi
+    WEB_IMAGE=$(docker compose config --format json 2>/dev/null | \
+        python3 -c "import sys,json; d=json.load(sys.stdin); print(d['services']['web']['image'])" 2>/dev/null || echo "")
+
+    if [[ -z "$WEB_IMAGE" ]]; then
+        warn "Could not determine web image name. Skipping admin account creation."
+        warn "Create your admin account via the web UI on first launch."
     else
-        info "Skipped. Create your admin account via the web UI on first launch."
+        if [[ -t 0 ]] && confirm "Create admin account now?" "y"; then
+            read -rp "  Admin username: " ADMIN_USER
+            while [[ -z "$ADMIN_USER" ]]; do
+                warn "Username cannot be empty."
+                read -rp "  Admin username: " ADMIN_USER
+            done
+            while true; do
+                read -rsp "  Admin password (min 8 characters): " ADMIN_PASS
+                echo
+                if [[ ${#ADMIN_PASS} -ge 8 ]]; then
+                    break
+                fi
+                warn "Password must be at least 8 characters."
+            done
+
+            if docker run --rm \
+                    -e AUTH_DB_PATH=/data/auth.db \
+                    -v scarguard-data:/data \
+                    "$WEB_IMAGE" \
+                    python /app/src/auth.py create-admin "$ADMIN_USER" "$ADMIN_PASS"; then
+                info "Admin account '${ADMIN_USER}' created."
+            else
+                warn "Account creation failed. Create it via the web UI on first launch."
+            fi
+        else
+            info "Skipped. Create your admin account via the web UI on first launch."
+        fi
     fi
 fi
 
-# ── Done ──────────────────────────────────────────────────────────────────────
-echo
-echo "${BOLD}${GREEN}╔══════════════════════════════════════════════════════════════╗${RESET}"
-echo "${BOLD}${GREEN}║  Setup complete!                                             ║${RESET}"
-echo "${BOLD}${GREEN}╚══════════════════════════════════════════════════════════════╝${RESET}"
-echo
+# ── Start / Restart ──────────────────────────────────────────────────────────
 
-echo "${BOLD}Next steps:${RESET}"
-echo
-echo "  1. ${BOLD}Configure your cameras:${RESET}"
-echo "       Start the stack and use the web UI config editor to set your RTSP URLs."
-echo "       Or edit the config directly via a temporary container:"
-echo "         docker run --rm -it -v scarguard-config:/config alpine:3.20 vi /config/scarguard.yml"
-echo
-
-if [[ -z "$MODEL_FILES" ]]; then
-    echo "  2. ${BOLD}Add a YOLO model${RESET} (if you skipped the starter download):"
-    echo "       Upload via the web UI Models page after starting the stack."
-    echo
-    echo "  3. ${BOLD}Start ScarGuard:${RESET}"
-else
-    echo "  2. ${BOLD}Start ScarGuard:${RESET}"
-fi
-
-echo "       docker compose up -d"
-echo
-
-echo "  $([[ -z "$MODEL_FILES" ]] && echo 4 || echo 3). ${BOLD}Open the web UI:${RESET}"
-
-# Determine likely IP for this host
+# Determine likely IP/URL for this host
 HOST_IP=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' || echo "YOUR_HOST_IP")
 if [[ "$HTTP_PORT_FINAL" == "80" ]]; then
-    echo "       http://${HOST_IP}"
+    WEB_URL="http://${HOST_IP}"
 else
-    echo "       http://${HOST_IP}:${HTTP_PORT_FINAL}"
+    WEB_URL="http://${HOST_IP}:${HTTP_PORT_FINAL}"
 fi
-echo
 
-if [[ "$NVIDIA_OK" == "false" ]]; then
-    if [[ "$PLATFORM" == "jetson" ]]; then
-        echo "${YELLOW}Reminder:${RESET} NVIDIA container runtime was not detected."
-        echo "  The detector service (GPU inference) will fail to start."
-        echo "  Log out and back in, then run:  docker compose up -d"
+if [[ "$IS_UPGRADE" == "true" ]]; then
+    step "Restarting services"
+    if docker compose up -d; then
+        info "Services restarted with updated images."
     else
-        echo "${YELLOW}Note:${RESET} Running in CPU-only mode (no NVIDIA runtime detected)."
-        echo "  Inference will be slower. Install nvidia-container-toolkit for GPU acceleration."
+        error "Failed to restart services. Run manually: docker compose up -d"
+    fi
+
+    echo
+    echo "${BOLD}${GREEN}╔══════════════════════════════════════════════════════════════╗${RESET}"
+    echo "${BOLD}${GREEN}║  Upgrade complete!                                           ║${RESET}"
+    echo "${BOLD}${GREEN}╚══════════════════════════════════════════════════════════════╝${RESET}"
+    echo
+    echo "  Web UI: ${BOLD}${WEB_URL}${RESET}"
+    echo
+    echo "  To view logs:     docker compose logs -f"
+    echo "  To stop:          docker compose down"
+    echo
+else
+    step "Starting ScarGuard"
+    if docker compose up -d; then
+        info "Services started."
+    else
+        error "Failed to start services. Run manually: docker compose up -d"
+    fi
+
+    echo
+    echo "${BOLD}${GREEN}╔══════════════════════════════════════════════════════════════╗${RESET}"
+    echo "${BOLD}${GREEN}║  Setup complete!                                             ║${RESET}"
+    echo "${BOLD}${GREEN}╚══════════════════════════════════════════════════════════════╝${RESET}"
+    echo
+
+    if [[ "$NVIDIA_OK" == "false" ]]; then
+        if [[ "$PLATFORM" == "jetson" ]]; then
+            echo "${YELLOW}Reminder:${RESET} NVIDIA container runtime was not detected."
+            echo "  The detector service (GPU inference) will fail to start."
+            echo "  Log out and back in, then run:  docker compose up -d"
+        else
+            echo "${YELLOW}Note:${RESET} Running in CPU-only mode (no NVIDIA runtime detected)."
+            echo "  Inference will be slower. Install nvidia-container-toolkit for GPU acceleration."
+        fi
+        echo
+    fi
+
+    echo "${BOLD}Next steps:${RESET}"
+    echo
+    echo "  1. ${BOLD}Open the web UI:${RESET}"
+    echo "       ${WEB_URL}"
+    echo
+    echo "  2. ${BOLD}Configure your cameras:${RESET}"
+    echo "       Go to Settings and add your RTSP camera URLs."
+    if [[ -z "$MODEL_FILES" ]]; then
+        echo
+        echo "  3. ${BOLD}Add a YOLO model:${RESET}"
+        echo "       Upload via the Models page in the admin menu."
     fi
     echo
-fi
-
-if [[ "$CONFIG_IS_NEW" == "true" ]]; then
-    echo "${YELLOW}Important:${RESET} scarguard.yml was created from the example in the config volume."
-    echo "  Update your RTSP camera URLs before starting — the system will not"
-    echo "  detect anything until real camera streams are configured."
+    echo "  To view logs:     docker compose logs -f"
+    echo "  To stop:          docker compose down"
+    echo "  To update:        git pull && sudo bash setup.sh"
     echo
 fi
-
-echo "  To view logs:     docker compose logs -f"
-echo "  To stop:          docker compose down"
-echo "  To update images: docker compose pull && docker compose up -d"
-echo


### PR DESCRIPTION
## Summary

- **Fix stats chart range bug** — 24h/7d/30d historical charts were all showing ~6.9h of data due to a 5000-row default limit at 5-second intervals. Added `get_metrics_for_chart()` with SQL time-bucket downsampling to ~2000 points per chart regardless of range.
- **Refactor `run_camera()`** — Extract `_apply_exclusion_zones()`, `_evaluate_action_rules()`, `_publish_detections()` as module-level functions. Pure restructuring, no behavior change.
- **FairLock for inference** — Replace bare `threading.Lock()` in `YOLODetector` with FIFO `FairLock` (deque of `threading.Event`). Prevents high-FPS cameras from starving low-FPS cameras for GPU time. Includes 30s timeout safety and lock wait time logging (INFO at >500ms).
- **Fix ultralytics startup warning** — Pre-create `/tmp/ultralytics` with correct ownership in both Dockerfiles so the non-root user can write there.
- **setup.sh upgrade UX** — Detect existing install via `.env`, show "Upgrade Check" banner, skip TLS/model/admin prompts on upgrade. Auto-start/restart services in both paths. Fresh installs direct user to web UI for camera config instead of suggesting vi.

## Test plan

- [ ] Stats page: select 24h range — verify chart shows full 24 hours; 7d and 30d should show distinct wider ranges
- [ ] Detector startup: no ultralytics config dir warning in logs
- [ ] Upgrade path: `git pull && sudo bash setup.sh` — no interactive prompts beyond platform checks, services auto-restart
- [ ] Fresh install: full interactive flow, services auto-start, final message directs to web UI
- [ ] Multi-camera: with 2+ cameras sharing a model, verify both get fair inference time (check stats page FPS)
- [ ] Detector behavior: detection events, exclusion zones, action rules all work identically after refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)