### PR TITLE
security: fork-gate all pull_request workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
   build-web:
     name: Build web image
     runs-on: [self-hosted, linux, docker]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     permissions:
       contents: read
       packages: read
@@ -113,6 +114,7 @@ jobs:
   build-notifier:
     name: Build notifier image
     runs-on: [self-hosted, linux, docker]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     permissions:
       contents: read
       packages: read
@@ -175,6 +177,7 @@ jobs:
   build-deterrent:
     name: Build deterrent image
     runs-on: [self-hosted, linux, docker]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     permissions:
       contents: read
       packages: read
@@ -237,6 +240,7 @@ jobs:
   build-caddy:
     name: Build caddy image
     runs-on: [self-hosted, linux, docker]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     permissions:
       contents: read
 
@@ -262,6 +266,7 @@ jobs:
   build-log-streamer:
     name: Build log-streamer image
     runs-on: [self-hosted, linux, docker]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     permissions:
       contents: read
       security-events: write
@@ -311,6 +316,7 @@ jobs:
   build-detector:
     name: Build detector image (Jetson)
     runs-on: [self-hosted, linux, arm64, jetson]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
 
     steps:
       - uses: actions/checkout@v4
@@ -358,6 +364,7 @@ jobs:
   build-detector-x86:
     name: Build detector image (x86)
     runs-on: [self-hosted, linux, docker]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
 
     steps:
       - uses: actions/checkout@v4
@@ -402,7 +409,10 @@ jobs:
   # ── Compose smoke test (x86 runner) ─────────────────────────────────────────
   compose-smoke-test:
     name: Compose smoke test
-    if: github.event_name != 'push'
+    if: >-
+      github.event_name != 'push' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.owner.login == 'sentania-labs')
     needs: [build-detector-x86, build-web, build-notifier, build-deterrent, build-caddy, build-log-streamer]
     runs-on: [self-hosted, linux, docker]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   lint:
     name: Lint (ruff)
     runs-on: [self-hosted, linux, generic]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     steps:
       - uses: actions/checkout@v4
 
@@ -45,6 +46,7 @@ jobs:
   typecheck:
     name: Type check (mypy)
     runs-on: [self-hosted, linux, generic]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     steps:
       - uses: actions/checkout@v4
 
@@ -88,6 +90,7 @@ jobs:
   test-web:
     name: Tests — web
     runs-on: [self-hosted, linux, generic]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     steps:
       - uses: actions/checkout@v4
 
@@ -108,6 +111,7 @@ jobs:
   test-notifier:
     name: Tests — notifier
     runs-on: [self-hosted, linux, generic]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     steps:
       - uses: actions/checkout@v4
 
@@ -128,6 +132,7 @@ jobs:
   test-deterrent:
     name: Tests — deterrent
     runs-on: [self-hosted, linux, generic]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Adds a job-level condition to every workflow that triggers on pull_request (or pull_request_target), restricting execution to PRs whose head repo is owned by sentania-labs. Fork PRs from outside the org are skipped. Defense-in-depth alongside the org-level approval toggle enabled 2026-04-19. Condition added: if: github.event_name != pull_request || github.event.pull_request.head.repo.owner.login == sentania-labs. Where jobs already had if:, conditions combined with &&. No logic changes — gate only.