### PR TITLE
feat(v0.13.0): deterrent service — Tuya Cloud physical deterrence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,18 @@ jobs:
             --build-arg BUILD_DATE=${{ github.event.head_commit.timestamp }} \
             .
 
+      # Trivy first — fail fast on CVEs before spending time on container tests.
+      - name: Trivy scan — web
+        if: github.event_name != 'push'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: scarguard-web:test
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          timeout: 20m0s
+
       # Uses docker create + cp instead of bind mounts (-v) because the
       # self-hosted runner uses Docker-in-Docker.  Bind mount paths reference
       # the outer host filesystem, not the runner container's filesystem,
@@ -92,17 +104,6 @@ jobs:
           rc=$?
           docker rm "$cid" > /dev/null
           exit $rc
-
-      - name: Trivy scan — web
-        if: github.event_name != 'push'
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: scarguard-web:test
-          format: table
-          exit-code: 1
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          timeout: 20m0s
 
       - name: Clean up
         if: always() && github.event_name != 'push'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,6 +170,68 @@ jobs:
         if: always() && github.event_name != 'push'
         run: docker rmi scarguard-notifier:test || true
 
+  # ── Build deterrent (x86 runner) ─────────────────────────────────────────────
+  build-deterrent:
+    name: Build deterrent image
+    runs-on: [self-hosted, linux, docker]
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build deterrent (validate only, no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/deterrent/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          provenance: false
+          cache-from: type=gha,scope=deterrent
+          cache-to: type=gha,scope=deterrent,mode=max
+
+      # ── Test + scan (PR only — main push only warms build cache) ──────────
+      - name: Build deterrent (amd64, load for test)
+        if: github.event_name != 'push'
+        run: |
+          docker build \
+            --tag scarguard-deterrent:test \
+            --file services/deterrent/Dockerfile \
+            .
+
+      - name: Test deterrent in container
+        if: github.event_name != 'push'
+        run: |
+          cid=$(docker create --user root --entrypoint "" scarguard-deterrent:test sh -c "pip install --quiet pytest && python3 -m pytest /app/tests/ -v --tb=short")
+          docker cp ${{ github.workspace }}/services/deterrent/tests/. "$cid:/app/tests/"
+          docker cp ${{ github.workspace }}/shared/. "$cid:/app/shared/"
+          docker start -a "$cid"
+          rc=$?
+          docker rm "$cid" > /dev/null
+          exit $rc
+
+      - name: Trivy scan — deterrent
+        if: github.event_name != 'push'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: scarguard-deterrent:test
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          timeout: 20m0s
+
+      - name: Clean up
+        if: always() && github.event_name != 'push'
+        run: docker rmi scarguard-deterrent:test || true
+
   # ── Build caddy (x86 runner) ────────────────────────────────────────────────
   build-caddy:
     name: Build caddy image
@@ -340,7 +402,7 @@ jobs:
   compose-smoke-test:
     name: Compose smoke test
     if: github.event_name != 'push'
-    needs: [build-detector-x86, build-web, build-notifier, build-caddy, build-log-streamer]
+    needs: [build-detector-x86, build-web, build-notifier, build-deterrent, build-caddy, build-log-streamer]
     runs-on: [self-hosted, linux, docker]
 
     steps:
@@ -365,6 +427,7 @@ jobs:
             --build-arg VERSION=dev-${{ github.sha }} \
             --build-arg GIT_COMMIT=${{ github.sha }} .
           docker build -f services/notifier/Dockerfile -t scarguard-notifier:smoke .
+          docker build -f services/deterrent/Dockerfile -t scarguard-deterrent:smoke .
           docker build -f services/caddy/Dockerfile -t scarguard-caddy:smoke .
           docker build -f services/log-streamer/Dockerfile -t scarguard-log-streamer:smoke .
 
@@ -439,5 +502,5 @@ jobs:
         run: |
           docker compose down -v || true
           docker rmi scarguard-detector-x86:smoke scarguard-web:smoke \
-            scarguard-notifier:smoke scarguard-caddy:smoke \
-            scarguard-log-streamer:smoke 2>/dev/null || true
+            scarguard-notifier:smoke scarguard-deterrent:smoke \
+            scarguard-caddy:smoke scarguard-log-streamer:smoke 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
             services/detector/src \
             services/web/src \
             services/notifier/src \
+            services/deterrent/src \
             services/log-streamer/src \
             shared
 
@@ -56,7 +57,8 @@ jobs:
         run: |
           pip install mypy types-PyYAML types-requests \
             -r services/web/requirements.txt \
-            -r services/notifier/requirements.txt
+            -r services/notifier/requirements.txt \
+            -r services/deterrent/requirements.txt
 
       - name: mypy — web
         env:
@@ -71,6 +73,14 @@ jobs:
           MYPYPATH: services/notifier/src:shared
         run: |
           mypy services/notifier/src shared \
+            --ignore-missing-imports \
+            --explicit-package-bases
+
+      - name: mypy — deterrent
+        env:
+          MYPYPATH: services/deterrent/src:shared
+        run: |
+          mypy services/deterrent/src shared \
             --ignore-missing-imports \
             --explicit-package-bases
 
@@ -113,3 +123,23 @@ jobs:
         env:
           PYTHONPATH: services/notifier/src:shared
         run: pytest services/notifier/tests/ -v
+
+  # ── Tests — deterrent ──────────────────────────────────────────────────────
+  test-deterrent:
+    name: Tests — deterrent
+    runs-on: [self-hosted, linux, generic]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install deps
+        run: pip install -r services/deterrent/requirements.txt pytest
+
+      - name: pytest
+        env:
+          PYTHONPATH: services/deterrent/src:shared
+        run: pytest services/deterrent/tests/ -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,46 @@ jobs:
         if: always()
         run: docker image prune -f
 
+  # ── Build & push — deterrent (x86 runner) ──────────────────────────────────
+  release-deterrent:
+    name: Release deterrent image
+    runs-on: [self-hosted, linux, docker]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push — deterrent
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/deterrent/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/scarguard-deterrent:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/scarguard-deterrent:latest
+          cache-from: type=gha,scope=deterrent
+          cache-to: type=gha,scope=deterrent,mode=max
+
+      - name: Prune dangling images
+        if: always()
+        run: docker image prune -f
+
   # ── Build & push — caddy (x86 runner) ──────────────────────────────────────
   release-caddy:
     name: Release caddy image
@@ -412,7 +452,7 @@ jobs:
   # with auto-generated notes so there's a visible changelog on the repo.
   create-release:
     name: Create GitHub Release
-    needs: [release-web, release-notifier, release-caddy, release-log-streamer, release-detector, release-detector-x86]
+    needs: [release-web, release-notifier, release-deterrent, release-caddy, release-log-streamer, release-detector, release-detector-x86]
     runs-on: [self-hosted, linux, generic]
     permissions:
       contents: write
@@ -460,6 +500,7 @@ jobs:
           | detector (x86) | `ghcr.io/{owner}/scarguard-detector-x86:{tag}` | x86_64 (CUDA + CPU) |
           | web | `ghcr.io/{owner}/scarguard-web:{tag}` | amd64, arm64 |
           | notifier | `ghcr.io/{owner}/scarguard-notifier:{tag}` | amd64, arm64 |
+          | deterrent | `ghcr.io/{owner}/scarguard-deterrent:{tag}` | amd64, arm64 |
           | caddy | `ghcr.io/{owner}/scarguard-caddy:{tag}` | amd64, arm64 |
           | log-streamer | `ghcr.io/{owner}/scarguard-log-streamer:{tag}` | amd64, arm64 |
 

--- a/ACTUATION_SPEC.md
+++ b/ACTUATION_SPEC.md
@@ -1,22 +1,36 @@
-# ScarGuard Actuation MVP — Specification
+# ScarGuard Deterrent Service — Specification
 
-**Version:** 0.1 (draft)
-**Target ScarGuard Release:** v0.2.x
+**Version:** 0.2
+**Target ScarGuard Release:** v0.13.x
 **Author:** Scott / Claude (design collaboration)
-**Date:** 2026-04-06
+**Date:** 2026-04-12
 
 ---
 
 ## Overview
 
-This document specifies the MVP actuation subsystem for ScarGuard — the ability to trigger sprinkler valves in response to wildlife detection events. The design prioritizes minimal physical integration (no custom wiring, soldering, or relay boards) by using off-the-shelf WiFi smart hose timer valves controlled via the Tuya local API.
+This document specifies the deterrent subsystem for ScarGuard — the ability to trigger physical deterrence devices (sprinklers, lights, sirens, smart plugs) in response to wildlife detection events. The design uses off-the-shelf Tuya/Smart Life ecosystem devices controlled via the **Tuya Cloud API** (`tinytuya.Cloud`).
 
 ### Design Principles
 
-- **No custom hardware.** All actuation hardware is commercially available, hose-thread, battery-powered, and WiFi-connected.
-- **Software-defined actuation.** Randomization logic, zone selection, timing, and cooldowns are handled entirely in a new Docker Compose service on the Orin.
-- **LAN-only control.** Valve commands are sent via `tinytuya` over the local network. No cloud API dependency at runtime.
-- **Seasonal deployment.** System is deployed spring through fall (Wisconsin climate). Batteries are swapped and hoses connected at season start; hoses are disconnected and valves stored for winter.
+- **No custom hardware.** All deterrent hardware is commercially available, WiFi-connected, and battery or mains powered.
+- **Software-defined deterrence.** Randomization logic, device selection, timing, and cooldowns are handled entirely in a new Docker Compose service (`deterrent`) on the host.
+- **Cloud API control.** Device commands are sent via `tinytuya.Cloud` (HTTPS to Tuya's OpenAPI). Local LAN control is not viable for battery-powered devices — they deep-sleep with WiFi radio off between cloud check-ins.
+- **Multi-device-type support.** Not limited to sprinkler valves — any Tuya-compatible smart device (lights, sirens, smart plugs) can be used as a deterrent.
+- **Seasonal deployment.** Sprinkler hardware is deployed spring through fall (Wisconsin climate). Batteries are swapped and hoses connected at season start; hoses are disconnected and valves stored for winter. Lights and sirens may remain year-round.
+
+### Changes from v0.1
+
+| Area | v0.1 (superseded) | v0.2 (current) |
+|------|-------------------|----------------|
+| Control method | `tinytuya` LAN TCP | `tinytuya.Cloud` HTTPS |
+| Service name | `actuator` | `deterrent` |
+| Device types | Sprinkler valves only | Sprinklers, lights, sirens, smart plugs |
+| Config fields | `local_key`, `ip`, `protocol_version` | `api_key`, `api_secret`, `api_region` |
+| Network requirements | LAN access (UDP 6666-6667, TCP 6668) | Outbound HTTPS only |
+| Response profiles | None (all devices fire) | Planned for 0.13.x (species-based routing) |
+
+**Why Cloud API?** Battery-powered Tuya devices enter deep sleep between cloud check-ins to conserve battery. The WiFi radio is powered down during sleep. Local LAN discovery (`tinytuya` scan on UDP 6666-6667) finds nothing, and TCP connections to port 6668 fail with "No route to host" because the device doesn't respond to ARP. Cloud commands work because the device polls the Tuya cloud on wake (~1-2s intervals) and picks up queued commands. This was validated on 2026-04-12 with a GreenVation WiFi sprinkler valve (device ID `eb074b33939a9f6effqm7l`).
 
 ---
 
@@ -26,32 +40,28 @@ This document specifies the MVP actuation subsystem for ScarGuard — the abilit
 
 | Qty | Item | Purpose | Est. Cost | Notes |
 |-----|------|---------|-----------|-------|
-| 4 | Tuya/Smart Life WiFi hose timer valve | Sprinkler zone control | $25–40 ea | Must use **Smart Life** or **Tuya Smart** app (not proprietary app). See Valve Selection below. |
-| 4 | Garden hose (appropriate length) | Water delivery to sprinkler heads | Varies | Length depends on hose bib to pond distance. Seasonal surface deployment — no burial needed. |
-| 4 | Sprinkler heads | Water dispersion around pond | $5–15 ea | Impact, oscillating, or fixed-pattern — pick based on coverage area. Aim toward pond perimeter. |
-| 16+ | AA batteries | Valve power | $10–15 (bulk) | 4x AA per valve. Replace at season start. Budget one extra set mid-season. |
-| 1 | Hose splitter (4-way) | Single hose bib to 4 lines | $15–25 | Brass preferred. Individual shutoffs per port are nice but not required. |
+| 1-4 | Tuya/Smart Life WiFi hose timer valve | Sprinkler zone control | $25-40 ea | Must use Smart Life or Tuya Smart app |
+| 1-4 | Garden hose + sprinkler heads | Water delivery | Varies | Length depends on layout |
+| 16+ | AA batteries | Valve power | $10-15 (bulk) | 4x AA per valve, replace seasonally |
+| 1 | Hose splitter (4-way) | Single hose bib to multiple lines | $15-25 | Brass preferred |
+| 0-2 | Tuya smart lights/plugs | Light deterrence | $10-20 ea | Optional — for night-time raccoon deterrence |
+| 0-1 | Tuya smart siren/alarm | Sound deterrence | $15-30 | Optional |
 
-**Estimated total: $175–275** depending on hose lengths and sprinkler choice.
+**Estimated total: $100-350** depending on configuration.
 
-### Valve Selection Criteria
+### Device Selection Criteria
 
-When purchasing valves, confirm ALL of the following:
+1. **Smart Life / Tuya Smart app compatible.** Must reference the "Smart Life" or "Tuya Smart" app.
+2. **2.4GHz WiFi.** All Tuya devices are 2.4GHz only.
+3. **Battery-powered devices work via Cloud API** but NOT via LAN control. Mains-powered devices may support both (future LAN fallback, unprioritized).
+4. **Standard garden hose fittings** for sprinkler valves (3/4" GHT).
 
-1. **Smart Life / Tuya Smart app compatible.** The product listing or packaging must reference the "Smart Life" or "Tuya Smart" app. This is what makes `tinytuya` local control possible.
-2. **2.4GHz WiFi.** All Tuya devices are 2.4GHz only — confirm your WiFi network broadcasts a 2.4GHz SSID the valves can reach at the pond.
-3. **Standard 3/4" garden hose thread (GHT).** Fits any standard US garden hose bib and hose.
-4. **No hub required (preferred).** Hub-free models simplify the stack. If a hub is required, one hub typically supports 4 valves.
-5. **Battery powered (4x AA).** Confirms DC solenoid operation and seasonal battery swap.
+**Known compatible:**
+- [GreenVation WiFi Sprinkler Timer](https://www.amazon.com/dp/B0G41G99YR) — PoC validated
+- VEVOR WiFi Sprinkler Timer (hub-free models)
+- Generic Tuya WiFi irrigation timers (verify Smart Life app compatibility)
 
-**Known compatible product lines (Tuya-based):**
-
-- RAINPOINT T-series (TTV103WRF — requires TWG004 hub)
-- VEVOR WiFi Sprinkler Timer (Smart Life app, hub-free models available)
-- Generic "Tuya WiFi irrigation timer" listings on Amazon (verify Smart Life app compatibility in listing/reviews)
-- [Valve purchased for PoC] (https://www.amazon.com/Sprinkler-GreenVation-Automatic-Watering-Irrigation/dp/B0G41G99YR/ref=sr_1_6?crid=H7IHM37EBJCT&dib=eyJ2IjoiMSJ9.qcdu0TSfg0GoazuKs5eQBSKTn9aTqGdQAYhIdujsFwtK4zStLneBAqXtRYsxOedVG_-V9i8Klzz0URDu4IJKAh4aRyZm4i8xd3KYPjhJvH6_79OLwRwpb87a997HjNIXFmuGhXjDJAm3iHIHH4wyWX875og9wmYPeh7O3SDzMpfq3sun6PNOfFiPBAmMdVN8nUK5EwtUAxpGlfnnNBRuCe6Q0dExVf318tuy_HK8HnRB3ytL6eGCRzUqRxCmdIexHXmy8qyuJAGplFC_PvBRCJ7_eOYPn9Nb49lLj99Pzto.UQSlSJscIwJSCC5Eeszh6_eQDdrj2Vr0026ciE1V6v0&dib_tag=se&keywords=Tuya%2BWiFi%2Bwater%2Btimer%2Bhose%2BSmart%2BLife%2Bno%2Bhub&nsdOptOutParam=true&qid=1775494442&sprefix=tuya%2Bwifi%2Bwater%2Btimer%2Bhose%2Bsmart%2Blife%2Bno%2Bhub%2Caps%2C230&sr=8-6&th=1)
-
-**Avoid:** RainPoint H-series (HTV*) — these use RainPoint's proprietary "Home" app and are NOT Tuya-compatible. The hardware protocols are incompatible.
+**Avoid:** RainPoint H-series (proprietary app, NOT Tuya-compatible).
 
 ---
 
@@ -59,60 +69,52 @@ When purchasing valves, confirm ALL of the following:
 
 ### Integration Point
 
-The actuation subsystem integrates into the existing ScarGuard stack as a new Docker Compose service (`actuator`). It subscribes to the same Redis pub/sub channel (`scarguard:detections`) that the notifier already consumes.
-
 ```
 ┌──────────┐    RTSP     ┌──────────┐   Redis pub/sub   ┌───────────┐
-│ Cameras  │────────────▶│ Detector │──────────────────▶│ Notifier  │
+│ Cameras  │────────────>│ Detector │──────────────────>│ Notifier  │
 └──────────┘             └──────────┘        │          └───────────┘
                                              │
-                                             ▼
-                                       ┌───────────┐   tinytuya    ┌─────────────┐
-                                       │ Actuator  │──────────────▶│ WiFi Valves │
-                                       └───────────┘   (LAN TCP)   └─────────────┘
+                                             v
+                                       ┌───────────┐  tinytuya.Cloud  ┌─────────────────┐
+                                       │ Deterrent │─────────────────>│ Tuya Cloud API  │
+                                       └───────────┘     (HTTPS)      └────────┬────────┘
+                                                                               │
+                                                                               v
+                                                                     ┌─────────────────┐
+                                                                     │ Smart Devices   │
+                                                                     │ (valves, lights,│
+                                                                     │  sirens, plugs) │
+                                                                     └─────────────────┘
 ```
 
-### Actuator Service
+### Deterrent Service
 
 | Property | Value |
 |----------|-------|
 | Base image | `python:3.11-slim` |
 | Dependencies | `tinytuya`, `pyyaml`, `redis`, `pydantic` |
-| Config source | `config/scarguard.yml` (mounted read-only) |
+| Config source | `scarguard.yml` (mounted read-only) |
 | Redis dependency | Same Redis instance as detector/notifier |
-| Network requirements | LAN access to valve IP addresses (UDP 6666-6667, 7000; TCP 6668) |
+| Network requirements | **Outbound HTTPS** to `openapi.tuyaus.com` (or regional equivalent). No inbound ports needed. |
 | Resource usage | Negligible CPU/RAM — event-driven, sleeps between detections |
-
-### docker-compose.yml Addition
-
-```yaml
-  # ── Actuator ──────────────────────────────────────────────────────────────
-  actuator:
-    build:
-      context: .
-      dockerfile: services/actuator/Dockerfile
-    image: ghcr.io/${GHCR_OWNER:-sentania-labs}/scarguard-actuator:${IMAGE_TAG:-latest}
-    environment:
-      CONFIG_PATH: /config/scarguard.yml
-    volumes:
-      - ./config:/config:ro
-    depends_on:
-      redis:
-        condition: service_healthy
-    restart: unless-stopped
-```
 
 ### Service Directory Structure
 
 ```
-services/actuator/
+services/deterrent/
 ├── Dockerfile
+├── entrypoint.sh
 ├── requirements.txt
-└── src/
-    ├── main.py           # Entry point: Redis subscriber, event dispatcher
-    ├── valve_controller.py  # tinytuya device management, on/off commands
-    ├── randomizer.py     # Zone selection, duration, delay randomization
-    └── battery_monitor.py   # Periodic battery status polling
+├── src/
+│   ├── main.py              # Redis subscriber, event dispatcher, config reload
+│   ├── cloud_controller.py  # tinytuya.Cloud wrapper — on/off commands, status queries
+│   ├── randomizer.py        # Device selection, duration/delay randomization
+│   ├── cooldown.py          # Global cooldown tracker
+│   ├── models.py            # Pydantic models for config and actuation events
+│   └── battery_monitor.py   # Periodic battery polling via Cloud API
+└── tests/
+    ├── test_randomizer.py
+    └── test_cooldown.py
 ```
 
 ---
@@ -122,100 +124,112 @@ services/actuator/
 ### scarguard.yml — Actuation Section
 
 ```yaml
-actuation:
+deterrent:
   enabled: true
 
-  # Randomization parameters
-  min_valves: 1              # Minimum valves to fire per event
-  max_valves: 4              # Maximum valves to fire per event
-  spray_duration_min_sec: 3  # Minimum spray time per valve
-  spray_duration_max_sec: 8  # Maximum spray time per valve
-  inter_spray_delay_min_sec: 1  # Min pause between valve activations
-  inter_spray_delay_max_sec: 5  # Max pause between valve activations
-  pre_delay_min_sec: 0       # Min delay before first spray (post-detection)
-  pre_delay_max_sec: 3       # Max delay before first spray
+  # Tuya Cloud API credentials — see TUYA_SETUP.md for how to obtain these
+  tuya:
+    api_key: "your-access-id"
+    api_secret: "your-access-secret"
+    api_region: "us"              # us | eu | cn | in
 
-  # Cooldown — prevents continuous firing if animal persists
-  cooldown_seconds: 60
+  # Device definitions — one entry per physical device
+  devices:
+    - name: pond-north-valve
+      device_id: "bf1234567890abcdef"
+      type: sprinkler              # sprinkler | light | sound | plug
+      enabled: true
+
+    - name: pond-light
+      device_id: "bf0987654321fedcba"
+      type: light
+      enabled: true
+
+  # Randomization ranges
+  defaults:
+    device_count_range: [1, 4]
+    spray_duration_range: [3, 8]
+    inter_device_delay_range: [1, 5]
+    pre_delay_range: [0, 3]
+    cooldown_seconds: 60
 
   # Battery monitoring
-  battery_check_enabled: true
-  battery_check_interval_hours: 24
-  battery_alert_threshold_percent: 20  # Alert via notifications when below this
-
-  # Valve definitions
-  valves:
-    - name: pond-north
-      device_id: "bf1234567890abcdef"
-      local_key: "abcdef1234567890"
-      ip: "172.16.1.100"
-      protocol_version: "3.3"
-      enabled: true
-
-    - name: pond-east
-      device_id: "bf0987654321fedcba"
-      local_key: "fedcba0987654321"
-      ip: "172.16.1.101"
-      protocol_version: "3.3"
-      enabled: true
-
-    - name: pond-south
-      device_id: "bf1122334455667788"
-      local_key: "8877665544332211"
-      ip: "172.16.1.102"
-      protocol_version: "3.3"
-      enabled: true
-
-    - name: pond-west
-      device_id: "bfaabbccddeeff0011"
-      local_key: "1100ffeeddccbbaa"
-      ip: "172.16.1.103"
-      protocol_version: "3.3"
-      enabled: true
+  battery_monitor:
+    enabled: true
+    check_interval_hours: 24
+    alert_threshold_percent: 20
 ```
 
 ### Config Notes
 
-- `device_id`, `local_key`, and `ip` are obtained via the `tinytuya` wizard (one-time setup).
-- `protocol_version` is typically `"3.3"` or `"3.4"` for current Tuya devices. The wizard reports this.
-- Individual valves can be disabled without removing them from config.
-- Assign static IPs or DHCP reservations on the UDM for each valve to prevent IP drift.
+- `api_key` and `api_secret` are obtained from the Tuya IoT Platform — see [TUYA_SETUP.md](TUYA_SETUP.md) for the full walkthrough.
+- `api_region` must match the Data Center selected during project creation.
+- No `local_key`, `ip`, or `protocol_version` fields — Cloud API doesn't need them.
+- Individual devices can be disabled without removing them from config.
+- Config hot-reloads without service restart (via `ConfigWatcher`).
 
 ---
 
 ## Actuation Logic
 
-### Event Flow
+### Event Flow (MVP — v0.13.0)
 
 1. Detector publishes detection event to Redis channel `scarguard:detections`.
-2. Actuator receives event, checks: is system armed? Is actuation enabled? Is cooldown active?
-3. If clear, randomizer selects parameters: which valves (random subset of enabled valves), spray duration per valve (random within range), inter-spray delay, and pre-delay.
-4. After pre-delay, actuator fires selected valves sequentially with randomized timing.
-5. Each valve command is: connect via tinytuya → set switch DP to `True` → sleep for duration → set switch DP to `False` → disconnect.
+2. Deterrent receives event, checks: is system armed? Is actuation enabled? Is cooldown clear?
+3. If clear, randomizer selects parameters: which devices (random subset of enabled), activation duration per device (random within range), inter-device delay, and pre-delay.
+4. After pre-delay, deterrent fires selected devices sequentially with randomized timing.
+5. Each device command: `tinytuya.Cloud.sendcommand()` → set DP to `True` → sleep for duration → set DP to `False`.
 6. Cooldown timer starts after sequence completes.
-7. Actuation events are published back to Redis (channel: `scarguard:actuations`) for the web UI and notifier to consume.
+7. Actuation events are published to Redis (channel: `scarguard:actuations`).
+
+### Response Profiles (v0.13.x — future)
+
+Species-based routing with time-of-day conditions:
+
+```yaml
+  response_profiles:
+    - name: heron-thermonuclear
+      match:
+        species: [great_blue_heron, green_heron]
+      device_types: [sprinkler, light, sound, plug]
+      devices: all
+
+    - name: raccoon-night
+      match:
+        species: [raccoon]
+        time_of_day: [sunset, sunrise]
+      device_types: [light, sound]
+
+    - name: duck-gentle
+      match:
+        species: [duck]
+      device_types: [sprinkler]
+      device_count_range: [1, 2]
+```
 
 ### Randomization Parameters
 
-All randomization uses `random.uniform()` (continuous) or `random.sample()` (valve selection) per event. No two events should produce identical patterns.
-
 | Parameter | Range (default) | Purpose |
 |-----------|----------------|---------|
-| Valve count | 1–4 | How many valves fire |
-| Valve selection | Random subset of enabled valves | Which valves fire |
-| Spray duration | 3–8 seconds per valve | How long each valve stays open |
-| Inter-spray delay | 1–5 seconds | Pause between sequential valve activations |
-| Pre-delay | 0–3 seconds | Delay before first spray (breaks association between camera/box and spray) |
+| Device count | 1-4 | How many devices fire |
+| Device selection | Random subset of enabled devices | Which devices fire |
+| Spray duration | 3-8 seconds per device | How long each device stays on |
+| Inter-device delay | 1-5 seconds | Pause between sequential activations |
+| Pre-delay | 0-3 seconds | Delay before first activation |
 
 ### Cooldown
 
-After an actuation sequence completes, the actuator ignores further detection events for `cooldown_seconds`. This prevents continuous firing when an animal lingers. Detection events that arrive during cooldown are logged but not acted on.
+After an actuation sequence completes, the deterrent ignores further detection events for `cooldown_seconds`. Events arriving during cooldown are logged but not acted on.
 
 ### Failure Handling
 
-- **Valve unreachable:** Log error, skip that valve, continue with remaining valves in sequence. Do not fail the entire actuation because one valve is offline.
-- **All valves unreachable:** Log error, publish a notification event (so Discord/email alerts fire).
-- **Redis disconnection:** Reconnect with backoff (same pattern as notifier service).
+- **Device unreachable:** Log error, skip that device, continue with remaining devices. Do not fail the entire sequence because one device is offline.
+- **All devices unreachable:** Log error, publish a notification event.
+- **Redis disconnection:** Reconnect with exponential backoff (same pattern as notifier).
+
+### Cloud API Rate Limits
+
+Tuya's free tier allows approximately 500 API calls/day. Each actuation uses ~2 calls per device (ON + OFF). With 4 devices and a 60-second cooldown, you'd need ~60 events/day to approach the limit. Monitor usage if you have high detection volumes.
 
 ---
 
@@ -223,114 +237,70 @@ After an actuation sequence completes, the actuator ignores further detection ev
 
 ### Polling
 
-A background task in the actuator service queries each valve's status DPs once per `battery_check_interval_hours` (default: 24 hours). This is a single short-lived TCP connection per valve — connect, query `device.status()`, parse battery DP, disconnect.
+A background thread queries each device's status DPs once per `check_interval_hours` (default: 24). Uses `tinytuya.Cloud.getstatus()` — a single HTTPS call per device.
 
 ### Alerting
 
-When any valve's battery percentage drops below `battery_alert_threshold_percent`, the actuator publishes a notification event to Redis channel `scarguard:notifications` with type `battery_low` and the valve name/level. The notifier service dispatches this via the same Discord/email channels used for detection alerts.
+When any device's battery drops below `alert_threshold_percent`, the deterrent publishes a notification event to Redis. The notifier dispatches alerts via the same channels used for detection alerts.
 
 ### Data Storage
 
-Battery readings are written to SQLite (`data/scarguard.db`) in an `actuator_status` table for historical tracking and web UI display.
-
-```sql
-CREATE TABLE IF NOT EXISTS actuator_status (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    valve_name TEXT NOT NULL,
-    battery_percent INTEGER,
-    reachable BOOLEAN NOT NULL DEFAULT 1,
-    checked_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-```
+Battery readings are written to SQLite for historical tracking and future web UI display.
 
 ---
 
-## Valve Setup Procedure (One-Time)
+## Device Setup
 
-### 1. Pair valves in Smart Life app
+See [TUYA_SETUP.md](TUYA_SETUP.md) for the complete step-by-step guide covering:
 
-Install the Smart Life app on your phone. Create an account (or use existing). Pair each valve following the manufacturer's instructions. Verify you can manually open/close each valve from the app.
-
-### 2. Create Tuya IoT developer project
-
-Go to `iot.tuya.com`, create a free developer account. Create a Cloud Development project. Subscribe to the "Smart Home Device Management" API. Link your Smart Life app account by scanning the QR code in the Tuya IoT console.
-
-### 3. Run tinytuya wizard
-
-On your dev machine (or any machine on the same LAN):
-
-```bash
-pip install tinytuya
-python -m tinytuya wizard
-```
-
-Enter your Tuya IoT API ID, Secret, and Region when prompted. The wizard outputs a `devices.json` with each device's `id`, `key` (local_key), and `ip`. Copy these values into `scarguard.yml`.
-
-### 4. Assign static IPs
-
-In the UDM console, create DHCP reservations for each valve's MAC address so the IPs don't change.
-
-### 5. Test connectivity
-
-```bash
-python -c "
-import tinytuya
-d = tinytuya.OutletDevice('DEVICE_ID', 'DEVICE_IP', 'LOCAL_KEY', version=3.3)
-print(d.status())
-"
-```
-
-You should get a JSON response with the device's data points. If you see a switch DP (usually DP `1`), you can test toggling it.
-
-### 6. Firewall rules
-
-Ensure your UDM firewall allows the Orin to reach the valve IPs on UDP 6666-6667, 7000 and TCP 6668. On a flat home LAN this is typically open by default.
+1. Creating a Tuya IoT Platform account
+2. Creating a Cloud Development project
+3. Subscribing to required API services
+4. Linking your Smart Life app account
+5. Obtaining API credentials and device IDs
+6. Configuring ScarGuard
 
 ---
 
-## Web UI Integration (Future)
+## Web UI Integration (v0.13.x)
 
-The following are out of scope for the actuation MVP but should be planned for:
+Out of scope for the MVP but planned:
 
-- **Actuation log tab:** Show actuation events with timestamp, valves fired, durations, and triggering detection event.
-- **Valve status panel:** Show each valve's name, enabled/disabled state, last battery reading, and reachability.
-- **Manual trigger button:** Fire a test actuation sequence from the web UI (useful for aiming sprinklers during setup).
-- **Actuation config in GUI:** Expose randomization parameters and valve definitions in the config editor.
+- **Deterrent config page:** Dedicated page (not inline in main config) for Tuya credentials, device list, randomization params, and battery monitoring settings. Main config page shows just an enable/disable toggle.
+- **Actuation log:** Show actuation events with timestamp, devices fired, durations, and triggering detection.
+- **Device status panel:** Each device's name, enabled state, last battery reading, and reachability.
+- **Manual trigger button:** Fire a test sequence from the web UI.
 
 ---
 
 ## CI/CD
 
-The actuator service uses `python:3.11-slim` (same as web and notifier), so it builds on both x86 and ARM64 via the existing multi-arch buildx workflow. No GPU or Jetson-specific dependencies.
+The deterrent service uses `python:3.11-slim` (same as web and notifier), so it builds on both x86 and ARM64. No GPU dependencies.
 
-Add to `ci.yml`:
-
-- Lint and type check `services/actuator/`
-- Build and push `scarguard-actuator` image alongside web and notifier
-- Same `runs-on` as web/notifier builds (x86 runners, multi-arch via QEMU)
+- `ci.yml`: Lint (`ruff`), type check (`mypy`), and `pytest` for `services/deterrent/`
+- `build.yml`: Build and push `scarguard-deterrent` image
+- `release.yml`: Include deterrent in the release image matrix
 
 ---
 
-## Open Questions
+## Resolved Questions (from v0.1)
 
-1. **DP mapping varies by manufacturer.** The switch DP is usually `1`, but battery percentage DP ID varies. Need to discover DPs for the specific valve model purchased using `device.detect_available_dps()` and document the mapping.
-
-2. **Actuation event schema.** Define the Pydantic model for actuation events published to Redis. Should include: event_id, triggering_detection_id, valves_fired (list with name/duration), total_sequence_time, timestamp.
-
-3. **Config hot-reload.** Should the actuator watch `scarguard.yml` for changes (matching detector/notifier behavior), or is a container restart acceptable for config changes? Recommend: match existing hot-reload pattern for consistency.
-
-4. **Web UI actuation log.** Should actuation events write to the existing `events` table with a new event type, or a dedicated `actuations` table? Recommend: dedicated table to keep schemas clean.
+1. **DP mapping:** Default DP codes per device type (`switch_1` for sprinklers/plugs, `switch_led` for lights, `switch` for sirens). Per-device `dp_code` override available in config.
+2. **Actuation event schema:** Pydantic `ActuationEvent` model with trigger info, device actions (name, type, duration, success/error), total duration.
+3. **Config hot-reload:** Yes — uses `ConfigWatcher` + `AtomicRef`, matching existing service pattern.
+4. **Web UI actuation log:** Deferred to 0.13.x. Events published to `scarguard:actuations` Redis channel for future consumption.
 
 ---
 
 ## Acceptance Criteria
 
-- [ ] Actuator service starts, connects to Redis, and subscribes to `scarguard:detections`
-- [ ] On detection event (system armed, actuation enabled, cooldown clear): randomized valve sequence fires
-- [ ] Valves physically open and close via tinytuya LAN commands
+- [ ] Deterrent service starts, connects to Redis, and subscribes to `scarguard:detections`
+- [ ] On detection event (system armed, actuation enabled, cooldown clear): randomized device sequence fires
+- [ ] Devices activate and deactivate via Tuya Cloud API commands
 - [ ] Cooldown prevents re-firing within configured window
-- [ ] Unreachable valves are skipped without failing the sequence
+- [ ] Unreachable devices are skipped without failing the sequence
 - [ ] Battery monitor runs on configured interval and publishes alerts below threshold
-- [ ] Actuation events are logged to SQLite
+- [ ] Actuation events are published to `scarguard:actuations` Redis channel
 - [ ] Service follows existing patterns: config from `scarguard.yml`, Python 3.11, type hints, Pydantic models, structured logging
 - [ ] Docker image builds in CI alongside web/notifier
+- [ ] `TUYA_SETUP.md` provides L100-level instructions for L200/L300 Tuya Cloud setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ Named after Scar (aka Kroger), a survivor fish badly injured by a heron who live
 
 ## What This Is
 
-A containerized wildlife detection and notification system. Watches RTSP camera feeds for target species (herons, ducks, raccoons) and sends real-time notifications (Discord, email, webhooks) enabling downstream response to protect a backyard koi pond. ScarGuard is detection and notification only — physical deterrence is handled by downstream systems (future companion project: Scar's Revenge). Works with any RTSP camera and any Docker host with an NVIDIA GPU.
+A containerized wildlife detection and notification system. Watches RTSP camera feeds for target species (herons, ducks, raccoons) and sends real-time notifications (Discord, email, webhooks) enabling downstream response to protect a backyard koi pond. ScarGuard handles detection, notification, and physical deterrence (sprinklers, lights, sirens via Tuya Cloud API). Works with any RTSP camera and any Docker host with an NVIDIA GPU.
 
 ## Tech Stack (Reference Setup)
 
 - **Compute:** NVIDIA Jetson Orin Nano, JetPack 6.2.1 (L4T 36.4.7) — any NVIDIA GPU host works
 - **Cameras:** 2x UniFi (G3 Flex + G5 Flex) via RTSP — any RTSP camera works
-- **Services:** Docker Compose with 4 containers: Redis, Detector, Web (FastAPI + Jinja), Notifier
+- **Services:** Docker Compose with 5 containers: Redis, Detector, Web (FastAPI + Jinja), Notifier, Deterrent
 - **Detection:** YOLO model on GPU, OpenCV RTSP ingestion
 - **IPC:** Redis pub/sub as internal message bus
 - **Database:** SQLite (single writer, no Postgres)
@@ -69,7 +69,7 @@ Run these before considering any code change done (mirrors CI exactly):
 
 ```bash
 # Ruff — all services (detector included; no GPU deps needed)
-ruff check services/detector/src services/web/src services/notifier/src shared
+ruff check services/detector/src services/web/src services/notifier/src services/deterrent/src shared
 
 # mypy — web (detector is excluded from CI: torch/opencv not available outside L4T)
 MYPYPATH=services/web/src:shared \
@@ -78,6 +78,10 @@ MYPYPATH=services/web/src:shared \
 # mypy — notifier
 MYPYPATH=services/notifier/src:shared \
   python3 -m mypy services/notifier/src shared --ignore-missing-imports --explicit-package-bases
+
+# mypy — deterrent
+MYPYPATH=services/deterrent/src:shared \
+  python3 -m mypy services/deterrent/src shared --ignore-missing-imports --explicit-package-bases
 ```
 
 Required packages (if not already installed): `pip install ruff mypy types-PyYAML types-requests types-redis`

--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -275,8 +275,43 @@ ScarGuard supports three operating modes controlled by `system.armed` and the op
 
 The schedule is entirely optional. If the `schedule` key is missing, `enabled` is false, or both time fields are empty, no automatic transitions occur and the armed state is under manual control only.
 
+## Actuation (Physical Deterrence)
+
+The `deterrent` section configures the deterrent service — automated physical deterrence via Tuya Cloud API. See [TUYA_SETUP.md](TUYA_SETUP.md) for obtaining API credentials.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `deterrent.enabled` | bool | `false` | Master toggle for physical deterrence |
+| `deterrent.tuya.api_key` | str | — | Tuya IoT Platform Access ID |
+| `deterrent.tuya.api_secret` | str | — | Tuya IoT Platform Access Secret |
+| `deterrent.tuya.api_region` | str | `"us"` | Tuya data center: `us`, `eu`, `cn`, `in` |
+| `deterrent.devices[].name` | str | — | Human-readable device name |
+| `deterrent.devices[].device_id` | str | — | Tuya device ID |
+| `deterrent.devices[].type` | str | — | One of: `sprinkler`, `light`, `sound`, `plug` |
+| `deterrent.devices[].enabled` | bool | `true` | Whether this device participates in deterrence |
+| `deterrent.devices[].dp_code` | str | (auto) | Override the default DP code for on/off |
+| `deterrent.defaults.device_count_range` | list[int] | `[1, 4]` | Min/max devices to fire per event |
+| `deterrent.defaults.spray_duration_range` | list[float] | `[3.0, 8.0]` | Min/max seconds each device stays on |
+| `deterrent.defaults.inter_device_delay_range` | list[float] | `[1.0, 5.0]` | Min/max seconds between device activations |
+| `deterrent.defaults.pre_delay_range` | list[float] | `[0.0, 3.0]` | Min/max seconds before sequence starts |
+| `deterrent.defaults.cooldown_seconds` | int | `60` | Minimum gap between deterrence sequences |
+| `deterrent.battery_monitor.enabled` | bool | `true` | Poll battery levels periodically |
+| `deterrent.battery_monitor.check_interval_hours` | int | `24` | Hours between battery checks |
+| `deterrent.battery_monitor.alert_threshold_percent` | int | `20` | Alert when battery drops below this |
+
+### Default DP Codes by Device Type
+
+| Device type | Default DP code | Notes |
+|---|---|---|
+| `sprinkler` | `switch_1` | Most Tuya sprinkler valves |
+| `light` | `switch_led` | Tuya smart lights |
+| `sound` | `switch` | Tuya sirens/alarms |
+| `plug` | `switch_1` | Tuya smart plugs |
+
+Override per-device with `dp_code` if your device uses a different DP.
+
 ## Service Communication
 
-- **Between services:** Redis pub/sub. Detector publishes detection events; notifier and web UI subscribe.
-- **Config:** All services read from mounted `config/scarguard.yml` in external data directory. Web UI can write to it. Detector and notifier auto-restart on config file changes.
-- **Database:** SQLite at `data/scarguard.db`, shared volume between web and detector.
+- **Between services:** Redis pub/sub. Detector publishes detection events; notifier, deterrent, and web UI subscribe.
+- **Config:** All services read from mounted `config/scarguard.yml` in external data directory. Web UI can write to it. Detector, notifier, and deterrent auto-reload on config file changes.
+- **Database:** SQLite at `data/scarguard.db`, shared volume between web, detector, and deterrent.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,14 +3,16 @@
 Active and planned features. Each item includes acceptance criteria. Completed features (1–17, 18–22, 23–27) are in [ROADMAP_ARCHIVE.md](ROADMAP_ARCHIVE.md).
 ---
 
-## Actuation — Sprinkler Deterrence (Scar's Revenge)
+## Deterrence — Physical Deterrence (Scar's Revenge)
 
-New `actuator` Docker Compose service for automated physical deterrence. Subscribes to `scarguard:detections` on Redis and triggers Tuya WiFi hose timer valves via `tinytuya` LAN control (no cloud dependency). Randomized spray patterns (valve count, duration, inter-spray delays) to prevent wildlife habituation.
+New `deterrent` Docker Compose service for automated physical deterrence. Subscribes to `scarguard:detections` on Redis and triggers Tuya smart devices via the **Tuya Cloud API** (`tinytuya.Cloud`). Supports sprinklers, lights, sirens, and smart plugs — any device in the Tuya/Smart Life ecosystem. Randomized activation patterns (device selection, duration, delays) to prevent wildlife habituation.
 
-- **Hardware:** Off-the-shelf Tuya/Smart Life WiFi hose timer valves, standard garden hose fittings, battery-powered. No custom wiring or relay boards.
-- **Config:** `actuation` section in `scarguard.yml` — valve definitions (device_id, local_key, IP), randomization ranges, cooldown, battery alert thresholds.
-- **Battery monitoring:** Periodic polling via tinytuya with low-battery alerts through the existing notification system.
-- **Blocked on:** PoC valve hardware arrival and LAN control validation.
+- **v0.13.0 (MVP):** Any detection fires all enabled devices with randomized timing and global cooldown. Opt-in via `deterrent.enabled` in config.
+- **v0.13.x:** Response profiles (species-based routing, time-of-day conditions, device-type filtering). Example: heron = all deterrents ("Global Thermonuclear War"), raccoon at night = lights + sound only.
+- **Hardware:** Off-the-shelf Tuya/Smart Life smart devices — hose timer valves, smart plugs, lights, sirens. Battery-powered devices work via Cloud API (LAN control not viable due to deep sleep).
+- **Config:** `deterrent` section in `scarguard.yml` — Tuya Cloud credentials, device definitions (device_id, type), randomization ranges, cooldown, battery alert thresholds.
+- **Setup guide:** [TUYA_SETUP.md](TUYA_SETUP.md) — step-by-step instructions for creating a Tuya IoT Platform account and obtaining API credentials.
+- **Battery monitoring:** Periodic polling via Tuya Cloud API with low-battery alerts through the existing notification system.
 - **Full specification:** [ACTUATION_SPEC.md](ACTUATION_SPEC.md)
 
 ---
@@ -108,15 +110,17 @@ trail before the big 0.13 feature lands.
 
 ---
 
-## v0.13 — actuator service (planned)
+## v0.13 — deterrent service
 
 The first version in which ScarGuard closes the detect → notify → *deter*
-loop end-to-end. Introduces a new `actuator` service that controls a Tuya
-WiFi valve for sprinkler-based heron deterrence. See
-`ACTUATION_SPEC.md` for the design. Expected to ship as a **beta/opt-in**
-in 0.13.0, with 0.13.x patches hardening based on real-world use. **1.0.0**
-is reserved for "actuator validated in production" — i.e. the first
-version where ScarGuard fully delivers on its name.
+loop end-to-end. Introduces a new `deterrent` service that controls Tuya
+smart devices (sprinklers, lights, sirens, plugs) via the Tuya Cloud API.
+See `ACTUATION_SPEC.md` for the design and `TUYA_SETUP.md` for user-facing
+setup instructions. Ships as **beta/opt-in** in 0.13.0 (MVP: all devices
+fire on any detection with randomization + cooldown). 0.13.x patches add
+response profiles (species → device-type routing, time-of-day conditions).
+**1.0.0** is reserved for "deterrent validated in production" — i.e. the
+first version where ScarGuard fully delivers on its name.
 
 ---
 
@@ -135,3 +139,5 @@ version where ScarGuard fully delivers on its name.
 - Automated Orin runner/self-updates — CI pushes runner updates to Orin via SSH (parked)
 - Isolated benchmark runner — use concurrency groups or dedicated runner labels at release time to ensure CPU inference benchmarks run without competing workloads skewing FPS numbers
 - CI path filtering — skip full CI on docs-only or benchmark-only PRs using `paths-ignore` in workflow triggers. Needs a lightweight "skip" job if CI becomes a required status check.
+- Tuya LAN fallback — for always-on (mains-powered) Tuya devices, offer `tinytuya` local TCP control as a lower-latency alternative to Cloud API. Not viable for battery-powered devices (WiFi radio sleeps between cloud check-ins).
+- Config secrets at rest — encrypt sensitive values (API keys, SMTP passwords, webhook tokens) in `scarguard.yml`. Target v0.14.x or v0.15.x.

--- a/STATUS.md
+++ b/STATUS.md
@@ -64,7 +64,7 @@ None currently identified.
 ## Not Yet Built
 
 - Custom-trained heron model (have the tooling now, need labeled data)
-- Physical deterrence — actuator service with Tuya WiFi valve control (see [ACTUATION_SPEC.md](ACTUATION_SPEC.md)); blocked on PoC hardware
+- Physical deterrence — deterrent service with Tuya Cloud API control (see [ACTUATION_SPEC.md](ACTUATION_SPEC.md) and [TUYA_SETUP.md](TUYA_SETUP.md)); v0.13.0 MVP in progress
 
 See [ROADMAP.md](ROADMAP.md) for upcoming work and [ROADMAP_ARCHIVE.md](ROADMAP_ARCHIVE.md) for completed feature history (1–27).
 

--- a/TUYA_SETUP.md
+++ b/TUYA_SETUP.md
@@ -1,0 +1,234 @@
+# Tuya IoT Platform Setup Guide
+
+This guide walks you through creating the Tuya Cloud API credentials that
+ScarGuard's deterrent service needs to control your smart devices (sprinkler
+valves, lights, sirens, smart plugs).
+
+**Time required:** ~15 minutes
+
+**Difficulty:** Moderate (you'll be creating a developer account and linking
+your smart home app — no coding required)
+
+---
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+1. **Smart Life or Tuya Smart app** installed on your phone (iOS or Android)
+2. **All deterrent devices paired** and controllable in the app — test each
+   device (turn on/off) before proceeding
+3. **An email address** for your Tuya IoT Platform developer account (use
+   the **same email** as your Smart Life app account to simplify linking)
+
+---
+
+## Step 1: Create a Tuya IoT Platform Account
+
+1. Open your browser and go to **https://iot.tuya.com**
+2. Click **Register** (top right)
+3. Enter your email, create a password, and complete the verification
+4. Log in to the Tuya IoT Platform
+
+> **Tip:** Use the same email as your Smart Life / Tuya Smart app. This makes
+> Step 4 (account linking) easier.
+
+---
+
+## Step 2: Create a Cloud Development Project
+
+1. In the left sidebar, click **Cloud** then **Development**
+2. Click **Create Cloud Project** (blue button, top right)
+3. Fill in the project details:
+   - **Project Name:** `ScarGuard` (or any name you prefer)
+   - **Description:** `ScarGuard deterrent control` (optional)
+   - **Industry:** Select **Smart Home**
+   - **Development Method:** Select **Smart Home**
+   - **Data Center:** Choose the region closest to you:
+     - **Western America** → `us` (for US users)
+     - **Central Europe** → `eu`
+     - **China** → `cn`
+     - **India** → `in`
+     
+     > **Important:** Remember which Data Center you choose — you'll need
+     > this as the `api_region` value in your ScarGuard config.
+
+4. Click **Create**
+
+---
+
+## Step 3: Subscribe to Required API Services
+
+After creating the project, you'll be prompted to select API services.
+Subscribe to these (they're free):
+
+- **IoT Core** (required)
+- **Smart Home Device Management** (required)
+- **Authorization Token Management** (required)
+
+If you're not prompted automatically:
+
+1. In your project, go to the **Service API** tab
+2. Click **Go to Authorize**
+3. Search for and subscribe to the services listed above
+
+---
+
+## Step 4: Link Your Smart Life App Account
+
+This step connects your physical devices to the Cloud API.
+
+1. In your project, go to the **Devices** tab
+2. Click **Link Tuya App Account**
+3. Choose **Automatic Link**
+4. A QR code will appear on screen
+5. Open the **Smart Life** app on your phone:
+   - Go to **Profile** (bottom right tab)
+   - Tap the **scan icon** (top right, looks like a viewfinder)
+   - Scan the QR code displayed on your computer screen
+6. Confirm the link in the app when prompted
+7. Your devices should now appear in the Devices tab
+
+> **Troubleshooting:** If no devices appear after linking:
+> - Make sure you used the same email for iot.tuya.com and Smart Life
+> - Check that your Data Center region matches your Smart Life region
+> - Try the **Manual Link** option using your Smart Life account credentials
+
+---
+
+## Step 5: Get Your API Credentials
+
+1. Navigate to your project's **Overview** page (click the project name)
+2. Find these two values:
+   - **Access ID / Client ID** — this is your `api_key`
+   - **Access Secret / Client Secret** — click "Show" to reveal, then copy
+
+> **Keep these secret.** Anyone with these credentials can control your devices.
+
+---
+
+## Step 6: Get Device IDs
+
+1. In your project, go to the **Devices** tab
+2. Each linked device shows a **Device ID** column
+3. Copy the Device ID for each device you want ScarGuard to control
+
+> **Tip:** The Device ID is a long string like `eb074b33939a9f6effqm7l`.
+> Device names in the Tuya portal match what you see in the Smart Life app.
+
+---
+
+## Step 7: Configure ScarGuard
+
+Add the `deterrent` section to your `scarguard.yml`:
+
+```yaml
+deterrent:
+  enabled: true
+
+  tuya:
+    api_key: "your-access-id-here"
+    api_secret: "your-access-secret-here"
+    api_region: "us"    # must match the Data Center from Step 2
+
+  devices:
+    - name: pond-north-valve       # any descriptive name
+      device_id: "your-device-id"  # from Step 6
+      type: sprinkler              # sprinkler | light | sound | plug
+      enabled: true
+
+    # Add more devices as needed:
+    # - name: pond-light
+    #   device_id: "another-device-id"
+    #   type: light
+    #   enabled: true
+
+  defaults:
+    device_count_range: [1, 4]
+    spray_duration_range: [3, 8]
+    inter_device_delay_range: [1, 5]
+    pre_delay_range: [0, 3]
+    cooldown_seconds: 60
+
+  battery_monitor:
+    enabled: true
+    check_interval_hours: 24
+    alert_threshold_percent: 20
+```
+
+---
+
+## Step 8: Test
+
+1. Restart your ScarGuard stack:
+   ```bash
+   docker compose down && docker compose up -d
+   ```
+2. Check the deterrent service logs:
+   ```bash
+   docker compose logs deterrent -f
+   ```
+3. You should see:
+   ```
+   ScarGuard deterrent service starting
+   Tuya Cloud controller initialised (region=us)
+   Actuation enabled — N device(s) registered, cooldown 60s
+   Subscribed to Redis channel: scarguard:detections
+   ```
+4. When a detection event fires, the deterrent service will activate your
+   devices with randomized timing.
+
+---
+
+## Troubleshooting
+
+### "sign invalid" error
+- Double-check `api_key` and `api_secret` — copy-paste directly from iot.tuya.com
+- Verify `api_region` matches the Data Center you selected in Step 2
+  (Western America = `us`, Central Europe = `eu`)
+
+### "permission deny" error
+- Go to **Service API** in your project and ensure you've subscribed to
+  all three required API services (Step 3)
+
+### "device offline" error
+- Open the Smart Life app and verify you can still control the device
+- Battery-powered devices sleep between cloud check-ins — this is normal.
+  The Cloud API queues commands for pickup on the next wake cycle (~1-2s)
+
+### No devices appear after linking
+- The Smart Life app account email must match the iot.tuya.com account email
+- The Data Center region must match. US users with a "Western America"
+  Smart Life account must select "Western America" in iot.tuya.com
+
+### Rate limits
+- Tuya's free tier allows approximately 500 API calls/day
+- Each actuation sequence uses ~2 API calls per device (ON + OFF)
+- With 4 devices and a 60-second cooldown, you'd need ~60 events/day
+  to approach the limit — unlikely in normal operation
+
+---
+
+## Security Notes
+
+- API credentials in `scarguard.yml` are stored in plaintext. The config
+  file is mounted read-only in the deterrent container.
+- **Do not commit `scarguard.yml` to git** if it contains credentials.
+  The config file lives in an external data volume, not in the repo.
+- Credentials are redacted in the web UI for the `viewer` role.
+- Encrypted config secrets are planned for a future release (v0.14.x or
+  v0.15.x).
+
+---
+
+## What's Next
+
+Once the deterrent service is running, detections will automatically trigger
+your devices. The MVP fires all enabled devices on any detection. Future
+releases (v0.13.x) will add response profiles for species-based routing:
+
+- Heron detected → all deterrents fire (sprinklers + lights + sirens)
+- Raccoon at night → lights and sound only
+- Duck → gentle single-sprinkler deterrence
+
+See [ROADMAP.md](ROADMAP.md) for the full plan.

--- a/config/scarguard.example.yml
+++ b/config/scarguard.example.yml
@@ -243,8 +243,41 @@ redis:
   #     # auth_token: "Bearer …"   # optional
 
 
-# ── Future: Physical Deterrence ───────────────────────────────────────────────
-# Physical deterrence (valve actuation, relays) is planned as a separate
-# companion project: "Scar's Revenge". It will receive webhook notifications
-# from ScarGuard and control the hardware. Configure a webhook channel above
-# to send detection events to the Scar's Revenge API endpoint.
+# ── Physical Deterrence (Tuya Cloud) ──────────────────────────────────────────
+# Automated deterrence via Tuya smart devices (sprinklers, lights, sirens,
+# smart plugs).  Requires a Tuya IoT Platform account and API credentials.
+# See TUYA_SETUP.md for step-by-step instructions.
+#
+# deterrent:
+#   enabled: true
+#
+#   # Tuya Cloud API credentials — get these from iot.tuya.com
+#   tuya:
+#     api_key: "your-access-id"
+#     api_secret: "your-access-secret"
+#     api_region: "us"              # us | eu | cn | in
+#
+#   # Devices to control — one entry per physical device
+#   devices:
+#     - name: pond-north-valve
+#       device_id: "bf1234567890abcdef"
+#       type: sprinkler              # sprinkler | light | sound | plug
+#       enabled: true
+#     # - name: pond-light
+#     #   device_id: "bf0987654321fedcba"
+#     #   type: light
+#     #   enabled: true
+#
+#   # Randomisation ranges — vary the response to prevent wildlife habituation
+#   defaults:
+#     device_count_range: [1, 4]       # how many devices to fire per event
+#     spray_duration_range: [3, 8]     # seconds each device stays on
+#     inter_device_delay_range: [1, 5] # seconds between device activations
+#     pre_delay_range: [0, 3]          # seconds before sequence starts
+#     cooldown_seconds: 60             # minimum gap between actuation sequences
+#
+#   # Battery monitoring — alerts when device batteries run low
+#   battery_monitor:
+#     enabled: true
+#     check_interval_hours: 24
+#     alert_threshold_percent: 20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,30 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # ── Deterrent ─────────────────────────────────────────────────────────────
+  # Physical deterrence via Tuya Cloud API.  Subscribes to detection events
+  # and triggers smart devices (sprinklers, lights, sirens, plugs).
+  deterrent:
+    build:
+      context: .
+      dockerfile: services/deterrent/Dockerfile
+    image: ghcr.io/${GHCR_OWNER:-sentania-labs}/scarguard-deterrent:${IMAGE_TAG:-latest}
+    environment:
+      CONFIG_PATH: /config/scarguard.yml
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+    healthcheck:
+      test: ["CMD", "test", "-f", "/tmp/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    volumes:
+      - scarguard-config:/config:ro
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
   # ── Log Streamer (sidecar) ────────────────────────────────────────────────
   # Tails container logs via Docker socket and publishes to Redis.
   # Replaces the Docker socket mount previously needed by the web container.

--- a/services/deterrent/Dockerfile
+++ b/services/deterrent/Dockerfile
@@ -1,0 +1,30 @@
+# Build context: repo root
+# docker build -f services/deterrent/Dockerfile -t scarguard-deterrent .
+FROM python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
+
+COPY services/deterrent/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir -r requirements.txt
+
+COPY services/deterrent/src/ ./src/
+COPY shared/ ./shared/
+
+ENV PYTHONPATH=/app/src:/app/shared
+ENV PYTHONUNBUFFERED=1
+
+# Create non-root user for defense in depth.
+# Container starts as root; entrypoint fixes volume ownership then drops
+# to scarguard via gosu.
+RUN useradd -r -s /usr/sbin/nologin scarguard && \
+    mkdir -p /data /config && \
+    chown scarguard:scarguard /data /config
+
+COPY services/deterrent/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["python", "src/main.py"]

--- a/services/deterrent/Dockerfile
+++ b/services/deterrent/Dockerfile
@@ -4,7 +4,11 @@ FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
+# Upgrade base packages to pick up security fixes not yet in the slim image,
+# then install gosu for entrypoint user-switching.
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY services/deterrent/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \

--- a/services/deterrent/Dockerfile
+++ b/services/deterrent/Dockerfile
@@ -1,6 +1,6 @@
 # Build context: repo root
 # docker build -f services/deterrent/Dockerfile -t scarguard-deterrent .
-FROM python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
+FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/deterrent/entrypoint.sh
+++ b/services/deterrent/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+# Fix volume ownership — the scarguard user needs write access to /data
+# for SQLite (battery status).  Only run the recursive chown once (sentinel
+# file prevents slow restarts).
+if [ "$(id -u)" = "0" ]; then
+    if [ ! -f /data/.ownership-fixed-deterrent ]; then
+        chown -R scarguard:scarguard /data 2>/dev/null || echo "WARNING: chown failed on /data — check volume mounts" >&2
+        chown -R scarguard:scarguard /config 2>/dev/null || echo "WARNING: chown failed on /config — check volume mounts" >&2
+        touch /data/.ownership-fixed-deterrent 2>/dev/null || true
+    else
+        # On subsequent starts, just fix top-level dirs (fast)
+        chown scarguard:scarguard /data /config 2>/dev/null || true
+    fi
+    exec gosu scarguard "$@"
+fi
+exec "$@"

--- a/services/deterrent/requirements.txt
+++ b/services/deterrent/requirements.txt
@@ -1,0 +1,5 @@
+redis==7.4.0
+pyyaml==6.0.3
+pydantic==2.12.5
+tinytuya>=1.16.1
+tzdata

--- a/services/deterrent/src/actuation_models.py
+++ b/services/deterrent/src/actuation_models.py
@@ -1,0 +1,70 @@
+"""Pydantic models for the deterrent service."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Config models — parsed from the ``deterrent`` section of scarguard.yml
+# ---------------------------------------------------------------------------
+
+class TuyaCredentials(BaseModel):
+    api_key: str
+    api_secret: str
+    api_region: str = "us"
+
+
+class DeviceConfig(BaseModel):
+    name: str
+    device_id: str
+    type: Literal["sprinkler", "light", "sound", "plug"]
+    enabled: bool = True
+    dp_code: str | None = None  # override the default DP code for on/off
+
+
+class ActuationDefaults(BaseModel):
+    device_count_range: list[int] = [1, 4]
+    spray_duration_range: list[float] = [3.0, 8.0]
+    inter_device_delay_range: list[float] = [1.0, 5.0]
+    pre_delay_range: list[float] = [0.0, 3.0]
+    cooldown_seconds: int = 60
+
+
+class BatteryMonitorConfig(BaseModel):
+    enabled: bool = True
+    check_interval_hours: int = 24
+    alert_threshold_percent: int = 20
+
+
+class ActuationConfig(BaseModel):
+    enabled: bool = False  # opt-in — disabled by default
+    tuya: TuyaCredentials | None = None
+    devices: list[DeviceConfig] = []
+    defaults: ActuationDefaults = ActuationDefaults()
+    battery_monitor: BatteryMonitorConfig = BatteryMonitorConfig()
+
+
+# ---------------------------------------------------------------------------
+# Event models — published to Redis ``scarguard:actuations``
+# ---------------------------------------------------------------------------
+
+class DeviceAction(BaseModel):
+    device_name: str
+    device_id: str
+    device_type: str
+    duration_sec: float
+    delay_before_sec: float
+    success: bool = False
+    error: str | None = None
+
+
+class ActuationEvent(BaseModel):
+    timestamp: str  # ISO 8601
+    trigger_class: str
+    trigger_camera: str
+    trigger_confidence: float
+    pre_delay_sec: float
+    actions: list[DeviceAction]
+    total_duration_sec: float

--- a/services/deterrent/src/battery_monitor.py
+++ b/services/deterrent/src/battery_monitor.py
@@ -1,0 +1,108 @@
+"""Periodic battery monitoring for Tuya devices.
+
+Polls device status via the Cloud API on a configurable interval and
+publishes low-battery alerts to the ``scarguard:notifications`` Redis channel.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from datetime import datetime, timezone
+
+import redis as redis_lib
+from actuation_models import ActuationConfig, DeviceConfig
+from cloud_controller import TuyaCloudController
+
+logger = logging.getLogger(__name__)
+
+
+class BatteryMonitor:
+    """Background daemon thread that polls battery levels."""
+
+    def __init__(
+        self,
+        controller: TuyaCloudController,
+        redis_client: redis_lib.Redis,
+    ) -> None:
+        self._controller = controller
+        self._redis = redis_client
+        self._shutdown = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._config: ActuationConfig | None = None
+
+    def configure(self, config: ActuationConfig) -> None:
+        """Update configuration (called on hot-reload)."""
+        self._config = config
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._shutdown.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="battery-monitor", daemon=True,
+        )
+        self._thread.start()
+        logger.info("Battery monitor started")
+
+    def stop(self) -> None:
+        self._shutdown.set()
+        if self._thread is not None:
+            self._thread.join(timeout=10)
+        logger.info("Battery monitor stopped")
+
+    def _run(self) -> None:
+        while not self._shutdown.is_set():
+            cfg = self._config
+            if cfg is None or not cfg.battery_monitor.enabled:
+                self._shutdown.wait(60)
+                continue
+
+            interval_sec = cfg.battery_monitor.check_interval_hours * 3600
+            self._check_all(cfg)
+            self._shutdown.wait(interval_sec)
+
+    def _check_all(self, cfg: ActuationConfig) -> None:
+        """Poll battery for every enabled device and alert if low."""
+        threshold = cfg.battery_monitor.alert_threshold_percent
+        for device in cfg.devices:
+            if not device.enabled:
+                continue
+            self._check_device(device, threshold)
+
+    def _check_device(self, device: DeviceConfig, threshold: int) -> None:
+        status = self._controller.get_device_status(device.device_id)
+        if status is None:
+            logger.warning("Battery check skipped for %s — status unavailable", device.name)
+            return
+
+        battery = status.get("battery_percentage")
+        if battery is None:
+            # Device may not have a battery DP (e.g. smart plugs)
+            return
+
+        logger.info("Device %s battery: %d%%", device.name, battery)
+        if battery <= threshold:
+            self._publish_alert(device, battery, threshold)
+
+    def _publish_alert(self, device: DeviceConfig, battery: int, threshold: int) -> None:
+        alert = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "class_name": "low_battery",
+            "confidence": 1.0,
+            "camera_name": f"deterrent:{device.name}",
+            "snapshot_path": None,
+            "message": (
+                f"Deterrent device \"{device.name}\" battery is at {battery}% "
+                f"(threshold: {threshold}%)"
+            ),
+        }
+        try:
+            self._redis.publish("scarguard:health", json.dumps(alert))
+            logger.warning(
+                "Low battery alert: %s at %d%% (threshold %d%%)",
+                device.name, battery, threshold,
+            )
+        except Exception:
+            logger.exception("Failed to publish battery alert for %s", device.name)

--- a/services/deterrent/src/battery_monitor.py
+++ b/services/deterrent/src/battery_monitor.py
@@ -99,7 +99,7 @@ class BatteryMonitor:
             ),
         }
         try:
-            self._redis.publish("scarguard:health", json.dumps(alert))
+            self._redis.publish("scarguard:detections", json.dumps(alert))
             logger.warning(
                 "Low battery alert: %s at %d%% (threshold %d%%)",
                 device.name, battery, threshold,

--- a/services/deterrent/src/cloud_controller.py
+++ b/services/deterrent/src/cloud_controller.py
@@ -1,0 +1,98 @@
+"""Tuya Cloud API wrapper for device control."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import tinytuya
+from actuation_models import DeviceConfig
+
+logger = logging.getLogger(__name__)
+
+# Default DP codes for on/off by device type.  Can be overridden per-device
+# via the ``dp_code`` config field.
+_DEFAULT_DP_CODES: dict[str, str] = {
+    "sprinkler": "switch_1",
+    "light": "switch_led",
+    "sound": "switch",
+    "plug": "switch_1",
+}
+
+
+class TuyaCloudController:
+    """Controls Tuya devices via the Cloud API.
+
+    Uses ``tinytuya.Cloud`` which makes signed HTTPS REST calls to Tuya's
+    OpenAPI.  Token refresh is handled automatically by the library.
+    """
+
+    def __init__(self, api_key: str, api_secret: str, api_region: str = "us") -> None:
+        self._cloud = tinytuya.Cloud(
+            apiRegion=api_region,
+            apiKey=api_key,
+            apiSecret=api_secret,
+        )
+        logger.info("Tuya Cloud controller initialised (region=%s)", api_region)
+
+    def _dp_code_for(self, device: DeviceConfig) -> str:
+        """Return the DP code to use for on/off toggling."""
+        return device.dp_code or _DEFAULT_DP_CODES.get(device.type, "switch_1")
+
+    def activate_device(self, device: DeviceConfig, duration_sec: float) -> tuple[bool, str | None]:
+        """Turn *device* ON, wait *duration_sec*, then turn it OFF.
+
+        Returns ``(success, error_message)``.  A partial success (ON worked
+        but OFF failed) still returns ``True`` — the device will auto-timeout
+        on most Tuya firmware.
+        """
+        dp_code = self._dp_code_for(device)
+        error: str | None = None
+
+        # --- ON ---
+        try:
+            on_cmd: dict[str, Any] = {"commands": [{"code": dp_code, "value": True}]}
+            result = self._cloud.sendcommand(device.device_id, on_cmd)
+            if not result.get("success"):
+                msg = f"ON failed: {result}"
+                logger.error("Device %s (%s) — %s", device.name, device.device_id, msg)
+                return False, msg
+            logger.info("Device %s ON (dp=%s)", device.name, dp_code)
+        except Exception as exc:
+            msg = f"ON exception: {exc}"
+            logger.error("Device %s (%s) — %s", device.name, device.device_id, msg)
+            return False, msg
+
+        # --- HOLD ---
+        time.sleep(duration_sec)
+
+        # --- OFF ---
+        try:
+            off_cmd: dict[str, Any] = {"commands": [{"code": dp_code, "value": False}]}
+            result = self._cloud.sendcommand(device.device_id, off_cmd)
+            if not result.get("success"):
+                error = f"OFF failed (device may auto-timeout): {result}"
+                logger.warning("Device %s (%s) — %s", device.name, device.device_id, error)
+            else:
+                logger.info("Device %s OFF", device.name)
+        except Exception as exc:
+            error = f"OFF exception (device may auto-timeout): {exc}"
+            logger.warning("Device %s (%s) — %s", device.name, device.device_id, error)
+
+        return True, error
+
+    def get_device_status(self, device_id: str) -> dict[str, Any] | None:
+        """Query device status (battery level, switch state, etc.).
+
+        Returns the parsed status dict on success, or ``None`` on failure.
+        """
+        try:
+            result = self._cloud.getstatus(device_id)
+            if result.get("success") and result.get("result"):
+                return {item["code"]: item["value"] for item in result["result"]}
+            logger.warning("Status query failed for %s: %s", device_id, result)
+            return None
+        except Exception:
+            logger.exception("Status query exception for %s", device_id)
+            return None

--- a/services/deterrent/src/cooldown.py
+++ b/services/deterrent/src/cooldown.py
@@ -1,0 +1,34 @@
+"""Global cooldown tracker for actuation sequences."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+
+class CooldownTracker:
+    """Thread-safe cooldown gate.
+
+    MVP: single global cooldown.  Per-species cooldowns are planned for
+    0.13.x when response profiles are added.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._last_actuation: float = 0.0
+
+    def is_clear(self, cooldown_seconds: int) -> bool:
+        """Return ``True`` if enough time has passed since the last actuation."""
+        with self._lock:
+            return (time.monotonic() - self._last_actuation) >= cooldown_seconds
+
+    def record(self) -> None:
+        """Record that an actuation just completed."""
+        with self._lock:
+            self._last_actuation = time.monotonic()
+
+    def seconds_remaining(self, cooldown_seconds: int) -> float:
+        """Return how many seconds remain before cooldown expires (0 if clear)."""
+        with self._lock:
+            remaining = cooldown_seconds - (time.monotonic() - self._last_actuation)
+            return max(0.0, remaining)

--- a/services/deterrent/src/main.py
+++ b/services/deterrent/src/main.py
@@ -1,0 +1,393 @@
+"""ScarGuard deterrent — subscribes to Redis detections and triggers Tuya devices."""
+
+import json
+import logging
+import os
+import pathlib
+import queue
+import signal
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import redis as redis_lib
+import yaml
+from actuation_models import ActuationConfig, ActuationEvent, DeviceAction
+from atomic_ref import AtomicRef
+from battery_monitor import BatteryMonitor
+from cloud_controller import TuyaCloudController
+from config_watcher import ConfigWatcher
+from cooldown import CooldownTracker
+from randomizer import build_random_plan
+
+logger = logging.getLogger(__name__)
+
+CONFIG_PATH = os.environ.get("CONFIG_PATH", "/config/scarguard.yml")
+CHANNEL = "scarguard:detections"
+ACTUATION_CHANNEL = "scarguard:actuations"
+
+_REDIS_RECONNECT_DELAY = 5
+_REDIS_MAX_RECONNECT_DELAY = 60
+
+
+def load_config() -> dict[str, Any]:
+    with open(CONFIG_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def setup_logging(log_level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def parse_actuation_config(cfg: dict[str, Any]) -> ActuationConfig:
+    """Parse the ``deterrent`` section of the config, returning defaults if absent."""
+    raw = cfg.get("deterrent", {})
+    if not raw:
+        return ActuationConfig()
+    return ActuationConfig(**raw)
+
+
+def build_controller(act_cfg: ActuationConfig) -> TuyaCloudController | None:
+    """Build a Cloud controller from config, or None if credentials are missing."""
+    if act_cfg.tuya is None:
+        return None
+    return TuyaCloudController(
+        api_key=act_cfg.tuya.api_key,
+        api_secret=act_cfg.tuya.api_secret,
+        api_region=act_cfg.tuya.api_region,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Worker thread — processes events sequentially (tinytuya.Cloud isn't
+# documented as thread-safe, and actuation sequences are inherently serial).
+# ---------------------------------------------------------------------------
+
+def _worker(
+    event_queue: queue.Queue[dict[str, Any] | None],
+    act_cfg_ref: AtomicRef[ActuationConfig],
+    controller_ref: AtomicRef[TuyaCloudController | None],
+    armed_ref: AtomicRef[bool],
+    cooldown: CooldownTracker,
+    redis_cfg: dict[str, Any],
+) -> None:
+    """Consume detection events and run actuation sequences."""
+    logger.info("Deterrent worker thread started")
+
+    # Mutable container so the lazily-created Redis client persists across calls.
+    pub_holder: list[redis_lib.Redis | None] = [None]
+
+    while True:
+        event = event_queue.get()
+        if event is None:  # poison pill — shutdown
+            break
+
+        act_cfg = act_cfg_ref.get()
+        controller = controller_ref.get()
+
+        # Gate checks
+        if not act_cfg.enabled:
+            logger.debug("Actuation disabled — ignoring event")
+            continue
+        if not armed_ref.get():
+            logger.debug("System disarmed — ignoring event")
+            continue
+        if controller is None:
+            logger.warning("No Tuya credentials configured — cannot actuate")
+            continue
+
+        cooldown_sec = act_cfg.defaults.cooldown_seconds
+        if not cooldown.is_clear(cooldown_sec):
+            remaining = cooldown.seconds_remaining(cooldown_sec)
+            logger.info("Cooldown active (%.0fs remaining) — skipping", remaining)
+            continue
+
+        enabled_devices = [d for d in act_cfg.devices if d.enabled]
+        if not enabled_devices:
+            logger.warning("No enabled devices — cannot actuate")
+            continue
+
+        class_name = event.get("class_name", "unknown")
+        camera_name = event.get("camera_name", "unknown")
+        confidence = event.get("confidence", 0.0)
+        logger.info(
+            "Actuation triggered: %s from %s (conf=%.2f) — %d device(s) available",
+            class_name, camera_name, confidence, len(enabled_devices),
+        )
+
+        # Build randomised plan
+        selected, durations, inter_delays, pre_delay = build_random_plan(
+            enabled_devices, act_cfg.defaults,
+        )
+
+        # Execute
+        t_start = time.monotonic()
+        actions: list[DeviceAction] = []
+
+        if pre_delay > 0:
+            logger.debug("Pre-delay: %.1fs", pre_delay)
+            time.sleep(pre_delay)
+
+        for i, device in enumerate(selected):
+            if inter_delays[i] > 0:
+                logger.debug("Inter-device delay: %.1fs", inter_delays[i])
+                time.sleep(inter_delays[i])
+
+            duration = durations[i]
+            logger.info(
+                "Firing device %s (%s) for %.1fs",
+                device.name, device.type, duration,
+            )
+            success, error = controller.activate_device(device, duration)
+            actions.append(DeviceAction(
+                device_name=device.name,
+                device_id=device.device_id,
+                device_type=device.type,
+                duration_sec=duration,
+                delay_before_sec=inter_delays[i],
+                success=success,
+                error=error,
+            ))
+
+        total_duration = time.monotonic() - t_start
+        cooldown.record()
+
+        actuation_event = ActuationEvent(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            trigger_class=class_name,
+            trigger_camera=camera_name,
+            trigger_confidence=confidence,
+            pre_delay_sec=pre_delay,
+            actions=actions,
+            total_duration_sec=round(total_duration, 2),
+        )
+
+        successes = sum(1 for a in actions if a.success)
+        logger.info(
+            "Actuation complete: %d/%d devices fired in %.1fs",
+            successes, len(actions), total_duration,
+        )
+
+        # Publish actuation event to Redis
+        _publish_actuation(pub_holder, redis_cfg, actuation_event)
+
+    logger.info("Deterrent worker thread stopped")
+
+
+def _publish_actuation(
+    holder: list[redis_lib.Redis | None],
+    redis_cfg: dict[str, Any],
+    event: ActuationEvent,
+) -> None:
+    """Publish an actuation event to Redis.  Lazily connects."""
+    try:
+        client = holder[0]
+        if client is None:
+            host = redis_cfg.get("host", "redis")
+            port = int(redis_cfg.get("port", 6379))
+            password = os.environ.get("REDIS_PASSWORD", "") or None
+            client = redis_lib.Redis(host=host, port=port, password=password, decode_responses=True)
+            holder[0] = client
+        client.publish(ACTUATION_CHANNEL, event.model_dump_json())
+    except Exception:
+        logger.exception("Failed to publish actuation event")
+        holder[0] = None  # force reconnect on next attempt
+
+
+# ---------------------------------------------------------------------------
+# Subscribe loop — mirrors the notifier pattern
+# ---------------------------------------------------------------------------
+
+def subscribe_loop(
+    redis_cfg: dict[str, Any],
+    event_queue: queue.Queue[dict[str, Any] | None],
+    shutdown_event: threading.Event,
+) -> None:
+    """Connect to Redis and forward detection events to the worker queue."""
+    host = redis_cfg.get("host", "redis")
+    port = int(redis_cfg.get("port", 6379))
+    delay = _REDIS_RECONNECT_DELAY
+
+    while not shutdown_event.is_set():
+        client: redis_lib.Redis | None = None
+        pubsub: redis_lib.client.PubSub | None = None
+        try:
+            redis_password = os.environ.get("REDIS_PASSWORD", "") or None
+            client = redis_lib.Redis(
+                host=host, port=port, password=redis_password, decode_responses=True,
+            )
+            pubsub = client.pubsub()
+            pubsub.subscribe(CHANNEL)
+            logger.info("Subscribed to Redis channel: %s", CHANNEL)
+            delay = _REDIS_RECONNECT_DELAY
+
+            pathlib.Path("/tmp/healthy").touch(exist_ok=True)
+
+            for message in pubsub.listen():
+                if shutdown_event.is_set():
+                    break
+                if message["type"] != "message":
+                    continue
+
+                pathlib.Path("/tmp/healthy").touch(exist_ok=True)
+
+                try:
+                    event = json.loads(message["data"])
+                except json.JSONDecodeError:
+                    logger.warning("Malformed message: %s", message["data"])
+                    continue
+
+                logger.debug(
+                    "Detection: %s from %s (conf=%.2f)",
+                    event.get("class_name"),
+                    event.get("camera_name"),
+                    event.get("confidence", 0.0),
+                )
+                try:
+                    event_queue.put_nowait(event)
+                except queue.Full:
+                    logger.warning("Event queue full — dropping event")
+
+        except redis_lib.RedisError:
+            if shutdown_event.is_set():
+                break
+            logger.exception("Redis connection lost — retrying in %ds", delay)
+            time.sleep(delay)
+            delay = min(delay * 2, _REDIS_MAX_RECONNECT_DELAY)
+        finally:
+            if pubsub is not None:
+                try:
+                    pubsub.unsubscribe()
+                    pubsub.close()
+                except Exception:
+                    pass
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    pass
+
+    logger.info("Subscription loop exited")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    cfg = load_config()
+    setup_logging(cfg.get("system", {}).get("log_level", "info"))
+    logger.info("ScarGuard deterrent service starting")
+
+    act_cfg = parse_actuation_config(cfg)
+    controller = build_controller(act_cfg)
+
+    act_cfg_ref: AtomicRef[ActuationConfig] = AtomicRef(act_cfg)
+    controller_ref: AtomicRef[TuyaCloudController | None] = AtomicRef(controller)
+    armed_ref: AtomicRef[bool] = AtomicRef(cfg.get("system", {}).get("armed", True))
+
+    cooldown = CooldownTracker()
+    event_queue: queue.Queue[dict[str, Any] | None] = queue.Queue(maxsize=64)
+
+    if not act_cfg.enabled:
+        logger.info("Actuation disabled in config — service will idle until enabled")
+    elif controller is None:
+        logger.warning("Actuation enabled but Tuya credentials missing — check config")
+    else:
+        enabled_count = sum(1 for d in act_cfg.devices if d.enabled)
+        logger.info(
+            "Actuation enabled — %d device(s) registered, cooldown %ds",
+            enabled_count, act_cfg.defaults.cooldown_seconds,
+        )
+
+    # Battery monitor
+    redis_cfg = cfg.get("redis", {})
+    battery_monitor: BatteryMonitor | None = None
+    if controller is not None:
+        redis_password = os.environ.get("REDIS_PASSWORD", "") or None
+        batt_redis = redis_lib.Redis(
+            host=redis_cfg.get("host", "redis"),
+            port=int(redis_cfg.get("port", 6379)),
+            password=redis_password,
+            decode_responses=True,
+        )
+        battery_monitor = BatteryMonitor(controller, batt_redis)
+        battery_monitor.configure(act_cfg)
+        if act_cfg.battery_monitor.enabled:
+            battery_monitor.start()
+
+    # Shutdown signal handling
+    shutdown_event = threading.Event()
+
+    def _shutdown(sig: int, _frame: object) -> None:
+        logger.info("Received signal %s — shutting down", sig)
+        shutdown_event.set()
+        event_queue.put(None)  # poison pill for worker
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    # Config hot-reload
+    def _on_config_change(new_cfg: dict[str, Any]) -> None:
+        new_act = parse_actuation_config(new_cfg)
+        new_armed = new_cfg.get("system", {}).get("armed", True)
+
+        # Rebuild controller if credentials changed
+        old_act = act_cfg_ref.get()
+        if new_act.tuya != old_act.tuya:
+            new_controller = build_controller(new_act)
+            controller_ref.set(new_controller)
+            logger.info("Tuya Cloud controller rebuilt (credentials changed)")
+
+        act_cfg_ref.set(new_act)
+        armed_ref.set(new_armed)
+
+        # Start/stop battery monitor on config change
+        if battery_monitor is not None:
+            battery_monitor.configure(new_act)
+            if new_act.battery_monitor.enabled:
+                battery_monitor.start()  # no-op if already running
+            else:
+                battery_monitor.stop()
+
+        enabled_count = sum(1 for d in new_act.devices if d.enabled)
+        logger.info(
+            "Config reloaded — actuation %s, %d device(s), armed=%s",
+            "enabled" if new_act.enabled else "disabled",
+            enabled_count,
+            new_armed,
+        )
+
+    watcher = ConfigWatcher(CONFIG_PATH, _on_config_change)
+    watcher.start()
+
+    # Start worker thread
+    worker_thread = threading.Thread(
+        target=_worker,
+        name="deterrent-worker",
+        daemon=True,
+        args=(event_queue, act_cfg_ref, controller_ref, armed_ref, cooldown, redis_cfg),
+    )
+    worker_thread.start()
+
+    # Subscribe loop blocks until shutdown
+    subscribe_loop(redis_cfg, event_queue, shutdown_event)
+
+    # Cleanup
+    event_queue.put(None)  # ensure worker exits
+    worker_thread.join(timeout=10)
+    watcher.stop()
+    if battery_monitor is not None:
+        battery_monitor.stop()
+
+    logger.info("Deterrent service stopped cleanly")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/deterrent/src/main.py
+++ b/services/deterrent/src/main.py
@@ -91,6 +91,11 @@ def _worker(
         act_cfg = act_cfg_ref.get()
         controller = controller_ref.get()
 
+        # Skip system/internal events (battery alerts, camera health, etc.)
+        class_name = event.get("class_name", "")
+        if class_name in ("low_battery", "camera_offline"):
+            continue
+
         # Gate checks
         if not act_cfg.enabled:
             logger.debug("Actuation disabled — ignoring event")
@@ -113,7 +118,6 @@ def _worker(
             logger.warning("No enabled devices — cannot actuate")
             continue
 
-        class_name = event.get("class_name", "unknown")
         camera_name = event.get("camera_name", "unknown")
         confidence = event.get("confidence", 0.0)
         logger.info(

--- a/services/deterrent/src/main.py
+++ b/services/deterrent/src/main.py
@@ -339,6 +339,7 @@ def main() -> None:
 
     # Config hot-reload
     def _on_config_change(new_cfg: dict[str, Any]) -> None:
+        nonlocal battery_monitor
         new_act = parse_actuation_config(new_cfg)
         new_armed = new_cfg.get("system", {}).get("armed", True)
 
@@ -348,6 +349,18 @@ def main() -> None:
             new_controller = build_controller(new_act)
             controller_ref.set(new_controller)
             logger.info("Tuya Cloud controller rebuilt (credentials changed)")
+
+            # Create battery monitor if credentials appeared for the first time
+            if new_controller is not None and battery_monitor is None:
+                redis_password = os.environ.get("REDIS_PASSWORD", "") or None
+                batt_redis = redis_lib.Redis(
+                    host=redis_cfg.get("host", "redis"),
+                    port=int(redis_cfg.get("port", 6379)),
+                    password=redis_password,
+                    decode_responses=True,
+                )
+                battery_monitor = BatteryMonitor(new_controller, batt_redis)
+                logger.info("Battery monitor created (credentials now available)")
 
         act_cfg_ref.set(new_act)
         armed_ref.set(new_armed)

--- a/services/deterrent/src/randomizer.py
+++ b/services/deterrent/src/randomizer.py
@@ -1,0 +1,61 @@
+"""Randomisation engine for actuation sequences.
+
+Stateless by design — randomisation IS the anti-habituation strategy.
+Each call produces independent random output so wildlife cannot predict
+the deterrence pattern.
+"""
+
+from __future__ import annotations
+
+import random
+
+from actuation_models import ActuationDefaults, DeviceConfig
+
+
+def build_random_plan(
+    devices: list[DeviceConfig],
+    defaults: ActuationDefaults,
+) -> tuple[list[DeviceConfig], list[float], list[float], float]:
+    """Select devices and randomise timing for an actuation sequence.
+
+    Parameters
+    ----------
+    devices:
+        All *enabled* devices eligible for this event.
+    defaults:
+        Randomisation ranges from config.
+
+    Returns
+    -------
+    (selected_devices, durations, inter_delays, pre_delay)
+
+    * ``selected_devices`` — ordered list of devices to fire
+    * ``durations`` — per-device activation duration in seconds
+    * ``inter_delays`` — delay *before* each device (index 0 is always 0)
+    * ``pre_delay`` — initial delay before the sequence starts
+    """
+    if not devices:
+        return [], [], [], 0.0
+
+    # How many devices to fire
+    min_count = max(1, defaults.device_count_range[0])
+    max_count = min(len(devices), defaults.device_count_range[1])
+    count = random.randint(min_count, max(min_count, max_count))
+
+    # Pick and shuffle
+    selected = random.sample(devices, count)
+    random.shuffle(selected)
+
+    # Randomise durations
+    dur_min, dur_max = defaults.spray_duration_range
+    durations = [random.uniform(dur_min, dur_max) for _ in selected]
+
+    # Randomise inter-device delays (first device has no pre-delay)
+    delay_min, delay_max = defaults.inter_device_delay_range
+    inter_delays = [0.0] + [random.uniform(delay_min, delay_max) for _ in range(len(selected) - 1)]
+
+    # Pre-delay before the whole sequence
+    pre_min, pre_max = defaults.pre_delay_range
+    pre_delay = random.uniform(pre_min, pre_max)
+
+    return selected, durations, inter_delays, pre_delay

--- a/services/deterrent/src/randomizer.py
+++ b/services/deterrent/src/randomizer.py
@@ -37,10 +37,11 @@ def build_random_plan(
     if not devices:
         return [], [], [], 0.0
 
-    # How many devices to fire
-    min_count = max(1, defaults.device_count_range[0])
-    max_count = min(len(devices), defaults.device_count_range[1])
-    count = random.randint(min_count, max(min_count, max_count))
+    # How many devices to fire (clamp both ends to available count)
+    available = len(devices)
+    min_count = max(1, min(defaults.device_count_range[0], available))
+    max_count = max(min_count, min(defaults.device_count_range[1], available))
+    count = random.randint(min_count, max_count)
 
     # Pick and shuffle
     selected = random.sample(devices, count)

--- a/services/deterrent/tests/conftest.py
+++ b/services/deterrent/tests/conftest.py
@@ -1,0 +1,1 @@
+"""Shared fixtures for deterrent service tests."""

--- a/services/deterrent/tests/test_cooldown.py
+++ b/services/deterrent/tests/test_cooldown.py
@@ -1,0 +1,42 @@
+"""Tests for the cooldown tracker."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from cooldown import CooldownTracker
+
+
+class TestCooldownTracker:
+    def test_initially_clear(self) -> None:
+        cd = CooldownTracker()
+        assert cd.is_clear(60) is True
+
+    def test_not_clear_after_record(self) -> None:
+        cd = CooldownTracker()
+        cd.record()
+        assert cd.is_clear(60) is False
+
+    def test_clear_after_cooldown_expires(self) -> None:
+        cd = CooldownTracker()
+        cd.record()
+        # Simulate time passing by patching monotonic
+        recorded_time = time.monotonic()
+        with patch("cooldown.time.monotonic", return_value=recorded_time + 61):
+            assert cd.is_clear(60) is True
+
+    def test_seconds_remaining(self) -> None:
+        cd = CooldownTracker()
+        cd.record()
+        remaining = cd.seconds_remaining(60)
+        assert 59.0 <= remaining <= 60.0
+
+    def test_seconds_remaining_zero_when_clear(self) -> None:
+        cd = CooldownTracker()
+        assert cd.seconds_remaining(60) == 0.0
+
+    def test_zero_cooldown_always_clear(self) -> None:
+        cd = CooldownTracker()
+        cd.record()
+        assert cd.is_clear(0) is True

--- a/services/deterrent/tests/test_randomizer.py
+++ b/services/deterrent/tests/test_randomizer.py
@@ -1,0 +1,81 @@
+"""Tests for the randomisation engine."""
+
+from __future__ import annotations
+
+from actuation_models import ActuationDefaults, DeviceConfig
+from randomizer import build_random_plan
+
+
+def _device(name: str, dev_type: str = "sprinkler") -> DeviceConfig:
+    return DeviceConfig(name=name, device_id=f"id-{name}", type=dev_type)
+
+
+class TestBuildRandomPlan:
+    def test_empty_devices_returns_empty(self) -> None:
+        selected, durations, delays, pre = build_random_plan([], ActuationDefaults())
+        assert selected == []
+        assert durations == []
+        assert delays == []
+        assert pre == 0.0
+
+    def test_single_device(self) -> None:
+        devices = [_device("v1")]
+        defaults = ActuationDefaults(device_count_range=[1, 1])
+        selected, durations, delays, pre = build_random_plan(devices, defaults)
+        assert len(selected) == 1
+        assert len(durations) == 1
+        assert len(delays) == 1
+        assert delays[0] == 0.0  # first device has no inter-delay
+
+    def test_respects_count_range(self) -> None:
+        devices = [_device(f"v{i}") for i in range(6)]
+        defaults = ActuationDefaults(device_count_range=[2, 3])
+        for _ in range(50):
+            selected, *_ = build_random_plan(devices, defaults)
+            assert 2 <= len(selected) <= 3
+
+    def test_count_capped_by_available_devices(self) -> None:
+        devices = [_device("v1"), _device("v2")]
+        defaults = ActuationDefaults(device_count_range=[1, 10])
+        for _ in range(20):
+            selected, *_ = build_random_plan(devices, defaults)
+            assert len(selected) <= 2
+
+    def test_durations_within_range(self) -> None:
+        devices = [_device(f"v{i}") for i in range(4)]
+        defaults = ActuationDefaults(spray_duration_range=[2.0, 5.0])
+        for _ in range(30):
+            _, durations, *_ = build_random_plan(devices, defaults)
+            for d in durations:
+                assert 2.0 <= d <= 5.0
+
+    def test_pre_delay_within_range(self) -> None:
+        devices = [_device("v1")]
+        defaults = ActuationDefaults(pre_delay_range=[1.0, 3.0])
+        for _ in range(30):
+            *_, pre = build_random_plan(devices, defaults)
+            assert 1.0 <= pre <= 3.0
+
+    def test_inter_delays_within_range(self) -> None:
+        devices = [_device(f"v{i}") for i in range(4)]
+        defaults = ActuationDefaults(
+            device_count_range=[4, 4],
+            inter_device_delay_range=[0.5, 2.0],
+        )
+        _, _, delays, _ = build_random_plan(devices, defaults)
+        assert delays[0] == 0.0  # first is always 0
+        for d in delays[1:]:
+            assert 0.5 <= d <= 2.0
+
+    def test_selected_are_from_input(self) -> None:
+        devices = [_device(f"v{i}") for i in range(5)]
+        selected, *_ = build_random_plan(devices, ActuationDefaults())
+        for d in selected:
+            assert d in devices
+
+    def test_no_duplicate_devices(self) -> None:
+        devices = [_device(f"v{i}") for i in range(5)]
+        for _ in range(30):
+            selected, *_ = build_random_plan(devices, ActuationDefaults())
+            ids = [d.device_id for d in selected]
+            assert len(ids) == len(set(ids))

--- a/services/log-streamer/Dockerfile
+++ b/services/log-streamer/Dockerfile
@@ -8,6 +8,8 @@ FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99
 
 WORKDIR /app
 
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 COPY services/log-streamer/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
     pip install --no-cache-dir -r requirements.txt

--- a/services/log-streamer/Dockerfile
+++ b/services/log-streamer/Dockerfile
@@ -4,7 +4,7 @@
 # Lightweight sidecar that tails Docker container logs and publishes them
 # to Redis.  Replaces the Docker socket mount previously needed by the
 # web container for the admin logs tab.
-FROM python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
+FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/notifier/Dockerfile
+++ b/services/notifier/Dockerfile
@@ -1,6 +1,6 @@
 # Build context: repo root
 # docker build -f services/notifier/Dockerfile -t scarguard-notifier .
-FROM python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
+FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/notifier/Dockerfile
+++ b/services/notifier/Dockerfile
@@ -4,7 +4,9 @@ FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY services/notifier/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -1,5 +1,5 @@
 # Build context: repo root
-FROM python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
+FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -3,7 +3,9 @@ FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY services/web/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \

--- a/services/web/src/config_model.py
+++ b/services/web/src/config_model.py
@@ -278,6 +278,39 @@ class TLSConfig(BaseModel):
     key_path: str = "/config/certs/key.pem"
 
 
+class TuyaCredentialsConfig(BaseModel):
+    api_key: str = ""
+    api_secret: str = ""
+    api_region: str = "us"
+
+
+class ActuationDeviceConfig(BaseModel):
+    name: str
+    device_id: str
+    type: Literal["sprinkler", "light", "sound", "plug"] = "sprinkler"
+    enabled: bool = True
+
+    @field_validator("name")
+    @classmethod
+    def name_nonempty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Device name must not be empty")
+        return v.strip()
+
+    @field_validator("device_id")
+    @classmethod
+    def device_id_nonempty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Device ID must not be empty")
+        return v.strip()
+
+
+class ActuationConfig(BaseModel):
+    enabled: bool = False
+    tuya: TuyaCredentialsConfig = TuyaCredentialsConfig()
+    devices: list[ActuationDeviceConfig] = []
+
+
 class StructuredConfigPayload(BaseModel):
     """Subset of scarguard.yml written by the structured form editor.
 
@@ -290,3 +323,4 @@ class StructuredConfigPayload(BaseModel):
     detection: DetectionConfig = DetectionConfig()
     notifications: NotificationsConfig = NotificationsConfig()
     tls: TLSConfig = TLSConfig()
+    deterrent: ActuationConfig = ActuationConfig()

--- a/services/web/src/config_redact.py
+++ b/services/web/src/config_redact.py
@@ -27,6 +27,8 @@ _STRUCTURAL_PATHS: tuple[tuple[str, ...], ...] = (
     ("cameras", "[]", "rtsp_url"),
     ("notifications", "discord", "webhook_url"),
     ("notifications", "email", "smtp_pass"),
+    ("deterrent", "tuya", "api_key"),
+    ("deterrent", "tuya", "api_secret"),
 )
 
 # Field-name heuristic for the heterogeneous `notifications.channels` list

--- a/services/web/src/main.py
+++ b/services/web/src/main.py
@@ -20,6 +20,7 @@ from routes import (
     audit_log,
     config,
     dashboard,
+    deterrent,
     events,
     feedback,
     models,
@@ -198,6 +199,7 @@ async def auth_middleware(request: Request, call_next):
 
     # Default: no authenticated user. Always set so templates can safely read it.
     request.state.user = None
+    request.state.deterrent_enabled = False  # set properly below when config loads
 
     # Always allow public paths (login page, setup page, static assets)
     if _is_public(path):
@@ -209,6 +211,10 @@ async def auth_middleware(request: Request, call_next):
     system_cfg = cfg.get("system") or {}
     auth_cfg = system_cfg.get("auth") or {}
     auth_enabled = _parse_auth_enabled(auth_cfg.get("enabled", True))
+
+    # Expose deterrent state to base.html nav (controls Deterrent link visibility)
+    act_cfg = cfg.get("deterrent") or {}
+    request.state.deterrent_enabled = bool(act_cfg.get("enabled", False))
 
     if not auth_enabled:
         # When auth is disabled (single-user / dev / test setups), grant every
@@ -412,3 +418,4 @@ app.include_router(training.router)
 app.include_router(audit_log.router)
 app.include_router(snapshot.router)
 app.include_router(feedback.router)
+app.include_router(deterrent.router)

--- a/services/web/src/routes/config.py
+++ b/services/web/src/routes/config.py
@@ -13,6 +13,7 @@ import db
 import redis.asyncio as aioredis
 import yaml
 from config_model import (
+    ActuationConfig,
     CameraConfig,
     DetectionConfig,
     NotificationsConfig,
@@ -93,6 +94,7 @@ def _parse_cfg(raw_cfg: dict) -> StructuredConfigPayload:
         detection=_section(DetectionConfig, raw_cfg.get("detection", {})),
         notifications=_section(NotificationsConfig, raw_cfg.get("notifications", {})),
         tls=_section(TLSConfig, raw_cfg.get("tls", {})),
+        deterrent=_section(ActuationConfig, raw_cfg.get("deterrent", {})),
     )
 
 
@@ -117,6 +119,11 @@ def _redact_parsed_cfg(cfg: StructuredConfigPayload) -> None:
     email = cfg.notifications.email
     if email.smtp_pass:
         email.smtp_pass = REDACTED_PLACEHOLDER
+    tuya = cfg.deterrent.tuya
+    if tuya.api_key:
+        tuya.api_key = REDACTED_PLACEHOLDER
+    if tuya.api_secret:
+        tuya.api_secret = REDACTED_PLACEHOLDER
 
 
 def _cameras_json(cfg_cameras: list[CameraConfig]) -> str:
@@ -304,6 +311,13 @@ async def save_structured_config(request: Request) -> Response:
         payload.tls.model_dump()
     )
     existing["tls"] = payload.tls.model_dump()
+
+    # Merge deterrent: preserve fields the form doesn't know about (e.g.
+    # defaults, battery_monitor) while updating enabled/tuya/devices.
+    existing_act = existing.get("deterrent", {})
+    if not isinstance(existing_act, dict):
+        existing_act = {}
+    existing["deterrent"] = {**existing_act, **payload.deterrent.model_dump()}
 
     config_store.save(existing)
     audit.record_request(

--- a/services/web/src/routes/config.py
+++ b/services/web/src/routes/config.py
@@ -312,12 +312,15 @@ async def save_structured_config(request: Request) -> Response:
     )
     existing["tls"] = payload.tls.model_dump()
 
-    # Merge deterrent: preserve fields the form doesn't know about (e.g.
-    # defaults, battery_monitor) while updating enabled/tuya/devices.
+    # Merge deterrent: the config page only sends ``enabled``; the full
+    # device list and credentials live on the dedicated /admin/deterrent page.
+    # Only merge the fields the structured form actually controls to avoid
+    # wiping Tuya keys/devices with empty defaults on unrelated config saves.
     existing_act = existing.get("deterrent", {})
     if not isinstance(existing_act, dict):
         existing_act = {}
-    existing["deterrent"] = {**existing_act, **payload.deterrent.model_dump()}
+    existing_act["enabled"] = payload.deterrent.enabled
+    existing["deterrent"] = existing_act
 
     config_store.save(existing)
     audit.record_request(

--- a/services/web/src/routes/deterrent.py
+++ b/services/web/src/routes/deterrent.py
@@ -1,0 +1,117 @@
+"""Deterrent admin page — Tuya credentials and device management."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import config_store
+from config_redact import REDACTED_PLACEHOLDER
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
+from route_auth import has_admin_access, require_admin, require_viewer
+from starlette.responses import Response
+
+log = logging.getLogger(__name__)
+router = APIRouter(prefix="/admin/deterrent")
+templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
+
+
+@router.get("", response_class=HTMLResponse)
+async def deterrent_page(request: Request) -> Response:
+    """Deterrent config page — Tuya credentials and device list."""
+    gate = require_viewer(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    cfg = config_store.load()
+    act: dict[str, Any] = cfg.get("deterrent", {})
+    if not isinstance(act, dict):
+        act = {}
+
+    read_only = not has_admin_access(request)
+    tuya: dict[str, Any] = act.get("tuya", {})
+    if not isinstance(tuya, dict):
+        tuya = {}
+    devices: list[dict[str, Any]] = act.get("devices", [])
+    if not isinstance(devices, list):
+        devices = []
+
+    # Redact for viewers
+    if read_only:
+        if tuya.get("api_key"):
+            tuya["api_key"] = REDACTED_PLACEHOLDER
+        if tuya.get("api_secret"):
+            tuya["api_secret"] = REDACTED_PLACEHOLDER
+
+    return templates.TemplateResponse(
+        request,
+        "deterrent.html",
+        {
+            "read_only": read_only,
+            "enabled": act.get("enabled", False),
+            "tuya": tuya,
+            "devices": devices,
+            "devices_json": json.dumps(devices),
+        },
+    )
+
+
+@router.post("", response_class=JSONResponse)
+async def save_deterrent(request: Request) -> Response:
+    """Save deterrent config — admin only."""
+    gate = require_admin(request, is_api=True)
+    if not isinstance(gate, dict):
+        return gate
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "Invalid JSON"}, status_code=400)
+
+    existing = config_store.load()
+    existing_act: dict[str, Any] = existing.get("deterrent", {})
+    if not isinstance(existing_act, dict):
+        existing_act = {}
+
+    # Update tuya credentials (skip if redacted)
+    tuya_input = body.get("tuya", {})
+    if isinstance(tuya_input, dict):
+        existing_tuya = existing_act.get("tuya", {})
+        if not isinstance(existing_tuya, dict):
+            existing_tuya = {}
+        for key in ("api_key", "api_secret", "api_region"):
+            val = tuya_input.get(key, "")
+            if val and val != REDACTED_PLACEHOLDER:
+                existing_tuya[key] = val
+            elif key == "api_region" and val:
+                existing_tuya[key] = val
+        existing_act["tuya"] = existing_tuya
+
+    # Update devices list
+    devices_input = body.get("devices")
+    if isinstance(devices_input, list):
+        clean_devices = []
+        for d in devices_input:
+            if not isinstance(d, dict):
+                continue
+            name = str(d.get("name", "")).strip()
+            device_id = str(d.get("device_id", "")).strip()
+            if not name or not device_id:
+                continue
+            clean_devices.append({
+                "name": name,
+                "device_id": device_id,
+                "type": d.get("type", "sprinkler"),
+                "enabled": bool(d.get("enabled", True)),
+            })
+        existing_act["devices"] = clean_devices
+
+    existing["deterrent"] = existing_act
+    config_store.save(existing)
+
+    log.info("Deterrent config saved — %d device(s)", len(existing_act.get("devices", [])))
+    return JSONResponse({"ok": True})

--- a/services/web/src/routes/deterrent.py
+++ b/services/web/src/routes/deterrent.py
@@ -77,19 +77,33 @@ async def save_deterrent(request: Request) -> Response:
     if not isinstance(existing_act, dict):
         existing_act = {}
 
-    # Update tuya credentials (skip if redacted)
+    # Update tuya credentials — only persist if both required fields are
+    # present to avoid writing a partial block that breaks service startup.
+    # Redacted placeholder values are ignored (viewer submitted the form).
     tuya_input = body.get("tuya", {})
     if isinstance(tuya_input, dict):
         existing_tuya = existing_act.get("tuya", {})
         if not isinstance(existing_tuya, dict):
             existing_tuya = {}
-        for key in ("api_key", "api_secret", "api_region"):
-            val = tuya_input.get(key, "")
-            if val and val != REDACTED_PLACEHOLDER:
-                existing_tuya[key] = val
-            elif key == "api_region" and val:
-                existing_tuya[key] = val
-        existing_act["tuya"] = existing_tuya
+        api_key = tuya_input.get("api_key", "")
+        api_secret = tuya_input.get("api_secret", "")
+        api_region = tuya_input.get("api_region", "us")
+
+        # Resolve effective values: use input unless it's redacted/empty,
+        # in which case keep the existing value.
+        eff_key = api_key if (api_key and api_key != REDACTED_PLACEHOLDER) else existing_tuya.get("api_key", "")
+        eff_secret = api_secret if (api_secret and api_secret != REDACTED_PLACEHOLDER) else existing_tuya.get("api_secret", "")
+        eff_region = api_region if api_region else existing_tuya.get("api_region", "us")
+
+        if eff_key and eff_secret:
+            existing_tuya["api_key"] = eff_key
+            existing_tuya["api_secret"] = eff_secret
+            existing_tuya["api_region"] = eff_region
+            existing_act["tuya"] = existing_tuya
+        elif not eff_key and not eff_secret:
+            # Both cleared — remove tuya block entirely
+            existing_act.pop("tuya", None)
+        # else: one field set, one empty — keep existing tuya unchanged
 
     # Update devices list
     devices_input = body.get("devices")

--- a/services/web/src/static/config.js
+++ b/services/web/src/static/config.js
@@ -309,6 +309,9 @@ function readForm() {
       cert_path: document.getElementById("tls-cert-path").value.trim(),
       key_path: document.getElementById("tls-key-path").value.trim(),
     },
+    deterrent: {
+      enabled: document.getElementById("deterrent-enabled").checked,
+    },
   };
 }
 

--- a/services/web/src/templates/base.html
+++ b/services/web/src/templates/base.html
@@ -35,6 +35,7 @@
           <div class="nav-dropdown__sep"></div>
           {% if _is_admin %}<a href="/admin/users">Users</a>{% endif %}
           {% if _is_admin %}<a href="/admin/audit-log">Audit Log</a>{% endif %}
+          {% if request.state.deterrent_enabled %}<a href="/admin/deterrent">Deterrent</a>{% endif %}
           <a href="/admin/training">Training Data</a>
           <a href="/admin/training/evaluate">Model Evaluation</a>
           <a href="/admin/backups">Config Backups</a>

--- a/services/web/src/templates/config.html
+++ b/services/web/src/templates/config.html
@@ -471,6 +471,28 @@
   </div>
 
   {# ── TLS ────────────────────────────────────────────────────────────────── #}
+  <div class="config-section" id="section-deterrent">
+    <div class="config-section-header" onclick="toggleSection('section-deterrent')">
+      <span class="config-section-label">Deterrent</span>
+      <span class="config-section-chevron">▾</span>
+    </div>
+    <div class="config-section-body">
+      <div class="card">
+        <p class="hint">
+          Physical deterrence via Tuya smart devices (sprinklers, lights, sirens).
+          {% if not read_only %}Configure devices on the <a href="/admin/deterrent">Deterrent page</a>.{% endif %}
+        </p>
+        <div class="field-group">
+          <label class="toggle-label">
+            <input type="checkbox" id="deterrent-enabled" {% if cfg.deterrent.enabled %}checked{% endif %}>
+            <span class="toggle-track"></span>
+            Enable physical deterrence
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="config-section collapsed expert-only" id="section-tls">
     <div class="config-section-header" onclick="toggleSection('section-tls')">
       <span class="config-section-label">TLS</span>

--- a/services/web/src/templates/deterrent.html
+++ b/services/web/src/templates/deterrent.html
@@ -1,0 +1,215 @@
+{% extends "base.html" %}
+{% block title %}Deterrent — ScarGuard{% endblock %}
+{% block content %}
+<h1>Deterrent Configuration</h1>
+<p class="muted" style="font-size:0.85rem;margin-bottom:1rem;">
+  Configure Tuya Cloud API credentials and manage deterrent devices.
+  See <a href="https://github.com/sentania-labs/scarguard/blob/main/TUYA_SETUP.md" target="_blank">TUYA_SETUP.md</a> for setup instructions.
+</p>
+
+{% if read_only %}
+<div class="readonly-banner">
+  <strong>Read-only view.</strong> API credentials are masked.
+</div>
+{% endif %}
+
+<div id="deterrent-msg" style="display:none;margin-bottom:1rem;" class="alert"></div>
+
+{# ── Tuya Credentials ──────────────────────────────────────────────────── #}
+<div class="card" style="margin-bottom:1.5rem;">
+  <h2 style="margin-top:0;font-size:1.1rem;">Tuya Cloud Credentials</h2>
+  <p class="hint">
+    Get these from your Tuya IoT Platform project at
+    <a href="https://iot.tuya.com" target="_blank">iot.tuya.com</a>.
+  </p>
+  <div class="field-row">
+    <div class="field-group">
+      <label>API Key (Access ID)</label>
+      <input type="text" id="tuya-api-key" value="{{ tuya.get('api_key', '') }}"
+             placeholder="Access ID from Tuya IoT Platform"
+             {% if read_only %}disabled{% endif %}>
+    </div>
+    <div class="field-group">
+      <label>API Secret (Access Secret)</label>
+      <input type="password" id="tuya-api-secret" value="{{ tuya.get('api_secret', '') }}"
+             placeholder="Access Secret from Tuya IoT Platform"
+             {% if read_only %}disabled{% endif %}>
+    </div>
+  </div>
+  <div class="field-group" style="max-width:12rem;">
+    <label>API Region</label>
+    <select id="tuya-api-region" {% if read_only %}disabled{% endif %}>
+      {% for r in ["us", "eu", "cn", "in"] %}
+      <option value="{{ r }}" {% if tuya.get('api_region', 'us') == r %}selected{% endif %}>{{ r }}</option>
+      {% endfor %}
+    </select>
+  </div>
+</div>
+
+{# ── Devices ────────────────────────────────────────────────────────────── #}
+<div class="card" style="margin-bottom:1.5rem;">
+  <h2 style="margin-top:0;font-size:1.1rem;">Devices</h2>
+  <p class="hint">
+    Each device needs a name, Tuya Device ID (from the Devices tab in your
+    Tuya IoT project), and a type.
+  </p>
+
+  <table id="devices-table" style="width:100%;border-collapse:collapse;font-size:0.9rem;">
+    <thead>
+      <tr style="text-align:left;border-bottom:2px solid var(--border);">
+        <th style="padding:0.4rem 0.5rem;">Name</th>
+        <th style="padding:0.4rem 0.5rem;">Device ID</th>
+        <th style="padding:0.4rem 0.5rem;width:8rem;">Type</th>
+        <th style="padding:0.4rem 0.5rem;width:4rem;">Enabled</th>
+        {% if not read_only %}<th style="padding:0.4rem 0.5rem;width:3rem;"></th>{% endif %}
+      </tr>
+    </thead>
+    <tbody id="devices-body">
+    </tbody>
+  </table>
+
+  {% if not read_only %}
+  <button type="button" class="btn-secondary" onclick="addDevice()" style="margin-top:0.75rem;">
+    + Add device
+  </button>
+  {% endif %}
+</div>
+
+{% if not read_only %}
+<button type="button" id="save-deterrent-btn" onclick="saveDeterrent()">Save</button>
+{% endif %}
+
+<script>
+var _devices = {{ devices_json|safe }};
+var _readOnly = {{ 'true' if read_only else 'false' }};
+
+function renderDevices() {
+  var tbody = document.getElementById('devices-body');
+  tbody.innerHTML = '';
+  _devices.forEach(function(dev, i) {
+    var tr = document.createElement('tr');
+    tr.style.borderBottom = '1px solid var(--border)';
+    if (_readOnly) {
+      tr.innerHTML =
+        '<td style="padding:0.4rem 0.5rem;">' + esc(dev.name) + '</td>' +
+        '<td style="padding:0.4rem 0.5rem;font-family:var(--mono);font-size:0.8rem;">' + esc(dev.device_id) + '</td>' +
+        '<td style="padding:0.4rem 0.5rem;">' + esc(dev.type || 'sprinkler') + '</td>' +
+        '<td style="padding:0.4rem 0.5rem;">' + (dev.enabled !== false ? 'Yes' : 'No') + '</td>';
+    } else {
+      tr.innerHTML =
+        '<td style="padding:0.4rem 0.5rem;"><input type="text" data-idx="' + i + '" data-field="name" value="' + esc(dev.name) + '" style="width:100%;"></td>' +
+        '<td style="padding:0.4rem 0.5rem;"><input type="text" data-idx="' + i + '" data-field="device_id" value="' + esc(dev.device_id) + '" style="width:100%;font-family:var(--mono);font-size:0.8rem;"></td>' +
+        '<td style="padding:0.4rem 0.5rem;"><select data-idx="' + i + '" data-field="type">' +
+          ['sprinkler','light','sound','plug'].map(function(t) {
+            return '<option value="' + t + '"' + ((dev.type || 'sprinkler') === t ? ' selected' : '') + '>' + t + '</option>';
+          }).join('') +
+        '</select></td>' +
+        '<td style="padding:0.4rem 0.5rem;text-align:center;"><input type="checkbox" data-idx="' + i + '" data-field="enabled"' + (dev.enabled !== false ? ' checked' : '') + '></td>' +
+        '<td style="padding:0.4rem 0.5rem;"><button type="button" class="btn-danger-sm" onclick="removeDevice(' + i + ')" title="Remove">x</button></td>';
+    }
+    tbody.appendChild(tr);
+  });
+}
+
+function addDevice() {
+  _devices.push({name: '', device_id: '', type: 'sprinkler', enabled: true});
+  renderDevices();
+  // Focus the new name field
+  var inputs = document.querySelectorAll('#devices-body input[data-field="name"]');
+  if (inputs.length) inputs[inputs.length - 1].focus();
+}
+
+function removeDevice(idx) {
+  _devices.splice(idx, 1);
+  renderDevices();
+}
+
+function readDevicesFromForm() {
+  var rows = document.querySelectorAll('#devices-body tr');
+  var devices = [];
+  rows.forEach(function(tr, i) {
+    var nameEl = tr.querySelector('[data-field="name"]');
+    var idEl = tr.querySelector('[data-field="device_id"]');
+    var typeEl = tr.querySelector('[data-field="type"]');
+    var enabledEl = tr.querySelector('[data-field="enabled"]');
+    if (nameEl && idEl) {
+      devices.push({
+        name: nameEl.value.trim(),
+        device_id: idEl.value.trim(),
+        type: typeEl ? typeEl.value : 'sprinkler',
+        enabled: enabledEl ? enabledEl.checked : true,
+      });
+    }
+  });
+  return devices;
+}
+
+function esc(s) {
+  if (!s) return '';
+  var d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+async function saveDeterrent() {
+  var btn = document.getElementById('save-deterrent-btn');
+  var msg = document.getElementById('deterrent-msg');
+  btn.disabled = true;
+  msg.style.display = 'none';
+
+  var devices = readDevicesFromForm();
+  // Validate
+  for (var i = 0; i < devices.length; i++) {
+    if (!devices[i].name) {
+      showMsg('Device ' + (i + 1) + ': name is required', true);
+      btn.disabled = false;
+      return;
+    }
+    if (!devices[i].device_id) {
+      showMsg('Device "' + devices[i].name + '": Device ID is required', true);
+      btn.disabled = false;
+      return;
+    }
+  }
+
+  var payload = {
+    tuya: {
+      api_key: document.getElementById('tuya-api-key').value.trim(),
+      api_secret: document.getElementById('tuya-api-secret').value.trim(),
+      api_region: document.getElementById('tuya-api-region').value,
+    },
+    devices: devices,
+  };
+
+  try {
+    var resp = await fetch('/admin/deterrent', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': getCsrfToken(),
+      },
+      body: JSON.stringify(payload),
+    });
+    var data = await resp.json();
+    if (data.ok) {
+      showMsg('Deterrent config saved. Changes apply within ~10 seconds.', false);
+      _devices = devices;
+    } else {
+      showMsg('Error: ' + (data.error || 'Unknown error'), true);
+    }
+  } catch (e) {
+    showMsg('Network error: ' + e.message, true);
+  }
+  btn.disabled = false;
+}
+
+function showMsg(text, isError) {
+  var msg = document.getElementById('deterrent-msg');
+  msg.textContent = text;
+  msg.className = 'alert ' + (isError ? 'alert-err' : 'alert-ok');
+  msg.style.display = '';
+}
+
+renderDevices();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary

- New `deterrent` Docker Compose service that triggers Tuya smart devices (sprinklers, lights, sirens, smart plugs) via the Tuya Cloud API when wildlife is detected
- Randomized activation patterns (device selection, duration, delays) to prevent habituation
- Web UI: enable/disable toggle on config page + dedicated `/admin/deterrent` page for Tuya credentials and device management
- `TUYA_SETUP.md` — step-by-step guide for Tuya IoT Platform account setup (L100-level for L200/L300 activity)
- Full CI/CD: lint, typecheck, pytest, Docker build, Trivy scan, compose smoke test, GHCR release

## Background

Cloud API was chosen over LAN control after validating that battery-powered Tuya devices deep-sleep with WiFi radio off — local TCP connections fail. Cloud API works reliably (~1-2s latency). Validated 2024-04-12 with a GreenVation WiFi sprinkler valve.

## What's in v0.13.0 (MVP)

Any detection (system armed, deterrent enabled, cooldown clear) fires all enabled devices with randomized timing. Config key is `deterrent` in `scarguard.yml`.

## What's deferred to 0.13.x

- Response profiles (species → device-type routing: heron = all devices, raccoon at night = lights + sound)
- Time-of-day conditions (sunrise/sunset)
- Dashboard test-fire button for notifications
- Deterrent page: per-device test-fire and per-profile test-fire buttons
- Dedicated deterrent admin page enhancements (device status, actuation log)

## Test plan

- [ ] `ruff check` passes for all services
- [ ] `mypy` passes for web, notifier, and deterrent
- [ ] `pytest` passes — 114 web tests, 15 deterrent tests
- [ ] Docker image builds for deterrent service
- [ ] Compose smoke test with deterrent included
- [ ] Manual: enable deterrent in config UI, add device on deterrent page, verify config hot-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)