### PR TITLE
feat(v0.13.3): per-camera deterrent scoping + confidence + UI tabs + latency

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -67,14 +67,29 @@ detection:
   cooldown_seconds: 30
   frame_skip: 2
 
-  # Per-camera action rules (defined inside each camera block)
-  action_rules:
+  # Per-camera notification rules (defined inside each camera block)
+  # NOTE: v0.13.3 renamed `action_rules` → `notification_rules`.  Pre-v0.13.3
+  # configs are auto-migrated on load.
+  notification_rules:
     - class_name: great_blue_heron
       channels: [pond-alerts, owner-email]
     - class_name: bird
       channels: [pond-alerts]
     - class_name: "*"        # catch-all
       channels: [pond-alerts]
+
+  # Per-camera deterrent rules (v0.13.3+, defined inside each camera block).
+  # First-match-wins on class_name; empty list = no deterrent (explicit opt-in).
+  # Group names reference entries in deterrent.groups (below).
+  deterrent_rules:
+    - class_name: great_blue_heron
+      groups: [thermonuclear]        # the full battery of deterrents
+    - class_name: raccoon
+      groups: [minor]                # single siren
+
+  # Optional per-camera overrides (v0.13.3+).  Any omitted key inherits the
+  # corresponding global `detection.*` value.
+  confidence_threshold: 0.40         # higher than global for this camera's fine-tuned model
 
 notifications:
   channels:
@@ -260,6 +275,19 @@ The schedule is entirely optional. If the `schedule` key is missing, `enabled` i
 
 The `deterrent` section configures the deterrent service — automated physical deterrence via Tuya Cloud API. See [TUYA_SETUP.md](TUYA_SETUP.md) for obtaining API credentials.
 
+**v0.13.3 changed the firing model.** Prior to v0.13.3 any detection fired
+every enabled device.  From v0.13.3 onward, the deterrent service fires only
+**groups** explicitly referenced by a per-camera **`deterrent_rules`** entry
+(see the per-camera config section).  There is no default group — users
+deliberately opt-in each camera/class combination that should actuate.
+
+Firing is gated by two cooldown layers:
+
+1. **Per-group cooldown** (`deterrent.groups[].cooldown_seconds`) — prevents
+   the same group from firing twice in rapid succession.
+2. **Global cooldown** (`deterrent.defaults.cooldown_seconds`) — prevents
+   *any* actuation (across all groups) from firing more often than this.
+
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `deterrent.enabled` | bool | `false` | Master toggle for physical deterrence |
@@ -271,11 +299,18 @@ The `deterrent` section configures the deterrent service — automated physical 
 | `deterrent.devices[].type` | str | — | One of: `sprinkler`, `light`, `sound`, `plug` |
 | `deterrent.devices[].enabled` | bool | `true` | Whether this device participates in deterrence |
 | `deterrent.devices[].dp_code` | str | (auto) | Override the default DP code for on/off |
-| `deterrent.defaults.device_count_range` | list[int] | `[1, 4]` | Min/max devices to fire per event |
+| `deterrent.groups[].name` | str | — | **v0.13.3**: Unique group name (referenced from per-camera `deterrent_rules.groups`) |
+| `deterrent.groups[].devices` | list[str] | `[]` | **v0.13.3**: Device names (from the registry) fired by this group. A device may appear in multiple groups. |
+| `deterrent.groups[].cooldown_seconds` | int | `60` | **v0.13.3**: Minimum seconds between firings of this group (on top of the global cooldown). |
+| `deterrent.groups[].device_count_range` | list[int] \| null | inherit | **v0.13.3**: Override `defaults.device_count_range` for this group. `null` to inherit. |
+| `deterrent.groups[].spray_duration_range` | list[float] \| null | inherit | **v0.13.3**: Override spray duration. |
+| `deterrent.groups[].inter_device_delay_range` | list[float] \| null | inherit | **v0.13.3**: Override inter-device delay. |
+| `deterrent.groups[].pre_delay_range` | list[float] \| null | inherit | **v0.13.3**: Override pre-delay. |
+| `deterrent.defaults.device_count_range` | list[int] | `[1, 4]` | Min/max devices to fire per event (group override available) |
 | `deterrent.defaults.spray_duration_range` | list[float] | `[3.0, 8.0]` | Min/max seconds each device stays on |
 | `deterrent.defaults.inter_device_delay_range` | list[float] | `[1.0, 5.0]` | Min/max seconds between device activations |
 | `deterrent.defaults.pre_delay_range` | list[float] | `[0.0, 3.0]` | Min/max seconds before sequence starts |
-| `deterrent.defaults.cooldown_seconds` | int | `60` | Minimum gap between deterrence sequences |
+| `deterrent.defaults.cooldown_seconds` | int | `60` | **Global** cooldown — minimum gap between *any* two actuations across all groups. Group cooldowns stack on top. |
 | `deterrent.battery_monitor.enabled` | bool | `true` | Poll battery levels periodically |
 | `deterrent.battery_monitor.check_interval_hours` | int | `24` | Hours between battery checks |
 | `deterrent.battery_monitor.alert_threshold_percent` | int | `20` | Alert when battery drops below this |

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ ScarGuard watches the pond around the clock, identifies threats with a YOLO visi
 - **Email** — SMTP with optional snapshot attachment, multiple recipients
 - **Webhooks** — generic HTTP/HTTPS POST or GET to any URL, with custom headers
 - Named, multi-instance channels — run two Discord webhooks, two email addresses, multiple webhooks side-by-side
-- Action-rule routing — route heron detections to a deterrent webhook, raccoon detections to email only, etc.
+- Per-camera notification rules — route heron detections on pond-south to the heron alert channel, raccoon detections on back-yard to email only, etc. (v0.13.3: renamed from `action_rules`)
 - Retry with exponential backoff on transient failures
 
 ### Web UI
 - **Dashboard** — arm/disarm toggle, latest detection, today's count, schedule status
 - **Events** — paginated detection log with filters (camera, class, date range), snapshot overlays with bounding box rendering, real-time inserts via SSE, per-event feedback
 - **Live Feed** — SSE-driven annotated detection snapshots with offline indicator and auto-reconnect
-- **Settings** — full config editor (form-based and raw YAML), cameras, detection, notifications, channels, action rules, schedule, authentication, TLS
+- **Settings** — sub-tabbed config editor (System / Detection / Cameras / Notifications / Advanced), plus raw YAML view. Per-camera model, confidence, classes, exclusion zones, notification rules, and deterrent rules.
 - **System Stats** — real-time CPU, RAM, GPU usage and temperature, per-camera inference FPS, rolling charts
 - **Logs** — live service log tail with level filtering and pause/resume
 - **Training Data** — per-class feedback breakdown, dataset quality warnings, YOLO export
@@ -410,42 +410,40 @@ All channels can be added, edited, and enabled/disabled from the **Settings → 
 
 ---
 
-### Action Rules
+### Per-Camera Rules — Notifications and Deterrents
 
-Action rules control which notification channels fire for which detections. Without any rules defined, every detection triggers all enabled channels. With rules, you can route heron detections to a deterrent webhook while routing raccoon detections to Discord only.
+Two parallel rule systems live on each camera.  Both are lists of `{class_name,
+<target>}` entries evaluated top-down — the first rule whose `class_name` matches
+wins (`*` is the wildcard).
 
-Rules are defined at the top level of `scarguard.yml` and matched top-down — the first matching rule wins:
+- **`notification_rules`** — routes detections to specific named channels.
+  Without any rules defined, every detection notifies every enabled channel.
+  *(v0.13.3 renamed this from `action_rules`; old configs are auto-migrated on
+  load.)*
+- **`deterrent_rules`** (v0.13.3+) — fires named deterrent groups.  Empty means
+  *no deterrent action* — deterrents are explicit opt-in.
+
+Example camera block:
 
 ```yaml
-action_rules:
-  # Herons: notify Discord AND send to deterrent webhook
-  - class: great_blue_heron
-    actions: [pond-discord, deterrent-webhook]
-
-  # Green herons: Discord only
-  - class: green_heron
-    actions: [pond-discord]
-
-  # Raccoons: alert the owner, no deterrent notification
-  - class: raccoon
-    actions: [pond-discord, owner-email]
-
-  # Anything else on the pond-north camera: log it only (no notification)
-  - class: "*"
-    camera: pond-north
-    actions: []
-
-  # Catch-all: everything else goes to Discord
-  - class: "*"
-    actions: [pond-discord]
+cameras:
+  - name: pond-south
+    rtsp_url: rtsps://...
+    notification_rules:
+      - class_name: great_blue_heron
+        channels: [pond-discord, owner-email]
+      - class_name: "*"
+        channels: [pond-discord]
+    deterrent_rules:
+      - class_name: great_blue_heron
+        groups: [thermonuclear]        # all deterrents
+      - class_name: raccoon
+        groups: [minor]                # siren only
+      # no wildcard → anything else on this camera fires no deterrent
 ```
 
-Rule fields:
-- `class` — the detected class name, or `"*"` to match any class
-- `camera` — optional; if set, the rule only applies to detections from that camera
-- `actions` — list of channel names to notify; empty list `[]` means log-only (silent)
-
-The channel names in `actions` must match names defined in `notifications.channels`. Action rules are editable in the web UI under **Settings → Action Rules**.
+Both rule tables are edited in the web UI on the **Config → Cameras** sub-tab.
+Deterrent groups themselves live on **/admin/deterrent → Groups**.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Active and planned features. Each item includes acceptance criteria. Completed f
 New `deterrent` Docker Compose service for automated physical deterrence. Subscribes to `scarguard:detections` on Redis and triggers Tuya smart devices via the **Tuya Cloud API** (`tinytuya.Cloud`). Supports sprinklers, lights, sirens, and smart plugs — any device in the Tuya/Smart Life ecosystem. Randomized activation patterns (device selection, duration, delays) to prevent wildlife habituation.
 
 - **v0.13.0 (MVP):** Any detection fires all enabled devices with randomized timing and global cooldown. Opt-in via `deterrent.enabled` in config.
-- **v0.13.x:** Response profiles (species-based routing, time-of-day conditions, device-type filtering). Example: heron = all deterrents ("Global Thermonuclear War"), raccoon at night = lights + sound only.
+- ~~**v0.13.x:** Response profiles (species-based routing, time-of-day conditions, device-type filtering).~~ — ✓ Species-based routing shipped in v0.13.3 via deterrent groups + per-camera `deterrent_rules`. Time-of-day conditions remain a Future Idea.
 - **Hardware:** Off-the-shelf Tuya/Smart Life smart devices — hose timer valves, smart plugs, lights, sirens. Battery-powered devices work via Cloud API (LAN control not viable due to deep sleep).
 - **Config:** `deterrent` section in `scarguard.yml` — Tuya Cloud credentials, device definitions (device_id, type), randomization ranges, cooldown, battery alert thresholds.
 - **Setup guide:** [TUYA_SETUP.md](TUYA_SETUP.md) — step-by-step instructions for creating a Tuya IoT Platform account and obtaining API credentials.
@@ -150,6 +150,8 @@ first version where ScarGuard fully delivers on its name.
 ## Future Ideas (Unprioritized)
 
 - Twilio SMS notifications — paid per-message, but works on any phone without an app
+- Per-rule cooldown override — extend deterrent rules with an optional cooldown override, e.g. "heron: 10s, raccoon: 5min" without creating separate groups. v0.13.3 already supports per-group cooldown; this would add a per-match-row override. Deferred from 0.13.3 to keep scope focused.
+- Time-of-day conditions on deterrent rules — e.g. "raccoon at night only". Originally listed under v0.13.x; scoped out of the v0.13.3 rule engine.
 - Per-class cooldown — different cooldown values per detected species (e.g. 30s for squirrels, 5min for herons)
 - Mobile-friendly layout — basic nav responsiveness added in v0.11 (admin menu touch support, nav wrapping); full responsive CSS for all pages remains a future item
 - UI polish — logo, favicon, login screen branding. Japanese-inspired koi aesthetic. Use AI image generation for assets. Lowest priority.

--- a/STATUS.md
+++ b/STATUS.md
@@ -56,12 +56,24 @@
 - **Redis authentication:** `requirepass` with `REDIS_PASSWORD` env var across all services.
 - **FairLock inference scheduling:** FIFO lock prevents camera thread starvation when multiple cameras share a YOLO model.
 - **Caddy reverse proxy:** TLS termination, automatic HTTPS via Let's Encrypt or manual certs.
-- **Physical deterrence (v0.13.0):** Deterrent service controls Tuya smart devices (sprinklers, lights, sirens, plugs) via Cloud API. Any detection fires all enabled devices with randomized timing and global cooldown. Opt-in via `deterrent.enabled`.
+- **Physical deterrence (v0.13.0):** Deterrent service controls Tuya smart devices (sprinklers, lights, sirens, plugs) via Cloud API. Opt-in via `deterrent.enabled`.
 - **Deterrent web UI (v0.13.1):** Actuation log page with live SSE updates, device status panel (online/battery/switch), per-device test-fire button, actuation defaults and battery monitor config UI. Log streaming includes deterrent service.
+- **Per-camera deterrent scoping (v0.13.3):** Deterrent now fires only groups explicitly referenced by per-camera `deterrent_rules`. Groups are named subsets of the device registry with their own randomization + cooldown. No defaults — users opt-in deliberately per camera/class.
+- **Per-camera confidence override (v0.13.3):** Optional `confidence_threshold` per camera, useful for pairing fine-tuned species models with higher thresholds than a general COCO model. Inherits the global threshold when omitted.
+- **Config + Deterrent UI tabs (v0.13.3):** Config page Settings panel split into System / Detection / Cameras / Notifications / Advanced sub-tabs. Deterrent admin page split into Devices / Groups / Defaults / Battery / Latency tabs. URL-hash deep-linking.
+- **Actuation latency instrumentation (v0.13.3):** Per-event `trigger_delay_ms` (detection → dequeue) and `queue_depth`; per-device `cloud_ack_ms` (ON command → Tuya success). p50/p95 summary on the deterrent Latency tab.
 
 ## Known Issues / Buggy
 
-None currently identified.
+- **Tuya battery-device first-shot latency.** Battery-powered Tuya devices
+  (e.g. hose-timer valves) sleep their WiFi radio between Cloud beacons.
+  First actuation after idle can take seconds to tens of seconds before the
+  valve physically acts, because Tuya Cloud queues the command until the
+  device's next beacon.  The `cloud_ack_ms` field in the actuation log
+  measures the cloud-side ack latency only; actual physical response can
+  be longer.  See `TUYA_SETUP.md` for details.  No mitigation exists for
+  battery devices — the Tuya LAN fallback listed in ROADMAP Future Ideas is
+  explicitly not viable for sleeping devices.
 
 ## Not Yet Built
 
@@ -125,4 +137,5 @@ See [ROADMAP.md](ROADMAP.md) for upcoming work and [ROADMAP_ARCHIVE.md](ROADMAP_
 | v0.12.9 | **Follow-up: Caddy probe deny actually works now.** v0.12.8 edited `config/Caddyfile.template`, assuming it was the Caddyfile source of truth — it isn't. The live Caddy config is produced by a Python heredoc inside `config/caddy-entrypoint.sh`. v0.12.9 moves the `@probes` matcher + `respond 404` rule into the real heredoc, annotates `Caddyfile.template` as REFERENCE ONLY with an explicit warning, and adds a pointer comment in the entrypoint so future edits land in the right place. | ✅ Complete |
 | v0.13.0 | **Deterrent service MVP.** New `deterrent` Docker Compose service: subscribes to `scarguard:detections`, triggers Tuya smart devices (sprinklers, lights, sirens, plugs) via Cloud API. Randomized activation patterns, global cooldown, battery monitoring with low-battery alerts. Config hot-reload via ConfigWatcher. | ✅ Complete |
 | v0.13.1 | **Deterrent web UI.** (1) Actuation log page with live SSE updates, filtering, and pagination. (2) Device status panel — online/battery/switch state via Tuya Cloud query. (3) Per-device test-fire button. (4) Actuation defaults + battery monitor config UI. (5) Deterrent in log streaming filter. (6) About page deterrent status. (7) Security fixes: XSS in event stream, login redirect sanitization, /snapshot/send auth guard. (8) Detection publish fix — all detections now reach deterrent service regardless of action rules. | ✅ Complete |
-| v0.13.2 | **Review fixes + deprecation removal.** (1) Atomic config write in detector scheduler. (2) Pin all deps (tinytuya, tzdata, redis image digest). (3) Remove legacy flat notification keys (`notifications.discord` / `notifications.email`). (4) Documentation cleanup: README, CONFIG_REFERENCE, ROADMAP. (5) Redis auth guidance in .env.example. | 🚧 In progress |
+| v0.13.2 | **Review fixes + deprecation removal.** (1) Atomic config write in detector scheduler. (2) Pin all deps (tinytuya, tzdata, redis image digest). (3) Remove legacy flat notification keys (`notifications.discord` / `notifications.email`). (4) Documentation cleanup: README, CONFIG_REFERENCE, ROADMAP. (5) Redis auth guidance in .env.example. | ✅ Complete |
+| v0.13.3 | **Per-camera deterrent scoping + per-camera confidence + UI tab refactor + latency instrumentation.** (1) New `deterrent.groups` primitive — named subsets of devices with their own randomization + cooldown. (2) New per-camera `deterrent_rules` (first-match-wins) replace the fire-on-every-detection default. (3) Per-camera `confidence_threshold` override. (4) `action_rules` renamed to `notification_rules` with auto-migration on load. (5) Config page Settings panel split into sub-tabs; Deterrent page split into tabs + new Groups editor. (6) Latency instrumentation: `trigger_delay_ms`, `queue_depth`, per-device `cloud_ack_ms` with p50/p95 summary. (7) Tuya battery-device deep-sleep latency documented. (8) Dependabot bump: `python-multipart` 0.0.22 → 0.0.26. | 🚧 In progress |

--- a/TUYA_SETUP.md
+++ b/TUYA_SETUP.md
@@ -221,14 +221,44 @@ deterrent:
 
 ---
 
+## Known Latency Caveat — Battery Devices
+
+Battery-powered Tuya devices (hose-timer valves, battery sirens) **sleep
+their WiFi radio between Cloud beacons** to extend battery life.  When
+ScarGuard sends an ON command:
+
+1. Tuya Cloud accepts the command and queues it (fast — returns `success`
+   on the ack channel in ~100–500 ms).
+2. The physical device doesn't act until its next beacon checks in, which
+   can be **seconds to tens of seconds** after the ack.
+
+The Latency tab on `/admin/deterrent` shows `cloud_ack_ms` — the cloud-side
+ack time only.  The actual physical response can be longer.  The actuation
+log also persists `trigger_delay_ms` (detection → deterrent dequeue) for
+full end-to-end diagnosis.
+
+If first-shot latency on a battery valve proves consistently unworkable for
+your pond-protection use case, practical mitigations are limited.  The
+parked "Tuya LAN fallback" idea in the ROADMAP is explicitly NOT viable
+for battery devices — LAN TCP cannot reach a sleeping WiFi radio.  Mains-
+powered devices (light switches, plug-in sirens) do not have this problem.
+
 ## What's Next
 
-Once the deterrent service is running, detections will automatically trigger
-your devices. The MVP fires all enabled devices on any detection. Future
-releases (v0.13.x) will add response profiles for species-based routing:
+From v0.13.3, the deterrent service only fires when you **opt-in per
+camera/class**.  The flow is:
 
-- Heron detected → all deterrents fire (sprinklers + lights + sirens)
-- Raccoon at night → lights and sound only
-- Duck → gentle single-sprinkler deterrence
+1. Register devices on `/admin/deterrent` → **Devices** tab.
+2. Create one or more **groups** on the **Groups** tab — each group is a
+   named subset of devices with its own randomization + cooldown.
+3. On the Config page, open a camera card (Cameras sub-tab) and add
+   **Deterrent Rules** linking a detection class (e.g. `great_blue_heron`)
+   to a group name (e.g. `thermonuclear`).
 
-See [ROADMAP.md](ROADMAP.md) for the full plan.
+Example routing:
+
+- Pond-south + `great_blue_heron` → `thermonuclear` group (sprinklers + lights + sirens)
+- Pond-north + `raccoon` → `minor` group (siren only)
+- Front-door + `person` → *no deterrent rule* (notify only, no actuation)
+
+See [ROADMAP.md](ROADMAP.md) for upcoming work.

--- a/config/scarguard.example.yml
+++ b/config/scarguard.example.yml
@@ -94,24 +94,41 @@ cameras:
     enabled: true
     resolution: 720                               # Substream resolution hint (informational)
 
-  # ── Per-camera model & class overrides ──────────────────────────────────
-  # Optional: use a different YOLO model and/or detect different classes.
-  # If omitted, the camera inherits the global detection.model_path and
-  # detection.target_classes settings.
+  # ── Per-camera model, classes & confidence overrides ────────────────────
+  # Optional: use a different YOLO model, detect different classes, or run
+  # a different confidence threshold than the global `detection.*` values.
+  # Any field omitted inherits the global value.
   #
-  # model_path: /models/heron-v2.pt                # override global model
-  # detect_classes: [great_blue_heron, green_heron] # override global target_classes
+  # model_path: /models/heron-v2.pt                 # override global model
+  # detect_classes: [great_blue_heron, green_heron]  # override global target_classes
+  # confidence_threshold: 0.40                      # override global confidence (v0.13.3+)
 
-  # ── Per-camera action rules ─────────────────────────────────────────────
+  # ── Per-camera notification rules ────────────────────────────────────────
   # Optional: route detections to specific notification channels.
   # Rules are evaluated in order; the first match wins.
-  # Use class_name: "*" as a catch-all.  Omit action_rules to notify all channels.
+  # Use class_name: "*" as a catch-all.  Omit notification_rules to notify
+  # all channels.
   #
-  # action_rules:
+  # v0.13.3 renamed this from `action_rules` — legacy key auto-migrated on
+  # load.
+  #
+  # notification_rules:
   #   - class_name: great_blue_heron
   #     channels: [pond-alerts, email-digest]
   #   - class_name: "*"
   #     channels: [pond-alerts]
+
+  # ── Per-camera deterrent rules (v0.13.3+) ────────────────────────────────
+  # Explicit opt-in: only matched classes trigger deterrent actuation.
+  # Group names reference entries in `deterrent.groups` (see Actuation
+  # section further down).  Empty list = no deterrent for any detection on
+  # this camera.
+  #
+  # deterrent_rules:
+  #   - class_name: great_blue_heron
+  #     groups: [thermonuclear]
+  #   - class_name: raccoon
+  #     groups: [minor]
 
   # Add a second camera by uncommenting and editing:
   # - name: pond-south
@@ -213,7 +230,7 @@ redis:
   # ── Named channels (new format) ───────────────────────────────────────────
   # Define multiple named channels; each channel has a unique name and type.
   # When channels are defined, they take precedence over the legacy discord/email
-  # sections above.  Reference channels by name in camera action_rules.
+  # sections above.  Reference channels by name in camera notification_rules.
   #
   # Supported types: discord, email, webhook
   #

--- a/services/caddy/Dockerfile
+++ b/services/caddy/Dockerfile
@@ -1,6 +1,8 @@
 # Caddy reverse proxy with Python for config parsing.
 # Reads tls settings from scarguard.yml and generates a Caddyfile.
-FROM caddy:2-alpine@sha256:fce4f15aad23222c0ac78a1220adf63bae7b94355d5ea28eee53910624acedfa
+# v0.13.3: pull via Google's public Docker Hub mirror to dodge anon rate
+# limits on GHA shared-runner IPs.  Same digest, no quota.
+FROM mirror.gcr.io/library/caddy:2-alpine@sha256:fce4f15aad23222c0ac78a1220adf63bae7b94355d5ea28eee53910624acedfa
 
 RUN apk add --no-cache python3 py3-yaml
 

--- a/services/detector/src/detector.py
+++ b/services/detector/src/detector.py
@@ -47,6 +47,7 @@ class YOLODetector:
         self,
         frame: np.ndarray,
         target_classes: set[str] | None = None,
+        confidence: float | None = None,
     ) -> list[Detection]:
         """Run inference and return detections that pass class + confidence filters.
 
@@ -55,7 +56,11 @@ class YOLODetector:
 
         If *target_classes* is provided it overrides the instance-level filter,
         allowing cameras that share a model to detect different class subsets.
+        If *confidence* is provided it overrides the instance-level
+        confidence_threshold for this call only — enables per-camera
+        confidence tuning on a shared detector.
         """
+        conf = confidence if confidence is not None else self.confidence_threshold
         wait_seconds = self._lock.acquire()
         try:
             # NOTE: name + exist_ok are critical.  Ultralytics 8.3.x's Predictor
@@ -70,7 +75,7 @@ class YOLODetector:
             # short-circuits the scan loop on the very first iteration.
             results = self._model.predict(
                 frame,
-                conf=self.confidence_threshold,
+                conf=conf,
                 verbose=False,
                 save=False,
                 project="/tmp/runs",

--- a/services/detector/src/events.py
+++ b/services/detector/src/events.py
@@ -47,12 +47,17 @@ class EventProcessor:
         camera_name: str,
         frame: np.ndarray,
         actions_by_class: dict[str, list[str]] | None = None,
+        groups_by_class: dict[str, list[str]] | None = None,
     ) -> list[dict]:
         """
         Filter detections through cooldown logic and persist passing events.
 
         *actions_by_class* maps class_name → list of channel names to trigger.
         If absent or the class has no entry, all channels are notified (default).
+
+        *groups_by_class* maps class_name → list of deterrent group names to
+        fire.  Empty list or absent entry means "no deterrent action" —
+        deterrents are explicit-opt-in per v0.13.3 and have no "all" default.
 
         Returns a list of event dicts ready to be JSON-serialized and published.
         """
@@ -83,6 +88,10 @@ class EventProcessor:
                 actions_triggered: list[str] | None = []
             else:
                 actions_triggered = actions_by_class.get(det.class_name)
+            matched_groups: list[str] = (
+                list(groups_by_class.get(det.class_name, []))
+                if groups_by_class is not None else []
+            )
             self._persist(
                 timestamp, det, camera_name, snapshot_path,
                 actions_triggered, frame_size, feedback_token,
@@ -97,7 +106,7 @@ class EventProcessor:
 
             if actions_triggered is None:
                 logger.debug(
-                    "[%s] %s no matching action_rule — notifier will suppress",
+                    "[%s] %s no matching notification rule — notifier will suppress",
                     camera_name, det.class_name,
                 )
 
@@ -110,6 +119,7 @@ class EventProcessor:
                     "camera_name": camera_name,
                     "snapshot_path": snapshot_path,
                     "actions_triggered": actions_triggered,
+                    "matched_groups": matched_groups,
                     "bbox": bbox_list,
                     "frame_size": list(frame_size),
                     "feedback_token": feedback_token,

--- a/services/detector/src/main.py
+++ b/services/detector/src/main.py
@@ -56,6 +56,8 @@ class CameraState:
     stop_event: threading.Event
     zones_ref: AtomicRef[list[dict]]
     rules_ref: AtomicRef[list[dict]]
+    deterrent_rules_ref: AtomicRef[list[dict]]
+    confidence_ref: AtomicRef[float | None]
     model_path: str | None
     target_classes: set[str] | None
     detector: YOLODetector
@@ -74,8 +76,8 @@ def setup_logging(log_level: str) -> None:
     )
 
 
-def _match_action_rules(class_name: str, rules: list[dict]) -> list[str] | None:
-    """Return channel names for the first matching action rule.
+def _match_notification_rules(class_name: str, rules: list[dict]) -> list[str] | None:
+    """Return channel names for the first matching notification rule.
 
     Rules are evaluated in order; the first rule whose class_name matches
     (or is the wildcard "*") wins.  Returns ``None`` when no rule matches,
@@ -86,6 +88,23 @@ def _match_action_rules(class_name: str, rules: list[dict]) -> list[str] | None:
         if rule_class == "*" or rule_class == class_name:
             return list(rule.get("channels", []))
     return None
+
+
+def _match_deterrent_rules(class_name: str, rules: list[dict]) -> list[str]:
+    """Return deterrent group names for the first matching deterrent rule.
+
+    Rules are evaluated in order; the first rule whose class_name matches
+    (or is the wildcard "*") wins.  Returns ``[]`` when no rule matches —
+    no deterrent action should be taken for this class.  Unlike
+    notifications (which default to "notify all" when no rules exist),
+    deterrents default to "do nothing" per the v0.13.3 explicit-opt-in
+    design.
+    """
+    for rule in rules:
+        rule_class = rule.get("class_name", "*")
+        if rule_class == "*" or rule_class == class_name:
+            return list(rule.get("groups", []))
+    return []
 
 
 def _in_exclusion_zone(
@@ -125,20 +144,43 @@ def _resolve_known_channels(cfg: dict) -> set[str]:
     return channels
 
 
-def _validate_action_rules(
+def _validate_notification_rules(
     camera_name: str,
     rules: list[dict],
     known_channels: set[str],
 ) -> None:
-    """Log warnings for action rules that reference undefined channels."""
+    """Log warnings for notification rules that reference undefined channels."""
     for rule in rules:
         for ch_name in rule.get("channels", []):
             if ch_name not in known_channels:
                 logger.warning(
-                    "[%s] action_rules references unknown channel: %s",
+                    "[%s] notification_rules references unknown channel: %s",
                     camera_name,
                     ch_name,
                 )
+
+
+def _validate_deterrent_rules(
+    camera_name: str,
+    rules: list[dict],
+    known_groups: set[str],
+) -> None:
+    """Log warnings for deterrent rules that reference undefined groups."""
+    for rule in rules:
+        for g_name in rule.get("groups", []):
+            if g_name not in known_groups:
+                logger.warning(
+                    "[%s] deterrent_rules references unknown group: %s",
+                    camera_name,
+                    g_name,
+                )
+
+
+def _resolve_known_groups(cfg: dict) -> set[str]:
+    """Collect all defined deterrent group names from config."""
+    det = cfg.get("deterrent", {})
+    groups = det.get("groups", [])
+    return {g["name"] for g in groups if isinstance(g, dict) and g.get("name")}
 
 
 def _apply_exclusion_zones(
@@ -164,20 +206,45 @@ def _apply_exclusion_zones(
     return filtered
 
 
-def _evaluate_action_rules(
+def _evaluate_notification_rules(
     detections: list,
     rules: list[dict],
 ) -> dict[str, list[str] | None]:
-    """Build a class_name → channel list mapping from action rules."""
+    """Build a class_name → channel list mapping from notification rules."""
     actions_by_class: dict[str, list[str] | None] = {}
     if not rules:
         return actions_by_class
     for det in detections:
         if det.class_name not in actions_by_class:
-            actions_by_class[det.class_name] = _match_action_rules(
+            actions_by_class[det.class_name] = _match_notification_rules(
                 det.class_name, rules
             )
     return actions_by_class
+
+
+def _evaluate_deterrent_rules(
+    detections: list,
+    rules: list[dict],
+) -> dict[str, list[str]]:
+    """Build a class_name → group name list mapping from deterrent rules."""
+    groups_by_class: dict[str, list[str]] = {}
+    if not rules:
+        return groups_by_class
+    for det in detections:
+        if det.class_name not in groups_by_class:
+            groups_by_class[det.class_name] = _match_deterrent_rules(
+                det.class_name, rules
+            )
+    return groups_by_class
+
+
+def _read_camera_rules(camera_cfg: dict) -> list[dict]:
+    """Return the camera's notification_rules, falling back to legacy
+    action_rules (pre-v0.13.3 configs)."""
+    rules = camera_cfg.get("notification_rules")
+    if rules is None:
+        rules = camera_cfg.get("action_rules", [])
+    return list(rules or [])
 
 
 def _publish_detections(
@@ -188,11 +255,13 @@ def _publish_detections(
     publisher: RedisPublisher,
     visit_tracker: VisitTracker | None,
     actions_by_class: dict[str, list[str] | None],
+    groups_by_class: dict[str, list[str]],
 ) -> None:
     """Run cooldown dedup, publish events to Redis, and record visits."""
     events = event_processor.process(
         detections, camera_name, frame,
         actions_by_class=actions_by_class if actions_by_class else None,
+        groups_by_class=groups_by_class if groups_by_class else None,
     )
     for event in events:
         publisher.publish(event)
@@ -215,6 +284,8 @@ def run_camera(
     armed_ref: AtomicRef[bool],
     exclusion_zones_ref: AtomicRef[list[dict]],
     action_rules_ref: AtomicRef[list[dict]],
+    deterrent_rules_ref: AtomicRef[list[dict]],
+    confidence_ref: AtomicRef[float | None],
     stop_event: threading.Event,
     camera_stats: dict[str, dict] | None = None,
     camera_stats_lock: threading.Lock | None = None,
@@ -282,7 +353,11 @@ def run_camera(
 
         t0 = time.monotonic()
         try:
-            detections = detector.predict(frame, target_classes=target_classes)
+            detections = detector.predict(
+                frame,
+                target_classes=target_classes,
+                confidence=confidence_ref.get(),
+            )
         except TimeoutError:
             logger.warning("[%s] Inference lock timed out — skipping frame", name)
             continue
@@ -318,13 +393,17 @@ def run_camera(
         if not detections:
             continue
 
-        actions_by_class = _evaluate_action_rules(
+        actions_by_class = _evaluate_notification_rules(
             detections, action_rules_ref.get(),
+        )
+        groups_by_class = _evaluate_deterrent_rules(
+            detections, deterrent_rules_ref.get(),
         )
         _publish_detections(
             detections, name, frame,
             event_processor, publisher, visit_tracker,
             actions_by_class,
+            groups_by_class,
         )
 
     stream.release()
@@ -449,8 +528,9 @@ def main() -> None:
     signal.signal(signal.SIGTERM, _shutdown)
     signal.signal(signal.SIGINT, _shutdown)
 
-    # ---- Channel validation at startup ----------------------------------------
+    # ---- Channel + group validation at startup --------------------------------
     known_channels = _resolve_known_channels(cfg)
+    known_groups = _resolve_known_groups(cfg)
 
     # ---- Per-camera thread management -----------------------------------------
     active_cameras: dict[str, CameraState] = {}
@@ -474,16 +554,19 @@ def main() -> None:
             )
             return False
 
-        # Validate action rule channel references.
-        _validate_action_rules(
-            name,
-            camera_cfg.get("action_rules", []),
-            known_channels,
-        )
+        # Validate notification + deterrent rule references.
+        notif_rules = _read_camera_rules(camera_cfg)
+        _validate_notification_rules(name, notif_rules, known_channels)
+        det_rules = list(camera_cfg.get("deterrent_rules", []))
+        _validate_deterrent_rules(name, det_rules, known_groups)
 
         # Resolve per-camera target classes (None → use model/global default).
         cam_classes_raw: list[str] | None = camera_cfg.get("detect_classes")
         cam_classes: set[str] | None = set(cam_classes_raw) if cam_classes_raw is not None else None
+
+        # Per-camera confidence override (None → inherit global).
+        cam_conf_raw = camera_cfg.get("confidence_threshold")
+        cam_conf: float | None = float(cam_conf_raw) if cam_conf_raw is not None else None
 
         try:
             cam_detector = model_pool.get_detector(cam_model_path)
@@ -493,7 +576,9 @@ def main() -> None:
 
         cam_stop = threading.Event()
         zones_ref: AtomicRef[list[dict]] = AtomicRef(list(camera_cfg.get("exclusion_zones", [])))
-        rules_ref: AtomicRef[list[dict]] = AtomicRef(list(camera_cfg.get("action_rules", [])))
+        rules_ref: AtomicRef[list[dict]] = AtomicRef(notif_rules)
+        det_rules_ref: AtomicRef[list[dict]] = AtomicRef(det_rules)
+        conf_ref: AtomicRef[float | None] = AtomicRef(cam_conf)
         t = threading.Thread(
             target=run_camera,
             args=(
@@ -506,6 +591,8 @@ def main() -> None:
                 armed_ref,
                 zones_ref,
                 rules_ref,
+                det_rules_ref,
+                conf_ref,
                 cam_stop,
                 camera_stats,
                 camera_stats_lock,
@@ -521,6 +608,8 @@ def main() -> None:
             stop_event=cam_stop,
             zones_ref=zones_ref,
             rules_ref=rules_ref,
+            deterrent_rules_ref=det_rules_ref,
+            confidence_ref=conf_ref,
             model_path=effective_model,
             target_classes=cam_classes,
             detector=cam_detector,
@@ -596,7 +685,7 @@ def main() -> None:
 
     # ---- Config hot-reload ----------------------------------------------------
     def _on_config_change(new_cfg: dict) -> None:
-        nonlocal known_channels
+        nonlocal known_channels, known_groups
         new_sys = new_cfg.get("system", {})
         new_det = new_cfg.get("detection", {})
         new_cameras_list: list[dict] = [
@@ -646,8 +735,9 @@ def main() -> None:
             frame_skip_ref.set(new_frame_skip)
             changes.append(f"frame_skip={new_frame_skip}")
 
-        # Refresh known channels for validation.
+        # Refresh known channels + groups for validation.
         known_channels = _resolve_known_channels(new_cfg)
+        known_groups = _resolve_known_groups(new_cfg)
 
         # Update snapshot grabber camera list
         snapshot_grabber.update_cameras(new_cameras_list)
@@ -678,16 +768,28 @@ def main() -> None:
                     else:
                         changes.append(f"camera skipped after update (bad model): {cam_name}")
                 else:
-                    # Hot-reload exclusion zones and action rules for running cameras.
+                    # Hot-reload zones, rules, deterrent rules, confidence.
                     new_zones = list(cam_cfg.get("exclusion_zones", []))
                     if new_zones != state.zones_ref.get():
                         state.zones_ref.set(new_zones)
                         changes.append(f"exclusion_zones updated: {cam_name}")
-                    new_rules = list(cam_cfg.get("action_rules", []))
+                    new_rules = _read_camera_rules(cam_cfg)
                     if new_rules != state.rules_ref.get():
-                        _validate_action_rules(cam_name, new_rules, known_channels)
+                        _validate_notification_rules(cam_name, new_rules, known_channels)
                         state.rules_ref.set(new_rules)
-                        changes.append(f"action_rules updated: {cam_name}")
+                        changes.append(f"notification_rules updated: {cam_name}")
+                    new_det_rules = list(cam_cfg.get("deterrent_rules", []))
+                    if new_det_rules != state.deterrent_rules_ref.get():
+                        _validate_deterrent_rules(cam_name, new_det_rules, known_groups)
+                        state.deterrent_rules_ref.set(new_det_rules)
+                        changes.append(f"deterrent_rules updated: {cam_name}")
+                    new_conf_raw = cam_cfg.get("confidence_threshold")
+                    new_conf = float(new_conf_raw) if new_conf_raw is not None else None
+                    if new_conf != state.confidence_ref.get():
+                        state.confidence_ref.set(new_conf)
+                        changes.append(
+                            f"confidence_threshold updated: {cam_name} → {new_conf or 'inherit'}"
+                        )
 
         # cameras removed or disabled
         for name in old_camera_names - new_camera_names:

--- a/services/detector/tests/test_events.py
+++ b/services/detector/tests/test_events.py
@@ -131,8 +131,8 @@ def test_process_non_matching_rule_suppresses_event(tmp_path):
     processor.close()
 
 
-def _match_action_rules(class_name: str, rules: list[dict]) -> list[str] | None:
-    """Local copy of detector _match_action_rules for testing without cv2."""
+def _match_notification_rules(class_name: str, rules: list[dict]) -> list[str] | None:
+    """Local copy of detector _match_notification_rules for testing without cv2."""
     for rule in rules:
         rule_class = rule.get("class_name", "*")
         if rule_class == "*" or rule_class == class_name:
@@ -140,19 +140,54 @@ def _match_action_rules(class_name: str, rules: list[dict]) -> list[str] | None:
     return None
 
 
-def test_match_action_rules_returns_none_for_no_match():
-    """_match_action_rules returns None when no rule matches the class."""
+def _match_deterrent_rules(class_name: str, rules: list[dict]) -> list[str]:
+    """Local copy of detector _match_deterrent_rules for testing without cv2."""
+    for rule in rules:
+        rule_class = rule.get("class_name", "*")
+        if rule_class == "*" or rule_class == class_name:
+            return list(rule.get("groups", []))
+    return []
+
+
+def test_match_notification_rules_returns_none_for_no_match():
+    """_match_notification_rules returns None when no rule matches the class."""
     rules = [{"class_name": "bird", "channels": ["bird-alerts"]}]
-    assert _match_action_rules("bench", rules) is None
+    assert _match_notification_rules("bench", rules) is None
 
 
-def test_match_action_rules_returns_channels_for_match():
-    """_match_action_rules returns channel list for matching rule."""
+def test_match_notification_rules_returns_channels_for_match():
+    """_match_notification_rules returns channel list for matching rule."""
     rules = [{"class_name": "bird", "channels": ["bird-alerts-email", "bird-alerts-discord"]}]
-    assert _match_action_rules("bird", rules) == ["bird-alerts-email", "bird-alerts-discord"]
+    assert _match_notification_rules("bird", rules) == ["bird-alerts-email", "bird-alerts-discord"]
 
 
-def test_match_action_rules_wildcard_matches_any():
+def test_match_notification_rules_wildcard_matches_any():
     """Wildcard rule matches any class."""
     rules = [{"class_name": "*", "channels": ["all-alerts"]}]
-    assert _match_action_rules("anything", rules) == ["all-alerts"]
+    assert _match_notification_rules("anything", rules) == ["all-alerts"]
+
+
+def test_match_deterrent_rules_returns_empty_for_no_match():
+    """v0.13.3: deterrents default to do-nothing when no rule matches
+    (unlike notifications, which default to notify-all)."""
+    rules = [{"class_name": "bird", "groups": ["thermonuclear"]}]
+    assert _match_deterrent_rules("bench", rules) == []
+
+
+def test_match_deterrent_rules_returns_groups_for_match():
+    rules = [{"class_name": "heron", "groups": ["thermonuclear", "siren"]}]
+    assert _match_deterrent_rules("heron", rules) == ["thermonuclear", "siren"]
+
+
+def test_match_deterrent_rules_wildcard_matches_any():
+    rules = [{"class_name": "*", "groups": ["minor"]}]
+    assert _match_deterrent_rules("anything", rules) == ["minor"]
+
+
+def test_match_deterrent_rules_first_match_wins():
+    rules = [
+        {"class_name": "heron", "groups": ["thermonuclear"]},
+        {"class_name": "*", "groups": ["minor"]},
+    ]
+    assert _match_deterrent_rules("heron", rules) == ["thermonuclear"]
+    assert _match_deterrent_rules("duck", rules) == ["minor"]

--- a/services/deterrent/Dockerfile
+++ b/services/deterrent/Dockerfile
@@ -1,6 +1,8 @@
 # Build context: repo root
 # docker build -f services/deterrent/Dockerfile -t scarguard-deterrent .
-FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+# v0.13.3: pull via Google's public Docker Hub mirror to dodge anon rate
+# limits on GHA shared-runner IPs.
+FROM mirror.gcr.io/library/python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/deterrent/src/actuation_db.py
+++ b/services/deterrent/src/actuation_db.py
@@ -35,7 +35,9 @@ def _get_conn() -> sqlite3.Connection:
 
 
 def init_db() -> None:
-    """Create tables and indexes if they don't exist."""
+    """Create tables and indexes if they don't exist.  v0.13.3 adds three
+    latency columns + group_name — all additive, migrated with ALTER on
+    pre-existing databases."""
     with _lock:
         conn = _get_conn()
         conn.executescript("""
@@ -69,8 +71,24 @@ def init_db() -> None:
             CREATE INDEX IF NOT EXISTS idx_actions_event
                 ON device_actions(event_id);
         """)
+        # v0.13.3 additive columns — safe to re-run on existing DBs.
+        _add_column_if_missing(conn, "actuation_events", "group_name", "TEXT NOT NULL DEFAULT ''")
+        _add_column_if_missing(conn, "actuation_events", "trigger_delay_ms", "REAL")
+        _add_column_if_missing(conn, "actuation_events", "queue_depth", "INTEGER")
+        _add_column_if_missing(conn, "device_actions", "cloud_ack_ms", "REAL")
         conn.commit()
         logger.info("Actuation database initialised at %s", DB_PATH)
+
+
+def _add_column_if_missing(
+    conn: sqlite3.Connection, table: str, column: str, type_clause: str,
+) -> None:
+    """Add *column* of *type_clause* to *table* if it doesn't already exist."""
+    cols = {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
+    if column in cols:
+        return
+    conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {type_clause}")
+    logger.info("Added column %s.%s", table, column)
 
 
 def insert_event(event: ActuationEvent) -> int:
@@ -80,8 +98,9 @@ def insert_event(event: ActuationEvent) -> int:
         cur = conn.execute(
             """INSERT INTO actuation_events
                (timestamp, trigger_class, trigger_camera, trigger_confidence,
-                pre_delay_sec, total_duration_sec, device_count, success_count)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                pre_delay_sec, total_duration_sec, device_count, success_count,
+                group_name, trigger_delay_ms, queue_depth)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 event.timestamp,
                 event.trigger_class,
@@ -91,6 +110,9 @@ def insert_event(event: ActuationEvent) -> int:
                 event.total_duration_sec,
                 len(event.actions),
                 sum(1 for a in event.actions if a.success),
+                event.group_name,
+                event.trigger_delay_ms,
+                event.queue_depth,
             ),
         )
         event_id = cur.lastrowid
@@ -100,8 +122,8 @@ def insert_event(event: ActuationEvent) -> int:
             conn.execute(
                 """INSERT INTO device_actions
                    (event_id, device_name, device_id, device_type,
-                    duration_sec, delay_before_sec, success, error)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    duration_sec, delay_before_sec, success, error, cloud_ack_ms)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     event_id,
                     action.device_name,
@@ -111,6 +133,7 @@ def insert_event(event: ActuationEvent) -> int:
                     action.delay_before_sec,
                     int(action.success),
                     action.error,
+                    action.cloud_ack_ms,
                 ),
             )
         conn.commit()

--- a/services/deterrent/src/actuation_models.py
+++ b/services/deterrent/src/actuation_models.py
@@ -32,6 +32,35 @@ class ActuationDefaults(BaseModel):
     cooldown_seconds: int = 60
 
 
+class DeterrentGroup(BaseModel):
+    """A named subset of registered devices fired as a coordinated sequence.
+
+    A group references devices from the top-level ``deterrent.devices``
+    registry by ``name``.  A device may appear in multiple groups.  Any of
+    the *_range fields can be ``None`` (omitted) to inherit from
+    ``deterrent.defaults``.  ``cooldown_seconds`` is per-group — the global
+    ``deterrent.defaults.cooldown_seconds`` still gates cross-group repeats.
+    """
+
+    name: str
+    devices: list[str] = []
+    cooldown_seconds: int = 60
+    device_count_range: list[int] | None = None
+    spray_duration_range: list[float] | None = None
+    inter_device_delay_range: list[float] | None = None
+    pre_delay_range: list[float] | None = None
+
+    def effective_defaults(self, fallback: ActuationDefaults) -> ActuationDefaults:
+        """Return an ActuationDefaults where any group-level None inherits *fallback*."""
+        return ActuationDefaults(
+            device_count_range=self.device_count_range or fallback.device_count_range,
+            spray_duration_range=self.spray_duration_range or fallback.spray_duration_range,
+            inter_device_delay_range=self.inter_device_delay_range or fallback.inter_device_delay_range,
+            pre_delay_range=self.pre_delay_range or fallback.pre_delay_range,
+            cooldown_seconds=self.cooldown_seconds,
+        )
+
+
 class BatteryMonitorConfig(BaseModel):
     enabled: bool = True
     check_interval_hours: int = 24
@@ -42,6 +71,7 @@ class ActuationConfig(BaseModel):
     enabled: bool = False  # opt-in — disabled by default
     tuya: TuyaCredentials | None = None
     devices: list[DeviceConfig] = []
+    groups: list[DeterrentGroup] = []
     defaults: ActuationDefaults = ActuationDefaults()
     battery_monitor: BatteryMonitorConfig = BatteryMonitorConfig()
 
@@ -58,6 +88,10 @@ class DeviceAction(BaseModel):
     delay_before_sec: float
     success: bool = False
     error: str | None = None
+    # v0.13.3 latency instrumentation — time from sending the ON command to
+    # Tuya Cloud to receiving a success response.  None if the ON call
+    # raised before returning.
+    cloud_ack_ms: float | None = None
 
 
 class ActuationEvent(BaseModel):
@@ -65,6 +99,12 @@ class ActuationEvent(BaseModel):
     trigger_class: str
     trigger_camera: str
     trigger_confidence: float
+    # v0.13.3: which deterrent group fired this event.  Empty string for
+    # legacy events or test-fires.
+    group_name: str = ""
     pre_delay_sec: float
     actions: list[DeviceAction]
     total_duration_sec: float
+    # v0.13.3 latency instrumentation.
+    trigger_delay_ms: float | None = None  # detection timestamp → dequeue
+    queue_depth: int | None = None         # queue size at dequeue moment

--- a/services/deterrent/src/cloud_controller.py
+++ b/services/deterrent/src/cloud_controller.py
@@ -40,29 +40,39 @@ class TuyaCloudController:
         """Return the DP code to use for on/off toggling."""
         return device.dp_code or _DEFAULT_DP_CODES.get(device.type, "switch_1")
 
-    def activate_device(self, device: DeviceConfig, duration_sec: float) -> tuple[bool, str | None]:
+    def activate_device(
+        self, device: DeviceConfig, duration_sec: float,
+    ) -> tuple[bool, str | None, float | None]:
         """Turn *device* ON, wait *duration_sec*, then turn it OFF.
 
-        Returns ``(success, error_message)``.  A partial success (ON worked
-        but OFF failed) still returns ``True`` — the device will auto-timeout
-        on most Tuya firmware.
+        Returns ``(success, error_message, cloud_ack_ms)``.  A partial
+        success (ON worked but OFF failed) still returns ``True`` — the
+        device will auto-timeout on most Tuya firmware.  ``cloud_ack_ms``
+        is the elapsed time between sending the ON command to Tuya Cloud
+        and receiving a success response — useful for diagnosing battery-
+        device deep-sleep latency.  ``None`` if the ON call raised.
         """
         dp_code = self._dp_code_for(device)
         error: str | None = None
 
         # --- ON ---
+        t_on = time.monotonic()
         try:
             on_cmd: dict[str, Any] = {"commands": [{"code": dp_code, "value": True}]}
             result = self._cloud.sendcommand(device.device_id, on_cmd)
+            on_ack_ms = (time.monotonic() - t_on) * 1000.0
             if not result.get("success"):
                 msg = f"ON failed: {result}"
                 logger.error("Device %s (%s) — %s", device.name, device.device_id, msg)
-                return False, msg
-            logger.info("Device %s ON (dp=%s)", device.name, dp_code)
+                return False, msg, on_ack_ms
+            logger.info(
+                "Device %s ON (dp=%s) cloud_ack=%.0fms",
+                device.name, dp_code, on_ack_ms,
+            )
         except Exception as exc:
             msg = f"ON exception: {exc}"
             logger.error("Device %s (%s) — %s", device.name, device.device_id, msg)
-            return False, msg
+            return False, msg, None
 
         # --- HOLD ---
         time.sleep(duration_sec)
@@ -80,7 +90,7 @@ class TuyaCloudController:
             error = f"OFF exception (device may auto-timeout): {exc}"
             logger.warning("Device %s (%s) — %s", device.name, device.device_id, error)
 
-        return True, error
+        return True, error, on_ack_ms
 
     def get_device_status(self, device_id: str) -> dict[str, Any] | None:
         """Query device status (battery level, switch state, etc.).

--- a/services/deterrent/src/cooldown.py
+++ b/services/deterrent/src/cooldown.py
@@ -1,4 +1,15 @@
-"""Global cooldown tracker for actuation sequences."""
+"""Cooldown trackers for actuation sequences.
+
+Two layers:
+
+- ``CooldownTracker`` — a single global gate protecting against repeat
+  actuations of any kind inside ``defaults.cooldown_seconds``.  Prevents
+  cross-group rapid-fire (e.g. camera A firing "minor" and camera B firing
+  "thermonuclear" 50 ms apart).
+- ``GroupCooldownTracker`` — per-group gate gating repeat firings of the
+  same named group.  Lets you run a long group cooldown (10 min for
+  "thermonuclear") on top of a short global one (30 s).
+"""
 
 from __future__ import annotations
 
@@ -7,11 +18,7 @@ import time
 
 
 class CooldownTracker:
-    """Thread-safe cooldown gate.
-
-    MVP: single global cooldown.  Per-species cooldowns are planned for
-    0.13.x when response profiles are added.
-    """
+    """Thread-safe global cooldown gate."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
@@ -32,3 +39,36 @@ class CooldownTracker:
         with self._lock:
             remaining = cooldown_seconds - (time.monotonic() - self._last_actuation)
             return max(0.0, remaining)
+
+
+class GroupCooldownTracker:
+    """Per-group cooldown tracker.
+
+    Each group's last-fired monotonic timestamp lives in a dict guarded by
+    a single lock.  ``cooldown_seconds`` is passed per-query so a group's
+    cooldown can be updated from config without rebuilding the tracker.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._last: dict[str, float] = {}
+
+    def is_clear(self, group_name: str, cooldown_seconds: int) -> bool:
+        with self._lock:
+            last = self._last.get(group_name, 0.0)
+            return (time.monotonic() - last) >= cooldown_seconds
+
+    def record(self, group_name: str) -> None:
+        with self._lock:
+            self._last[group_name] = time.monotonic()
+
+    def seconds_remaining(self, group_name: str, cooldown_seconds: int) -> float:
+        with self._lock:
+            last = self._last.get(group_name, 0.0)
+            remaining = cooldown_seconds - (time.monotonic() - last)
+            return max(0.0, remaining)
+
+    def forget(self, group_name: str) -> None:
+        """Remove tracking for a group (e.g. after it's deleted from config)."""
+        with self._lock:
+            self._last.pop(group_name, None)

--- a/services/deterrent/src/main.py
+++ b/services/deterrent/src/main.py
@@ -15,12 +15,18 @@ from typing import Any
 import actuation_db
 import redis as redis_lib
 import yaml
-from actuation_models import ActuationConfig, ActuationEvent, DeviceAction
+from actuation_models import (
+    ActuationConfig,
+    ActuationEvent,
+    DeterrentGroup,
+    DeviceAction,
+    DeviceConfig,
+)
 from atomic_ref import AtomicRef
 from battery_monitor import BatteryMonitor
 from cloud_controller import TuyaCloudController
 from config_watcher import ConfigWatcher
-from cooldown import CooldownTracker
+from cooldown import CooldownTracker, GroupCooldownTracker
 from randomizer import build_random_plan
 from request_handler import RequestHandler
 
@@ -71,24 +77,148 @@ def build_controller(act_cfg: ActuationConfig) -> TuyaCloudController | None:
 # documented as thread-safe, and actuation sequences are inherently serial).
 # ---------------------------------------------------------------------------
 
+def _resolve_group_devices(
+    group: DeterrentGroup,
+    registry: list[DeviceConfig],
+) -> list[DeviceConfig]:
+    """Return the enabled devices referenced by *group*, preserving registry order."""
+    wanted = set(group.devices)
+    return [d for d in registry if d.enabled and d.name in wanted]
+
+
+def _parse_event_timestamp(event: dict[str, Any]) -> float | None:
+    """Return the event timestamp as unix seconds, or None if unparseable."""
+    ts = event.get("timestamp")
+    if not isinstance(ts, str):
+        return None
+    try:
+        return datetime.fromisoformat(ts).timestamp()
+    except ValueError:
+        return None
+
+
+def _fire_group(
+    group: DeterrentGroup,
+    act_cfg: ActuationConfig,
+    controller: TuyaCloudController,
+    event: dict[str, Any],
+    trigger_delay_ms: float | None,
+    queue_depth: int,
+    pub_holder: list[redis_lib.Redis | None],
+    redis_cfg: dict[str, Any],
+) -> bool:
+    """Fire a single deterrent group and persist/publish the resulting event.
+
+    Returns True if the group fired (at least one device was attempted),
+    False if it was skipped (e.g. no devices resolved).
+    """
+    group_devices = _resolve_group_devices(group, act_cfg.devices)
+    if not group_devices:
+        logger.warning(
+            "Group %r has no enabled devices resolvable from registry — skipping",
+            group.name,
+        )
+        return False
+
+    defaults = group.effective_defaults(act_cfg.defaults)
+    selected, durations, inter_delays, pre_delay = build_random_plan(
+        group_devices, defaults,
+    )
+
+    camera_name = event.get("camera_name", "unknown")
+    class_name = event.get("class_name", "")
+    confidence = event.get("confidence", 0.0)
+    logger.info(
+        "Firing group [%s]: %s from %s (conf=%.2f) — %d device(s)",
+        group.name, class_name, camera_name, confidence, len(selected),
+    )
+
+    t_start = time.monotonic()
+    actions: list[DeviceAction] = []
+
+    if pre_delay > 0:
+        logger.debug("Pre-delay: %.1fs", pre_delay)
+        time.sleep(pre_delay)
+
+    for i, device in enumerate(selected):
+        if inter_delays[i] > 0:
+            logger.debug("Inter-device delay: %.1fs", inter_delays[i])
+            time.sleep(inter_delays[i])
+
+        duration = durations[i]
+        logger.info(
+            "Firing device %s (%s) for %.1fs",
+            device.name, device.type, duration,
+        )
+        success, error, cloud_ack_ms = controller.activate_device(device, duration)
+        actions.append(DeviceAction(
+            device_name=device.name,
+            device_id=device.device_id,
+            device_type=device.type,
+            duration_sec=duration,
+            delay_before_sec=inter_delays[i],
+            success=success,
+            error=error,
+            cloud_ack_ms=cloud_ack_ms,
+        ))
+
+    total_duration = time.monotonic() - t_start
+
+    actuation_event = ActuationEvent(
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        trigger_class=class_name,
+        trigger_camera=camera_name,
+        trigger_confidence=confidence,
+        group_name=group.name,
+        pre_delay_sec=pre_delay,
+        actions=actions,
+        total_duration_sec=round(total_duration, 2),
+        trigger_delay_ms=trigger_delay_ms,
+        queue_depth=queue_depth,
+    )
+
+    successes = sum(1 for a in actions if a.success)
+    logger.info(
+        "Group [%s] complete: %d/%d devices fired in %.1fs (trigger_delay=%s)",
+        group.name, successes, len(actions), total_duration,
+        f"{trigger_delay_ms:.0f}ms" if trigger_delay_ms is not None else "n/a",
+    )
+
+    _publish_actuation(pub_holder, redis_cfg, actuation_event)
+    try:
+        actuation_db.insert_event(actuation_event)
+    except Exception:
+        logger.exception("Failed to persist actuation event")
+
+    return True
+
+
 def _worker(
     event_queue: queue.Queue[dict[str, Any] | None],
     act_cfg_ref: AtomicRef[ActuationConfig],
     controller_ref: AtomicRef[TuyaCloudController | None],
     armed_ref: AtomicRef[bool],
     cooldown: CooldownTracker,
+    group_cooldown: GroupCooldownTracker,
     redis_cfg: dict[str, Any],
 ) -> None:
-    """Consume detection events and run actuation sequences."""
+    """Consume detection events and run actuation sequences per matched group."""
     logger.info("Deterrent worker thread started")
 
-    # Mutable container so the lazily-created Redis client persists across calls.
     pub_holder: list[redis_lib.Redis | None] = [None]
 
     while True:
         event = event_queue.get()
         if event is None:  # poison pill — shutdown
             break
+
+        # Latency instrumentation — dequeue moment.
+        dequeue_ts = time.time()
+        queue_depth = event_queue.qsize()
+        event_ts = _parse_event_timestamp(event)
+        trigger_delay_ms: float | None = (
+            (dequeue_ts - event_ts) * 1000.0 if event_ts is not None else None
+        )
 
         act_cfg = act_cfg_ref.get()
         controller = controller_ref.get()
@@ -109,85 +239,61 @@ def _worker(
             logger.warning("No Tuya credentials configured — cannot actuate")
             continue
 
-        cooldown_sec = act_cfg.defaults.cooldown_seconds
-        if not cooldown.is_clear(cooldown_sec):
-            remaining = cooldown.seconds_remaining(cooldown_sec)
-            logger.info("Cooldown active (%.0fs remaining) — skipping", remaining)
-            continue
-
-        enabled_devices = [d for d in act_cfg.devices if d.enabled]
-        if not enabled_devices:
-            logger.warning("No enabled devices — cannot actuate")
-            continue
-
-        camera_name = event.get("camera_name", "unknown")
-        confidence = event.get("confidence", 0.0)
-        logger.info(
-            "Actuation triggered: %s from %s (conf=%.2f) — %d device(s) available",
-            class_name, camera_name, confidence, len(enabled_devices),
-        )
-
-        # Build randomised plan
-        selected, durations, inter_delays, pre_delay = build_random_plan(
-            enabled_devices, act_cfg.defaults,
-        )
-
-        # Execute
-        t_start = time.monotonic()
-        actions: list[DeviceAction] = []
-
-        if pre_delay > 0:
-            logger.debug("Pre-delay: %.1fs", pre_delay)
-            time.sleep(pre_delay)
-
-        for i, device in enumerate(selected):
-            if inter_delays[i] > 0:
-                logger.debug("Inter-device delay: %.1fs", inter_delays[i])
-                time.sleep(inter_delays[i])
-
-            duration = durations[i]
-            logger.info(
-                "Firing device %s (%s) for %.1fs",
-                device.name, device.type, duration,
+        # Explicit-opt-in per v0.13.3: only fire groups named in matched_groups.
+        # Absent/empty = no deterrent rule matched = do nothing.
+        matched_groups = event.get("matched_groups") or []
+        if not isinstance(matched_groups, list) or not matched_groups:
+            logger.debug(
+                "Event from %s has no matched deterrent groups — skipping",
+                event.get("camera_name", "unknown"),
             )
-            success, error = controller.activate_device(device, duration)
-            actions.append(DeviceAction(
-                device_name=device.name,
-                device_id=device.device_id,
-                device_type=device.type,
-                duration_sec=duration,
-                delay_before_sec=inter_delays[i],
-                success=success,
-                error=error,
-            ))
+            continue
 
-        total_duration = time.monotonic() - t_start
-        cooldown.record()
+        # Global cooldown gates ALL actuation (cross-group rapid-fire).
+        global_cd = act_cfg.defaults.cooldown_seconds
+        if not cooldown.is_clear(global_cd):
+            remaining = cooldown.seconds_remaining(global_cd)
+            logger.info(
+                "Global cooldown active (%.0fs remaining) — skipping event",
+                remaining,
+            )
+            continue
 
-        actuation_event = ActuationEvent(
-            timestamp=datetime.now(timezone.utc).isoformat(),
-            trigger_class=class_name,
-            trigger_camera=camera_name,
-            trigger_confidence=confidence,
-            pre_delay_sec=pre_delay,
-            actions=actions,
-            total_duration_sec=round(total_duration, 2),
-        )
+        # Index groups by name for quick lookup.
+        groups_by_name = {g.name: g for g in act_cfg.groups}
 
-        successes = sum(1 for a in actions if a.success)
-        logger.info(
-            "Actuation complete: %d/%d devices fired in %.1fs",
-            successes, len(actions), total_duration,
-        )
+        any_fired = False
+        for group_name in matched_groups:
+            group = groups_by_name.get(group_name)
+            if group is None:
+                logger.warning(
+                    "Matched group %r not found in deterrent.groups — skipping",
+                    group_name,
+                )
+                continue
 
-        # Publish actuation event to Redis
-        _publish_actuation(pub_holder, redis_cfg, actuation_event)
+            # Per-group cooldown gate.
+            if not group_cooldown.is_clear(group_name, group.cooldown_seconds):
+                remaining = group_cooldown.seconds_remaining(
+                    group_name, group.cooldown_seconds,
+                )
+                logger.info(
+                    "Group [%s] cooldown active (%.0fs remaining) — skipping group",
+                    group_name, remaining,
+                )
+                continue
 
-        # Persist to SQLite
-        try:
-            actuation_db.insert_event(actuation_event)
-        except Exception:
-            logger.exception("Failed to persist actuation event")
+            fired = _fire_group(
+                group, act_cfg, controller, event,
+                trigger_delay_ms, queue_depth,
+                pub_holder, redis_cfg,
+            )
+            if fired:
+                group_cooldown.record(group_name)
+                any_fired = True
+
+        if any_fired:
+            cooldown.record()
 
     logger.info("Deterrent worker thread stopped")
 
@@ -305,6 +411,7 @@ def main() -> None:
     armed_ref: AtomicRef[bool] = AtomicRef(cfg.get("system", {}).get("armed", True))
 
     cooldown = CooldownTracker()
+    group_cooldown = GroupCooldownTracker()
     event_queue: queue.Queue[dict[str, Any] | None] = queue.Queue(maxsize=64)
 
     # Initialise actuation event database
@@ -403,7 +510,10 @@ def main() -> None:
         target=_worker,
         name="deterrent-worker",
         daemon=True,
-        args=(event_queue, act_cfg_ref, controller_ref, armed_ref, cooldown, redis_cfg),
+        args=(
+            event_queue, act_cfg_ref, controller_ref, armed_ref,
+            cooldown, group_cooldown, redis_cfg,
+        ),
     )
     worker_thread.start()
 

--- a/services/deterrent/src/request_handler.py
+++ b/services/deterrent/src/request_handler.py
@@ -158,11 +158,12 @@ class RequestHandler:
             return
 
         logger.info("Test-fire: %s (%s) for %.1fs", device.name, device_id, duration)
-        success, error = controller.activate_device(device, duration)
+        success, error, on_ack_ms = controller.activate_device(device, duration)
         client.publish(result_channel, json.dumps({
             "ok": success,
             "error": error,
             "device_name": device.name,
+            "cloud_ack_ms": on_ack_ms,
         }))
         logger.info(
             "Test-fire result: %s — %s",

--- a/services/log-streamer/Dockerfile
+++ b/services/log-streamer/Dockerfile
@@ -4,7 +4,9 @@
 # Lightweight sidecar that tails Docker container logs and publishes them
 # to Redis.  Replaces the Docker socket mount previously needed by the
 # web container for the admin logs tab.
-FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+# v0.13.3: pull via Google's public Docker Hub mirror to dodge anon rate
+# limits on GHA shared-runner IPs.
+FROM mirror.gcr.io/library/python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/notifier/Dockerfile
+++ b/services/notifier/Dockerfile
@@ -1,6 +1,8 @@
 # Build context: repo root
 # docker build -f services/notifier/Dockerfile -t scarguard-notifier .
-FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+# v0.13.3: pull via Google's public Docker Hub mirror to dodge anon rate
+# limits on GHA shared-runner IPs.
+FROM mirror.gcr.io/library/python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/notifier/src/main.py
+++ b/services/notifier/src/main.py
@@ -122,15 +122,15 @@ def dispatch(
 
     # actions_triggered semantics:
     #   absent → legacy event or no action rules; notify all channels
-    #   None   → action rules exist but no rule matched; suppress entirely
-    #   []     → no action rules configured; notify all channels
+    #   None   → notification rules exist but no rule matched; suppress entirely
+    #   []     → no notification rules configured; notify all channels
     #   [...]  → notify only the named channels
     _MISSING = object()
     actions_raw = event.get("actions_triggered", _MISSING)
     if actions_raw is _MISSING:
         actions_triggered: list[str] = []
     elif actions_raw is None:
-        logger.debug("Event suppressed by action_rules — no notifications")
+        logger.debug("Event suppressed by notification rules — no notifications")
         return
     else:
         actions_triggered = actions_raw
@@ -139,7 +139,7 @@ def dispatch(
         if not current:
             logger.warning(
                 "actions_triggered=%s but no matching notifiers found "
-                "(check channel names in action_rules vs notifications.channels)",
+                "(check channel names in notification_rules vs notifications.channels)",
                 actions_triggered,
             )
 

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -1,5 +1,8 @@
 # Build context: repo root
-FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+# v0.13.3: pull via Google's public Docker Hub mirror (mirror.gcr.io) to
+# dodge Docker Hub's anonymous rate limit on GHA shared-runner IPs.
+# Same digest, no quota.
+FROM mirror.gcr.io/library/python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/web/requirements.txt
+++ b/services/web/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.135.3
 uvicorn[standard]==0.43.0
 jinja2==3.1.6
-python-multipart==0.0.22
+python-multipart==0.0.26
 pyyaml==6.0.3
 pydantic==2.12.5
 redis==7.4.0

--- a/services/web/src/actuation_db.py
+++ b/services/web/src/actuation_db.py
@@ -118,3 +118,73 @@ def get_actuation_actions(event_id: int) -> list[dict[str, Any]]:
         return []
     finally:
         conn.close()
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float | None:
+    """Linear-interpolated percentile of *sorted_values* (ascending).  None if empty."""
+    if not sorted_values:
+        return None
+    k = (len(sorted_values) - 1) * pct
+    lo = int(k)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = k - lo
+    return sorted_values[lo] * (1 - frac) + sorted_values[hi] * frac
+
+
+def get_latency_summary(last_n: int = 100) -> dict[str, Any]:
+    """Return p50/p95 summary over the last *last_n* actuations.
+
+    Aggregates three latency signals:
+    - ``trigger_delay_ms`` — detection timestamp → deterrent dequeue
+    - ``cloud_ack_ms`` — per-device: ON command sent → Tuya Cloud ack
+    - ``total_duration_sec`` — full actuation sequence wall clock
+
+    Returns ``{"count": N, "trigger_delay": {"p50":..., "p95":...}, ...}``
+    with None values when not enough samples are available.
+    """
+    out: dict[str, Any] = {
+        "count": 0,
+        "trigger_delay_ms": {"p50": None, "p95": None},
+        "cloud_ack_ms": {"p50": None, "p95": None},
+        "total_duration_sec": {"p50": None, "p95": None},
+    }
+    conn = _connect()
+    if conn is None:
+        return out
+    try:
+        rows = conn.execute(
+            "SELECT id, trigger_delay_ms, total_duration_sec FROM actuation_events "
+            "ORDER BY id DESC LIMIT ?",
+            (last_n,),
+        ).fetchall()
+        if not rows:
+            return out
+        out["count"] = len(rows)
+        event_ids = [r["id"] for r in rows]
+
+        trig = sorted(float(r["trigger_delay_ms"]) for r in rows if r["trigger_delay_ms"] is not None)
+        dur = sorted(float(r["total_duration_sec"]) for r in rows if r["total_duration_sec"] is not None)
+
+        placeholders = ",".join("?" * len(event_ids))
+        ack_rows = conn.execute(
+            f"SELECT cloud_ack_ms FROM device_actions "
+            f"WHERE event_id IN ({placeholders}) AND cloud_ack_ms IS NOT NULL",
+            event_ids,
+        ).fetchall()
+        ack = sorted(float(r["cloud_ack_ms"]) for r in ack_rows)
+
+        out["trigger_delay_ms"] = {
+            "p50": _percentile(trig, 0.50), "p95": _percentile(trig, 0.95),
+        }
+        out["cloud_ack_ms"] = {
+            "p50": _percentile(ack, 0.50), "p95": _percentile(ack, 0.95),
+        }
+        out["total_duration_sec"] = {
+            "p50": _percentile(dur, 0.50), "p95": _percentile(dur, 0.95),
+        }
+        return out
+    except Exception:
+        logger.warning("Failed to compute latency summary", exc_info=True)
+        return out
+    finally:
+        conn.close()

--- a/services/web/src/config_model.py
+++ b/services/web/src/config_model.py
@@ -192,11 +192,18 @@ class ExclusionZoneConfig(BaseModel):
         return v
 
 
-class ActionRuleConfig(BaseModel):
+class NotificationRuleConfig(BaseModel):
     """Maps a detected class (or "*" wildcard) to notification channel names."""
 
     class_name: str = "*"
     channels: list[str] = []
+
+
+class DeterrentRuleConfig(BaseModel):
+    """Maps a detected class (or "*" wildcard) to deterrent group names."""
+
+    class_name: str = "*"
+    groups: list[str] = []
 
 
 class CameraConfig(BaseModel):
@@ -206,8 +213,10 @@ class CameraConfig(BaseModel):
     resolution: int = 720
     model_path: str | None = None
     detect_classes: list[str] | None = None
+    confidence_threshold: float | None = None
     exclusion_zones: list[ExclusionZoneConfig] = []
-    action_rules: list[ActionRuleConfig] = []
+    notification_rules: list[NotificationRuleConfig] = []
+    deterrent_rules: list[DeterrentRuleConfig] = []
 
     @field_validator("name")
     @classmethod
@@ -221,6 +230,15 @@ class CameraConfig(BaseModel):
     def rtsp_url_format(cls, v: str) -> str:
         if v and not v.startswith(("rtsp://", "rtsps://")):
             raise ValueError("RTSP URL must start with rtsp:// or rtsps://")
+        return v
+
+    @field_validator("confidence_threshold")
+    @classmethod
+    def confidence_range(cls, v: float | None) -> float | None:
+        if v is None:
+            return v
+        if not 0.0 <= v <= 1.0:
+            raise ValueError("confidence_threshold must be between 0.0 and 1.0")
         return v
 
 
@@ -294,6 +312,40 @@ class ActuationDefaultsConfig(BaseModel):
         return v
 
 
+class DeterrentGroupConfig(BaseModel):
+    """A named subset of registered devices fired as a coordinated sequence.
+
+    ``devices`` is a list of device names from the registry.  A device may
+    appear in multiple groups.  Randomization ranges override
+    ``deterrent.defaults`` for this group only; set any range to null (omit)
+    to inherit.  ``cooldown_seconds`` gates repeat firings of this group
+    only — the top-level ``deterrent.defaults.cooldown_seconds`` still
+    enforces a global cross-group cooldown.
+    """
+
+    name: str
+    devices: list[str] = []
+    cooldown_seconds: int = 60
+    device_count_range: list[int] | None = None
+    spray_duration_range: list[float] | None = None
+    inter_device_delay_range: list[float] | None = None
+    pre_delay_range: list[float] | None = None
+
+    @field_validator("name")
+    @classmethod
+    def name_nonempty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Group name must not be empty")
+        return v.strip()
+
+    @field_validator("cooldown_seconds")
+    @classmethod
+    def cooldown_range(cls, v: int) -> int:
+        if not 5 <= v <= 3600:
+            raise ValueError("cooldown_seconds must be between 5 and 3600")
+        return v
+
+
 class DeterrentBatteryMonitorConfig(BaseModel):
     enabled: bool = True
     check_interval_hours: int = 24
@@ -318,6 +370,7 @@ class ActuationConfig(BaseModel):
     enabled: bool = False
     tuya: TuyaCredentialsConfig = TuyaCredentialsConfig()
     devices: list[ActuationDeviceConfig] = []
+    groups: list[DeterrentGroupConfig] = []
     defaults: ActuationDefaultsConfig = ActuationDefaultsConfig()
     battery_monitor: DeterrentBatteryMonitorConfig = DeterrentBatteryMonitorConfig()
 
@@ -326,7 +379,7 @@ class StructuredConfigPayload(BaseModel):
     """Subset of scarguard.yml written by the structured form editor.
 
     Only the sections the form knows about.  Other top-level keys (redis,
-    action_rules, webhooks, etc.) are preserved unchanged from the existing config.
+    webhooks, etc.) are preserved unchanged from the existing config.
     """
 
     system: SystemConfig = SystemConfig()

--- a/services/web/src/config_store.py
+++ b/services/web/src/config_store.py
@@ -1,12 +1,15 @@
 """Read and write scarguard.yml with simple file-level locking."""
 
 import copy
+import logging
 import os
 import threading
 import time
 from pathlib import Path
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 CONFIG_PATH = Path(os.environ.get("CONFIG_PATH", "/config/scarguard.yml"))
 
@@ -15,6 +18,35 @@ CONFIG_PATH = Path(os.environ.get("CONFIG_PATH", "/config/scarguard.yml"))
 _STALE_TOP_KEYS: set[str] = {"ssl"}
 # Nested keys under ``notifications`` stripped on save (legacy flat format).
 _STALE_NOTIFICATION_KEYS: set[str] = {"discord", "email"}
+# Per-camera keys stripped on save.  action_rules was renamed to
+# notification_rules in v0.13.3 and is migrated on read.
+_STALE_CAMERA_KEYS: set[str] = {"action_rules"}
+
+
+def _migrate_in_place(cfg: dict) -> None:
+    """Apply one-shot renames to *cfg* so older on-disk configs round-trip
+    through the v0.13.3 Pydantic models without losing data.
+
+    - Per-camera ``action_rules`` → ``notification_rules`` (v0.13.3 rename).
+    """
+    cameras = cfg.get("cameras")
+    if not isinstance(cameras, list):
+        return
+    migrated = 0
+    for cam in cameras:
+        if not isinstance(cam, dict):
+            continue
+        if "action_rules" in cam and "notification_rules" not in cam:
+            cam["notification_rules"] = cam.pop("action_rules")
+            migrated += 1
+        elif "action_rules" in cam:
+            # both present → notification_rules wins; legacy action_rules dropped
+            cam.pop("action_rules")
+            migrated += 1
+    if migrated:
+        logger.info(
+            "Migrated %d camera(s) from action_rules → notification_rules", migrated,
+        )
 
 _lock = threading.Lock()
 _cache_cfg: dict | None = None
@@ -31,6 +63,7 @@ def _read_unlocked() -> dict:
 
     if not isinstance(loaded, dict):
         raise ValueError("Config root must be a mapping (YAML dictionary)")
+    _migrate_in_place(loaded)
     return loaded
 
 
@@ -71,12 +104,22 @@ def load_cached(ttl_seconds: float = 1.0) -> dict:
 def save(cfg: dict) -> None:
     global _cache_cfg, _cache_mtime_ns, _cache_loaded_at
     import tempfile
+    # Migrate first so legacy keys become new keys (preserves their data);
+    # THEN strip any still-present stale keys (raw YAML edits only).
+    _migrate_in_place(cfg)
     for key in _STALE_TOP_KEYS:
         cfg.pop(key, None)
     notif = cfg.get("notifications")
     if isinstance(notif, dict):
         for key in _STALE_NOTIFICATION_KEYS:
             notif.pop(key, None)
+    cameras = cfg.get("cameras")
+    if isinstance(cameras, list):
+        for cam in cameras:
+            if not isinstance(cam, dict):
+                continue
+            for key in _STALE_CAMERA_KEYS:
+                cam.pop(key, None)
     with _lock:
         fd, tmp_path = tempfile.mkstemp(
             dir=str(CONFIG_PATH.parent), suffix=".tmp",

--- a/services/web/src/routes/actuations.py
+++ b/services/web/src/routes/actuations.py
@@ -138,10 +138,12 @@ def _render_actuation_row(event: dict) -> str:
     trigger_class = _html.escape(event.get("trigger_class", "").replace("_", " ").title())
     trigger_camera = _html.escape(event.get("trigger_camera", ""))
     confidence = event.get("trigger_confidence", 0.0)
+    group_name = _html.escape(event.get("group_name") or "\u2014")
     actions = event.get("actions", [])
     device_count = len(actions)
     success_count = sum(1 for a in actions if a.get("success"))
     total_dur = event.get("total_duration_sec", 0.0)
+    trigger_delay_ms = event.get("trigger_delay_ms")
 
     device_names = ", ".join(
         _html.escape(a.get("device_name", "")) for a in actions
@@ -149,14 +151,20 @@ def _render_actuation_row(event: dict) -> str:
 
     status_class = "ok" if success_count == device_count else ("warn" if success_count > 0 else "err")
 
+    delay_cell = (
+        f"{trigger_delay_ms:.0f}ms" if isinstance(trigger_delay_ms, (int, float)) else "\u2014"
+    )
+
     return (
         f'<tr class="actuation-new">'
         f"<td>{display_ts}</td>"
         f"<td>{trigger_class}</td>"
         f"<td>{trigger_camera}</td>"
         f"<td>{confidence:.0%}</td>"
+        f"<td>{group_name}</td>"
         f"<td>{device_names}</td>"
         f'<td class="status-{status_class}">{success_count}/{device_count}</td>'
         f"<td>{total_dur:.1f}s</td>"
+        f'<td class="muted" style="font-size:0.8rem;">{delay_cell}</td>'
         f"</tr>"
     )

--- a/services/web/src/routes/config.py
+++ b/services/web/src/routes/config.py
@@ -218,7 +218,7 @@ async def save_structured_config(request: Request) -> Response:
 
     Only updates the sections the form knows about (system, cameras, detection,
     notifications.channels).  All other keys in the existing config (redis,
-    action_rules, webhooks, etc.) are preserved unchanged.
+    webhooks, etc.) are preserved unchanged.
 
     For cameras, unknown fields (e.g. exclusion_zones) are preserved by merging
     the form values over the existing entry matched by name.

--- a/services/web/src/routes/deterrent.py
+++ b/services/web/src/routes/deterrent.py
@@ -10,6 +10,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+import actuation_db
 import config_store
 import redis.asyncio as aioredis
 from config_redact import REDACTED_PLACEHOLDER
@@ -44,6 +45,22 @@ async def deterrent_page(request: Request) -> Response:
     if not isinstance(devices, list):
         devices = []
 
+    groups: list[dict[str, Any]] = act.get("groups", [])
+    if not isinstance(groups, list):
+        groups = []
+
+    # Which cameras reference each group (for "used by" UI chips)?
+    group_usage: dict[str, list[str]] = {}
+    for cam in cfg.get("cameras", []):
+        if not isinstance(cam, dict):
+            continue
+        cam_name = cam.get("name", "")
+        for rule in cam.get("deterrent_rules", []):
+            if not isinstance(rule, dict):
+                continue
+            for g_name in rule.get("groups", []):
+                group_usage.setdefault(g_name, []).append(cam_name)
+
     defaults: dict[str, Any] = act.get("defaults", {})
     if not isinstance(defaults, dict):
         defaults = {}
@@ -67,6 +84,9 @@ async def deterrent_page(request: Request) -> Response:
             "tuya": tuya,
             "devices": devices,
             "devices_json": json.dumps(devices),
+            "groups": groups,
+            "groups_json": json.dumps(groups),
+            "group_usage_json": json.dumps(group_usage),
             "defaults": defaults,
             "defaults_json": json.dumps(defaults),
             "battery_monitor": battery_monitor,
@@ -150,6 +170,39 @@ async def save_deterrent(request: Request) -> Response:
                 dev_entry["dp_code"] = dp_code_lookup[device_id]
             clean_devices.append(dev_entry)
         existing_act["devices"] = clean_devices
+
+    # Update groups — list of {name, devices[], cooldown_seconds,
+    # optional *_range overrides}.  Validates and coerces types; unknown
+    # extra fields are dropped.
+    groups_input = body.get("groups")
+    if isinstance(groups_input, list):
+        clean_groups: list[dict[str, Any]] = []
+        seen_names: set[str] = set()
+        for g in groups_input:
+            if not isinstance(g, dict):
+                continue
+            name = str(g.get("name", "")).strip()
+            if not name or name in seen_names:
+                continue
+            seen_names.add(name)
+            devices_list = g.get("devices", [])
+            if not isinstance(devices_list, list):
+                devices_list = []
+            entry: dict[str, Any] = {
+                "name": name,
+                "devices": [str(d) for d in devices_list if d],
+                "cooldown_seconds": int(g.get("cooldown_seconds", 60)),
+            }
+            for opt_key in (
+                "device_count_range",
+                "spray_duration_range",
+                "inter_device_delay_range",
+                "pre_delay_range",
+            ):
+                if opt_key in g and g[opt_key]:
+                    entry[opt_key] = g[opt_key]
+            clean_groups.append(entry)
+        existing_act["groups"] = clean_groups
 
     # Update defaults
     defaults_input = body.get("defaults")
@@ -261,6 +314,20 @@ async def test_fire(request: Request) -> Response:
     )
     status_code = 200 if result.get("ok") else 502
     return JSONResponse(result, status_code=status_code)
+
+
+@router.get("/latency-summary", response_class=JSONResponse)
+async def latency_summary(request: Request) -> Response:
+    """Return p50/p95 latency percentiles over the last N actuations.
+
+    Viewer-accessible — diagnostic data, no secrets.
+    """
+    gate = require_viewer(request)
+    if not isinstance(gate, dict):
+        return gate
+    last_n = int(request.query_params.get("last_n", 100))
+    last_n = max(1, min(last_n, 1000))
+    return JSONResponse(actuation_db.get_latency_summary(last_n))
 
 
 @router.get("/device-status", response_class=JSONResponse)

--- a/services/web/src/routes/deterrent.py
+++ b/services/web/src/routes/deterrent.py
@@ -171,9 +171,24 @@ async def save_deterrent(request: Request) -> Response:
             clean_devices.append(dev_entry)
         existing_act["devices"] = clean_devices
 
+    # Compute the authoritative set of currently-registered device names.
+    # Used to filter out orphaned references in group.devices so a deleted
+    # device can't leave a group silently broken (deterrent worker would
+    # fail to resolve the group and skip firing).  Pulls from the just-
+    # persisted devices list if this request included one, otherwise from
+    # whatever's already on disk.
+    registry_devices = existing_act.get("devices", [])
+    if not isinstance(registry_devices, list):
+        registry_devices = []
+    registered_names: set[str] = {
+        d["name"] for d in registry_devices
+        if isinstance(d, dict) and isinstance(d.get("name"), str)
+    }
+
     # Update groups — list of {name, devices[], cooldown_seconds,
     # optional *_range overrides}.  Validates and coerces types; unknown
-    # extra fields are dropped.
+    # extra fields are dropped; device names unknown to the registry are
+    # filtered out (orphan rejection) with a warning log.
     groups_input = body.get("groups")
     if isinstance(groups_input, list):
         clean_groups: list[dict[str, Any]] = []
@@ -188,9 +203,17 @@ async def save_deterrent(request: Request) -> Response:
             devices_list = g.get("devices", [])
             if not isinstance(devices_list, list):
                 devices_list = []
+            requested_names = [str(d) for d in devices_list if d]
+            known_devices = [n for n in requested_names if n in registered_names]
+            orphaned = [n for n in requested_names if n not in registered_names]
+            if orphaned:
+                log.warning(
+                    "Group %r references unknown device name(s) %s — dropping",
+                    name, orphaned,
+                )
             entry: dict[str, Any] = {
                 "name": name,
-                "devices": [str(d) for d in devices_list if d],
+                "devices": known_devices,
                 "cooldown_seconds": int(g.get("cooldown_seconds", 60)),
             }
             for opt_key in (

--- a/services/web/src/static/config.js
+++ b/services/web/src/static/config.js
@@ -12,6 +12,35 @@ document.querySelectorAll(".tab-btn").forEach(btn => {
   });
 });
 
+// ── Settings sub-tabs ────────────────────────────────────────────────────────
+// Split the long Settings form into focused sub-tabs (System / Detection /
+// Cameras / Notifications / Advanced).  Each config-section carries a
+// data-subtab attribute; we toggle visibility based on the active button.
+// URL hash (e.g. #cameras) deep-links into a sub-tab.
+
+function _activateSubtab(name) {
+  name = name || "system";
+  document.querySelectorAll(".subtab-btn").forEach(b => {
+    b.classList.toggle("active", b.dataset.subtab === name);
+  });
+  document.querySelectorAll(".config-section[data-subtab]").forEach(sec => {
+    sec.classList.toggle("subtab-hidden", sec.dataset.subtab !== name);
+  });
+  try {
+    history.replaceState(null, "", "#" + name);
+  } catch (_) { /* older browsers */ }
+}
+
+document.querySelectorAll(".subtab-btn").forEach(btn => {
+  btn.addEventListener("click", () => _activateSubtab(btn.dataset.subtab));
+});
+
+(function initSubtab() {
+  const valid = ["system", "detection", "cameras", "notifications", "advanced"];
+  const hash = (location.hash || "").replace(/^#/, "");
+  _activateSubtab(valid.includes(hash) ? hash : "system");
+})();
+
 // ── Collapsible sections ──────────────────────────────────────────────────────
 
 function toggleSection(id) {
@@ -66,14 +95,51 @@ function _buildRuleRow(rule) {
   return row;
 }
 
-function addActionRule(card) {
-  card.querySelector(".rules-list").appendChild(_buildRuleRow({ class_name: "*", channels: [] }));
+function addNotificationRule(card) {
+  card.querySelector(".notif-rules-list").appendChild(
+    _buildRuleRow({ class_name: "*", channels: [] })
+  );
 }
 
-function readActionRules(card) {
-  return Array.from(card.querySelectorAll(".rule-row")).map(row => ({
+function readNotificationRules(card) {
+  return Array.from(card.querySelectorAll(".notif-rules-list .rule-row")).map(row => ({
     class_name: row.querySelector(".rule-class").value.trim() || "*",
     channels: row.querySelector(".rule-channels").value
+      .split(",").map(s => s.trim()).filter(Boolean),
+  }));
+}
+
+// ── Deterrent rules (per-camera) ────────────────────────────────────────────
+
+function _buildDeterrentRuleRow(rule) {
+  const row = document.createElement("div");
+  row.className = "rule-row det-rule-row";
+  row.innerHTML = `
+    <div class="field-row" style="gap:0.5rem;align-items:flex-end;">
+      <div class="field-group" style="flex:1;">
+        <label>Class (or *)</label>
+        <input type="text" class="drule-class" value="${_esc(rule.class_name || "*")}" placeholder="* or great_blue_heron">
+      </div>
+      <div class="field-group" style="flex:2;">
+        <label>Groups (comma-separated names from /admin/deterrent)</label>
+        <input type="text" class="drule-groups" value="${_esc((rule.groups || []).join(", "))}" placeholder="minor, thermonuclear">
+      </div>
+      <button type="button" class="btn-remove" onclick="this.closest('.rule-row').remove()">✕</button>
+    </div>
+  `;
+  return row;
+}
+
+function addDeterrentRule(card) {
+  card.querySelector(".det-rules-list").appendChild(
+    _buildDeterrentRuleRow({ class_name: "*", groups: [] })
+  );
+}
+
+function readDeterrentRules(card) {
+  return Array.from(card.querySelectorAll(".det-rules-list .rule-row")).map(row => ({
+    class_name: row.querySelector(".drule-class").value.trim() || "*",
+    groups: row.querySelector(".drule-groups").value
       .split(",").map(s => s.trim()).filter(Boolean),
   }));
 }
@@ -98,7 +164,11 @@ function buildCameraCard(cam) {
   const idx = cameraIndex++;
   const enabled = cam.enabled !== false;
   const zones = cam.exclusion_zones || [];
-  const rules = cam.action_rules || [];
+  // notification_rules was renamed from action_rules in v0.13.3; accept
+  // either key on incoming data so the form survives pre-migration configs.
+  const rules = cam.notification_rules || cam.action_rules || [];
+  const detRules = cam.deterrent_rules || [];
+  const camConf = (cam.confidence_threshold != null) ? cam.confidence_threshold : "";
   const snapUrl = cam.snapshot_url || null;
 
   const div = document.createElement("div");
@@ -129,11 +199,12 @@ function buildCameraCard(cam) {
       <input type="text" class="cam-rtsp" value="${_esc(cam.rtsp_url || "")}" placeholder="rtsp:// or rtsps://192.168.1.1:7447/TOKEN">
     </div>
     <details class="expert-only" style="margin-top:0.75rem;">
-      <summary style="cursor:pointer;font-weight:500;">Per-Camera Model & Classes</summary>
+      <summary style="cursor:pointer;font-weight:500;">Per-Camera Model, Classes & Confidence</summary>
       <div style="margin-top:0.5rem;">
         <p class="hint">
-          Override the global detection model and/or target classes for this camera.
-          Leave blank to use the global settings from the Detection section.
+          Override the global detection model, target classes, and/or confidence
+          threshold for this camera.  Leave blank to inherit the global values
+          from the Detection section.
         </p>
         <div class="field-row">
           <div class="field-group">
@@ -143,6 +214,16 @@ function buildCameraCard(cam) {
           <div class="field-group">
             <label>Detect classes (comma-separated, blank = global)</label>
             <input type="text" class="cam-detect-classes" value="${_esc((cam.detect_classes || []).join(", "))}" placeholder="e.g. great_blue_heron, green_heron">
+          </div>
+        </div>
+        <div class="field-row" style="margin-top:0.5rem;">
+          <div class="field-group" style="flex:1;">
+            <label>Confidence threshold (blank = inherit global)</label>
+            <div style="display:flex;gap:0.5rem;align-items:center;">
+              <input type="number" class="cam-confidence" min="0" max="1" step="0.01"
+                     value="${camConf}" placeholder="inherit" style="max-width:8rem;">
+              <span class="hint">Higher = fewer false positives. Useful for fine-tuned species models.</span>
+            </div>
           </div>
         </div>
       </div>
@@ -162,21 +243,37 @@ function buildCameraCard(cam) {
       </div>
     </details>
     <details class="expert-only" style="margin-top:0.75rem;">
-      <summary style="cursor:pointer;font-weight:500;">Action Rules (${rules.length})</summary>
+      <summary style="cursor:pointer;font-weight:500;">Notification Rules (${rules.length})</summary>
       <div style="margin-top:0.5rem;">
         <p class="hint">
           Route detections to specific named channels. Rules are evaluated in order — first match wins.
           Use <code>*</code> as a wildcard class to match any detection. Leave empty to notify all channels.
         </p>
-        <div class="rules-list"></div>
-        <button type="button" class="btn-add" style="margin-top:0.4rem;" onclick="addActionRule(this.closest('.camera-card'))">+ Add Rule</button>
+        <div class="notif-rules-list"></div>
+        <button type="button" class="btn-add" style="margin-top:0.4rem;" onclick="addNotificationRule(this.closest('.camera-card'))">+ Add Rule</button>
+      </div>
+    </details>
+    <details class="expert-only" style="margin-top:0.75rem;">
+      <summary style="cursor:pointer;font-weight:500;">Deterrent Rules (${detRules.length})</summary>
+      <div style="margin-top:0.5rem;">
+        <p class="hint">
+          Fire deterrent groups in response to detections from this camera.
+          Rules are evaluated in order — first match wins.  Use <code>*</code>
+          as a wildcard class.  <strong>Empty = no deterrent action</strong> —
+          deterrents are explicit-opt-in.  Create groups on the
+          <a href="/admin/deterrent#groups">Deterrent page</a> first.
+        </p>
+        <div class="det-rules-list"></div>
+        <button type="button" class="btn-add" style="margin-top:0.4rem;" onclick="addDeterrentRule(this.closest('.camera-card'))">+ Add Rule</button>
       </div>
     </details>
   `;
 
-  // Populate initial action rules (synchronous — no layout dependency)
-  const rulesList = div.querySelector(".rules-list");
-  rules.forEach(r => rulesList.appendChild(_buildRuleRow(r)));
+  // Populate initial rules (synchronous — no layout dependency)
+  const notifList = div.querySelector(".notif-rules-list");
+  rules.forEach(r => notifList.appendChild(_buildRuleRow(r)));
+  const detList = div.querySelector(".det-rules-list");
+  detRules.forEach(r => detList.appendChild(_buildDeterrentRuleRow(r)));
 
   // Initialize zone editor after inserting into DOM via microtask
   requestAnimationFrame(() => initZoneEditor(div, zones));
@@ -200,13 +297,21 @@ function readCameras() {
     const detectClasses = detectClassesRaw
       ? detectClassesRaw.split(",").map(s => s.trim()).filter(Boolean)
       : null;
+    const confRaw = card.querySelector(".cam-confidence").value.trim();
+    // Always emit confidence_threshold (possibly null) so clearing the UI
+    // field actually removes the override server-side.  Pydantic accepts
+    // null → field becomes None; the merge in routes/config.py preserves
+    // it correctly via model_dump(exclude_unset=True).
+    const confidence = confRaw === "" ? null : parseFloat(confRaw);
     const cam = {
       name: card.querySelector(".cam-name").value.trim(),
       rtsp_url: card.querySelector(".cam-rtsp").value.trim(),
       enabled: card.querySelector(".cam-enabled").checked,
       resolution: parseInt(card.querySelector(".cam-resolution").value, 10) || 720,
       exclusion_zones: readZones(card),
-      action_rules: readActionRules(card),
+      notification_rules: readNotificationRules(card),
+      deterrent_rules: readDeterrentRules(card),
+      confidence_threshold: (confidence !== null && !Number.isNaN(confidence)) ? confidence : null,
     };
     if (modelPath) cam.model_path = modelPath;
     if (detectClasses) cam.detect_classes = detectClasses;

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -447,6 +447,37 @@ input:focus, select:focus { outline: 1px solid var(--accent); }
 .tab-panel { display: none; }
 .tab-panel.active { display: block; }
 
+/* Settings sub-tabs (inside /config Settings panel) */
+.settings-subtabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin: 0.75rem 0 1rem;
+  border-bottom: 1px solid var(--border);
+}
+.subtab-btn {
+  background: transparent;
+  border: none;
+  padding: 0.45rem 0.9rem;
+  font-size: 0.9rem;
+  color: var(--text);
+  opacity: 0.7;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+.subtab-btn:hover { opacity: 1; }
+.subtab-btn.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  opacity: 1;
+}
+.config-section.subtab-hidden { display: none; }
+.det-tab-panel { display: none; }
+.det-tab-panel.active { display: block; }
+/* Expert-mode-only sub-tab button: hidden unless expert mode is on */
+body:not(.expert-mode) .subtab-advanced { display: none; }
+
 /* Camera card */
 .camera-card {
   background: var(--bg);

--- a/services/web/src/templates/actuations.html
+++ b/services/web/src/templates/actuations.html
@@ -41,9 +41,11 @@
         <th>Trigger</th>
         <th>Camera</th>
         <th>Conf</th>
+        <th>Group</th>
         <th>Devices</th>
         <th>Result</th>
         <th>Duration</th>
+        <th title="Detection timestamp → deterrent dequeue">Trigger delay</th>
       </tr>
     </thead>
     <tbody id="actuations-body">
@@ -53,9 +55,10 @@
         <td>{{ ev.trigger_class.replace("_", " ").title() }}</td>
         <td>{{ ev.trigger_camera }}</td>
         <td>{{ "%.0f%%"|format(ev.trigger_confidence * 100) }}</td>
+        <td>{{ ev.group_name or '—' }}</td>
         <td>
           {% for a in ev.actions %}
-            <span class="tag {% if a.success %}tag-ok{% else %}tag-err{% endif %}" title="{{ a.device_type }} — {{ '%.1f'|format(a.duration_sec) }}s{% if a.error %} — {{ a.error }}{% endif %}">{{ a.device_name }}</span>
+            <span class="tag {% if a.success %}tag-ok{% else %}tag-err{% endif %}" title="{{ a.device_type }} — {{ '%.1f'|format(a.duration_sec) }}s{% if a.cloud_ack_ms is not none %} — ack {{ '%.0f'|format(a.cloud_ack_ms) }}ms{% endif %}{% if a.error %} — {{ a.error }}{% endif %}">{{ a.device_name }}</span>
           {% endfor %}
         </td>
         <td>
@@ -64,9 +67,12 @@
           <span class="{% if sc == dc %}status-ok{% elif sc > 0 %}status-warn{% else %}status-err{% endif %}">{{ sc }}/{{ dc }}</span>
         </td>
         <td>{{ "%.1f"|format(ev.total_duration_sec) }}s</td>
+        <td class="muted" style="font-size:0.8rem;">
+          {% if ev.trigger_delay_ms is not none %}{{ "%.0f"|format(ev.trigger_delay_ms) }}ms{% else %}—{% endif %}
+        </td>
       </tr>
     {% else %}
-      <tr><td colspan="7" class="muted" style="text-align:center;padding:1rem;">No actuation events{% if trigger_class or camera or date_from or date_to %} match the current filter{% endif %}.</td></tr>
+      <tr><td colspan="9" class="muted" style="text-align:center;padding:1rem;">No actuation events{% if trigger_class or camera or date_from or date_to %} match the current filter{% endif %}.</td></tr>
     {% endfor %}
     </tbody>
   </table>

--- a/services/web/src/templates/config.html
+++ b/services/web/src/templates/config.html
@@ -32,8 +32,17 @@
     </label>
   </div>
 
+  {# ── Settings sub-tabs ──────────────────────────────────────────────────── #}
+  <div class="settings-subtabs" role="tablist" aria-label="Settings sections">
+    <button type="button" class="subtab-btn active" data-subtab="system">System</button>
+    <button type="button" class="subtab-btn" data-subtab="detection">Detection</button>
+    <button type="button" class="subtab-btn" data-subtab="cameras">Cameras</button>
+    <button type="button" class="subtab-btn" data-subtab="notifications">Notifications</button>
+    <button type="button" class="subtab-btn subtab-advanced expert-only" data-subtab="advanced">Advanced</button>
+  </div>
+
   {# ── System ───────────────────────────────────────────────────────────────── #}
-  <div class="config-section" id="section-system">
+  <div class="config-section" id="section-system" data-subtab="system">
     <div class="config-section-header" onclick="toggleSection('section-system')">
       <span class="config-section-label">System</span>
       <span class="config-section-chevron">▾</span>
@@ -124,7 +133,7 @@
   </div>
 
   {# ── Summary Reports ──────────────────────────────────────────────────────── #}
-  <div class="config-section expert-only" id="section-summary-report">
+  <div class="config-section expert-only" id="section-summary-report" data-subtab="system">
     <div class="config-section-header" onclick="toggleSection('section-summary-report')">
       <span class="config-section-label">Summary Reports</span>
       <span class="config-section-chevron">▾</span>
@@ -166,7 +175,7 @@
   </div>
 
   {# ── Cameras ──────────────────────────────────────────────────────────────── #}
-  <div class="config-section" id="section-cameras">
+  <div class="config-section" id="section-cameras" data-subtab="cameras">
     <div class="config-section-header" onclick="toggleSection('section-cameras')">
       <span class="config-section-label">Cameras</span>
       <span class="config-section-chevron">▾</span>
@@ -189,7 +198,7 @@
   </div>
 
   {# ── Detection ────────────────────────────────────────────────────────────── #}
-  <div class="config-section" id="section-detection">
+  <div class="config-section" id="section-detection" data-subtab="detection">
     <div class="config-section-header" onclick="toggleSection('section-detection')">
       <span class="config-section-label">Detection</span>
       <span class="config-section-chevron">▾</span>
@@ -239,7 +248,7 @@
   </div>
 
   {# ── Notification Channels (named, multi-instance) ───────────────────────── #}
-  <div class="config-section collapsed" id="section-channels">
+  <div class="config-section" id="section-channels" data-subtab="notifications">
     <div class="config-section-header" onclick="toggleSection('section-channels')">
       <span class="config-section-label">Notification Channels</span>
       <span class="config-section-chevron">▾</span>
@@ -264,7 +273,7 @@
   </div>
 
   {# ── Schedule ─────────────────────────────────────────────────────────────── #}
-  <div class="config-section collapsed expert-only" id="section-schedule">
+  <div class="config-section expert-only" id="section-schedule" data-subtab="advanced">
     <div class="config-section-header" onclick="toggleSection('section-schedule')">
       <span class="config-section-label">Schedule (Auto Arm/Disarm)</span>
       <span class="config-section-chevron">▾</span>
@@ -324,7 +333,7 @@
   </div>
 
   {# ── Auth ─────────────────────────────────────────────────────────────── #}
-  <div class="config-section collapsed expert-only" id="section-auth">
+  <div class="config-section expert-only" id="section-auth" data-subtab="advanced">
     <div class="config-section-header" onclick="toggleSection('section-auth')">
       <span class="config-section-label">Authentication</span>
       <span class="config-section-chevron">▾</span>
@@ -381,7 +390,7 @@
   </div>
 
   {# ── TLS ────────────────────────────────────────────────────────────────── #}
-  <div class="config-section" id="section-deterrent">
+  <div class="config-section" id="section-deterrent" data-subtab="advanced">
     <div class="config-section-header" onclick="toggleSection('section-deterrent')">
       <span class="config-section-label">Deterrent</span>
       <span class="config-section-chevron">▾</span>
@@ -403,7 +412,7 @@
     </div>
   </div>
 
-  <div class="config-section collapsed expert-only" id="section-tls">
+  <div class="config-section expert-only" id="section-tls" data-subtab="advanced">
     <div class="config-section-header" onclick="toggleSection('section-tls')">
       <span class="config-section-label">TLS</span>
       <span class="config-section-chevron">▾</span>

--- a/services/web/src/templates/deterrent.html
+++ b/services/web/src/templates/deterrent.html
@@ -434,6 +434,40 @@ function showMsg(text, isError) {
 
 renderDevices();
 
+// ── Device-rename propagation ────────────────────────────────────────────
+// When the operator edits a device name in the Devices table, keep the
+// Groups tab's device references in sync.  Without this, a group's
+// ``devices: [name]`` list can refer to stale pre-rename values after a
+// save, leaving the deterrent worker unable to resolve those devices.
+// Event delegation on the persistent tbody survives renderDevices()
+// re-renders.
+(function wireDeviceRenamePropagation() {
+  var tbody = document.getElementById('devices-body');
+  if (!tbody) return;
+  tbody.addEventListener('change', function(e) {
+    var t = e.target;
+    if (!t || !t.dataset || t.dataset.field !== 'name') return;
+    var idx = parseInt(t.dataset.idx, 10);
+    if (!Number.isFinite(idx) || idx < 0 || idx >= _devices.length) return;
+    var oldName = _devices[idx].name;
+    var newName = t.value.trim();
+    if (oldName === newName) return;
+    _devices[idx].name = newName;
+    if (oldName) {
+      _groups.forEach(function(g) {
+        var gi = g.devices.indexOf(oldName);
+        if (gi < 0) return;
+        if (newName) {
+          g.devices[gi] = newName;
+        } else {
+          g.devices.splice(gi, 1);
+        }
+      });
+    }
+    renderGroups();
+  });
+})();
+
 // ── Groups editor ────────────────────────────────────────────────────────
 
 function _groupUsageChips(name) {

--- a/services/web/src/templates/deterrent.html
+++ b/services/web/src/templates/deterrent.html
@@ -57,7 +57,17 @@
   <div id="status-panel" style="margin-top:0.75rem;"></div>
 </div>
 
+{# ── Tabs ───────────────────────────────────────────────────────────────── #}
+<div class="settings-subtabs" role="tablist" aria-label="Deterrent sections">
+  <button type="button" class="subtab-btn active" data-det-tab="devices">Devices</button>
+  <button type="button" class="subtab-btn" data-det-tab="groups">Groups</button>
+  <button type="button" class="subtab-btn" data-det-tab="defaults">Defaults</button>
+  <button type="button" class="subtab-btn" data-det-tab="battery">Battery</button>
+  <button type="button" class="subtab-btn" data-det-tab="latency">Latency</button>
+</div>
+
 {# ── Devices ────────────────────────────────────────────────────────────── #}
+<div class="det-tab-panel active" data-det-tab="devices">
 <div class="card" style="margin-bottom:1.5rem;">
   <h2 style="margin-top:0;font-size:1.1rem;">Devices</h2>
   <p class="hint">
@@ -86,8 +96,29 @@
   </button>
   {% endif %}
 </div>
+</div>{# /devices tab #}
+
+{# ── Groups ─────────────────────────────────────────────────────────────── #}
+<div class="det-tab-panel" data-det-tab="groups">
+<div class="card" style="margin-bottom:1.5rem;">
+  <h2 style="margin-top:0;font-size:1.1rem;">Groups</h2>
+  <p class="hint">
+    A group bundles one or more registered devices with its own randomization
+    and cooldown.  Cameras reference groups via <em>deterrent rules</em> on the
+    Config page.  A device may belong to multiple groups.  Empty range fields
+    inherit from <strong>Defaults</strong>.
+  </p>
+  <div id="groups-list"></div>
+  {% if not read_only %}
+  <button type="button" class="btn-secondary" onclick="addGroup()" style="margin-top:0.75rem;">
+    + Add group
+  </button>
+  {% endif %}
+</div>
+</div>{# /groups tab #}
 
 {# ── Actuation Defaults ──────────────────────────────────────────────── #}
+<div class="det-tab-panel" data-det-tab="defaults">
 <div class="card" style="margin-bottom:1.5rem;">
   <h2 style="margin-top:0;font-size:1.1rem;">Actuation Defaults</h2>
   <p class="hint">
@@ -152,8 +183,10 @@
     </div>
   </div>
 </div>
+</div>{# /defaults tab #}
 
-{# ── Battery Monitor ─��─────────────────────────────────────────────── #}
+{# ── Battery Monitor ────────────────────────────────────────────────── #}
+<div class="det-tab-panel" data-det-tab="battery">
 <div class="card" style="margin-bottom:1.5rem;">
   <h2 style="margin-top:0;font-size:1.1rem;">Battery Monitor</h2>
   <p class="hint">
@@ -183,6 +216,33 @@
     </div>
   </div>
 </div>
+</div>{# /battery tab #}
+
+{# ── Latency ───────────────────────────────────────────────────────────── #}
+<div class="det-tab-panel" data-det-tab="latency">
+<div class="card" style="margin-bottom:1.5rem;">
+  <h2 style="margin-top:0;font-size:1.1rem;">Latency (last 100 actuations)</h2>
+  <p class="hint">
+    End-to-end timing for actuation events.  Useful for diagnosing battery-
+    device deep-sleep latency.  See the
+    <a href="/deterrent-log">deterrent log</a> for per-event timing.
+  </p>
+  <button type="button" class="btn-secondary" onclick="refreshLatency()">Refresh</button>
+  <table id="latency-table" style="width:100%;border-collapse:collapse;font-size:0.9rem;margin-top:0.75rem;">
+    <thead>
+      <tr style="text-align:left;border-bottom:2px solid var(--border);">
+        <th style="padding:0.4rem 0.5rem;">Signal</th>
+        <th style="padding:0.4rem 0.5rem;width:8rem;">p50</th>
+        <th style="padding:0.4rem 0.5rem;width:8rem;">p95</th>
+      </tr>
+    </thead>
+    <tbody id="latency-body">
+      <tr><td colspan="3" class="muted" style="padding:0.5rem;">Loading...</td></tr>
+    </tbody>
+  </table>
+  <p class="hint" id="latency-count" style="margin-top:0.5rem;"></p>
+</div>
+</div>{# /latency tab #}
 
 {% if not read_only %}
 <button type="button" id="save-deterrent-btn" onclick="saveDeterrent()">Save</button>
@@ -190,7 +250,30 @@
 
 <script>
 var _devices = {{ devices_json|safe }};
+var _groups = {{ groups_json|safe }};
+var _groupUsage = {{ group_usage_json|safe }};
 var _readOnly = {{ 'true' if read_only else 'false' }};
+
+// ── Tab switching ────────────────────────────────────────────────────────
+function _activateDetTab(name) {
+  name = name || 'devices';
+  document.querySelectorAll('.subtab-btn[data-det-tab]').forEach(function(b) {
+    b.classList.toggle('active', b.dataset.detTab === name);
+  });
+  document.querySelectorAll('.det-tab-panel').forEach(function(p) {
+    p.classList.toggle('active', p.dataset.detTab === name);
+  });
+  try { history.replaceState(null, '', '#' + name); } catch (_) {}
+  if (name === 'latency') refreshLatency();
+}
+document.querySelectorAll('.subtab-btn[data-det-tab]').forEach(function(b) {
+  b.addEventListener('click', function() { _activateDetTab(b.dataset.detTab); });
+});
+(function initDetTab() {
+  var valid = ['devices', 'groups', 'defaults', 'battery', 'latency'];
+  var hash = (location.hash || '').replace(/^#/, '');
+  _activateDetTab(valid.indexOf(hash) >= 0 ? hash : 'devices');
+})();
 
 function renderDevices() {
   var tbody = document.getElementById('devices-body');
@@ -282,6 +365,8 @@ async function saveDeterrent() {
     }
   }
 
+  var groups = readGroupsFromForm();
+
   var payload = {
     tuya: {
       api_key: document.getElementById('tuya-api-key').value.trim(),
@@ -289,6 +374,7 @@ async function saveDeterrent() {
       api_region: document.getElementById('tuya-api-region').value,
     },
     devices: devices,
+    groups: groups,
     defaults: {
       cooldown_seconds: parseInt(document.getElementById('def-cooldown').value) || 60,
       device_count_range: [
@@ -328,6 +414,8 @@ async function saveDeterrent() {
     if (data.ok) {
       showMsg('Deterrent config saved. Changes apply within ~10 seconds.', false);
       _devices = devices;
+      _groups = groups;
+      renderGroups();  // re-render with updated device checkbox lists
     } else {
       showMsg('Error: ' + (data.error || 'Unknown error'), true);
     }
@@ -345,6 +433,179 @@ function showMsg(text, isError) {
 }
 
 renderDevices();
+
+// ── Groups editor ────────────────────────────────────────────────────────
+
+function _groupUsageChips(name) {
+  var cams = _groupUsage[name] || [];
+  if (!cams.length) return '<span class="muted" style="font-size:0.8rem;">unassigned</span>';
+  return cams.map(function(c) {
+    return '<span class="tag" style="background:rgba(var(--accent-rgb,100,181,246),0.15);font-size:0.75rem;">' + esc(c) + '</span>';
+  }).join(' ');
+}
+
+function _rangeInputs(name, idx, vals, attrs) {
+  vals = vals || [null, null];
+  attrs = attrs || '';
+  return (
+    '<input type="number" data-idx="' + idx + '" data-field="' + name + '_min" ' + attrs +
+    ' value="' + (vals[0] != null ? vals[0] : '') + '" style="width:5rem;" placeholder="inherit">' +
+    ' <span>to</span> ' +
+    '<input type="number" data-idx="' + idx + '" data-field="' + name + '_max" ' + attrs +
+    ' value="' + (vals[1] != null ? vals[1] : '') + '" style="width:5rem;" placeholder="inherit">'
+  );
+}
+
+function renderGroups() {
+  var list = document.getElementById('groups-list');
+  list.innerHTML = '';
+  if (!_groups.length) {
+    list.innerHTML = '<p class="muted" style="font-style:italic;">No groups yet. Create one to arm deterrents.</p>';
+    return;
+  }
+  _groups.forEach(function(g, i) {
+    var card = document.createElement('div');
+    card.className = 'camera-card';
+    card.style.marginBottom = '0.75rem';
+    var devCheckboxes = _devices.map(function(d) {
+      var checked = (g.devices || []).indexOf(d.name) >= 0 ? ' checked' : '';
+      var disabled = _readOnly ? ' disabled' : '';
+      return (
+        '<label style="display:inline-flex;align-items:center;gap:0.25rem;margin-right:0.75rem;font-size:0.85rem;">' +
+        '<input type="checkbox" data-idx="' + i + '" data-field="device" value="' + esc(d.name) + '"' + checked + disabled + '>' +
+        esc(d.name) +
+        '</label>'
+      );
+    }).join('');
+    if (!devCheckboxes) {
+      devCheckboxes = '<span class="muted" style="font-size:0.85rem;">No devices registered yet — add some on the Devices tab.</span>';
+    }
+    card.innerHTML =
+      '<div class="camera-card-header">' +
+        '<span class="camera-card-title">Group: ' + esc(g.name || '(unnamed)') + '</span>' +
+        (_readOnly ? '' : '<button type="button" class="btn-remove" onclick="removeGroup(' + i + ')">Remove</button>') +
+      '</div>' +
+      '<div class="field-row">' +
+        '<div class="field-group" style="flex:1;">' +
+          '<label>Name</label>' +
+          '<input type="text" data-idx="' + i + '" data-field="name" value="' + esc(g.name) + '" placeholder="e.g. minor or thermonuclear"' + (_readOnly ? ' disabled' : '') + '>' +
+        '</div>' +
+        '<div class="field-group" style="max-width:10rem;">' +
+          '<label>Cooldown (sec)</label>' +
+          '<input type="number" min="5" max="3600" step="1" data-idx="' + i + '" data-field="cooldown_seconds" value="' + (g.cooldown_seconds || 60) + '"' + (_readOnly ? ' disabled' : '') + '>' +
+        '</div>' +
+      '</div>' +
+      '<div class="field-group" style="margin-top:0.5rem;">' +
+        '<label>Devices in group</label>' +
+        '<div>' + devCheckboxes + '</div>' +
+      '</div>' +
+      '<details style="margin-top:0.5rem;"><summary style="cursor:pointer;font-size:0.85rem;">Randomization overrides (blank = inherit)</summary>' +
+        '<div class="field-row" style="margin-top:0.5rem;">' +
+          '<div class="field-group">' +
+            '<label>Device count</label><div style="display:flex;gap:0.5rem;align-items:center;">' +
+              _rangeInputs('device_count_range', i, g.device_count_range, 'min="1" max="20" step="1"' + (_readOnly ? ' disabled' : '')) +
+            '</div>' +
+          '</div>' +
+          '<div class="field-group">' +
+            '<label>Spray duration (s)</label><div style="display:flex;gap:0.5rem;align-items:center;">' +
+              _rangeInputs('spray_duration_range', i, g.spray_duration_range, 'min="0.5" max="60" step="0.5"' + (_readOnly ? ' disabled' : '')) +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+        '<div class="field-row" style="margin-top:0.5rem;">' +
+          '<div class="field-group">' +
+            '<label>Inter-device delay (s)</label><div style="display:flex;gap:0.5rem;align-items:center;">' +
+              _rangeInputs('inter_device_delay_range', i, g.inter_device_delay_range, 'min="0" max="30" step="0.5"' + (_readOnly ? ' disabled' : '')) +
+            '</div>' +
+          '</div>' +
+          '<div class="field-group">' +
+            '<label>Pre-delay (s)</label><div style="display:flex;gap:0.5rem;align-items:center;">' +
+              _rangeInputs('pre_delay_range', i, g.pre_delay_range, 'min="0" max="30" step="0.5"' + (_readOnly ? ' disabled' : '')) +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</details>' +
+      '<div style="margin-top:0.5rem;font-size:0.85rem;"><span class="muted">Used by:</span> ' + _groupUsageChips(g.name) + '</div>';
+    list.appendChild(card);
+  });
+}
+
+function addGroup() {
+  _groups.push({name: '', devices: [], cooldown_seconds: 60});
+  renderGroups();
+}
+
+function removeGroup(idx) {
+  _groups.splice(idx, 1);
+  renderGroups();
+}
+
+function _readGroupRange(card, field) {
+  var minEl = card.querySelector('[data-field="' + field + '_min"]');
+  var maxEl = card.querySelector('[data-field="' + field + '_max"]');
+  if (!minEl || !maxEl) return null;
+  var minV = minEl.value.trim();
+  var maxV = maxEl.value.trim();
+  if (minV === '' && maxV === '') return null;  // inherit
+  return [parseFloat(minV) || 0, parseFloat(maxV) || 0];
+}
+
+function readGroupsFromForm() {
+  var out = [];
+  document.querySelectorAll('#groups-list .camera-card').forEach(function(card) {
+    var nameEl = card.querySelector('[data-field="name"]');
+    if (!nameEl) return;
+    var name = nameEl.value.trim();
+    if (!name) return;
+    var cooldown = parseInt(card.querySelector('[data-field="cooldown_seconds"]').value) || 60;
+    var devices = [];
+    card.querySelectorAll('[data-field="device"]:checked').forEach(function(cb) {
+      devices.push(cb.value);
+    });
+    var entry = {name: name, devices: devices, cooldown_seconds: cooldown};
+    ['device_count_range', 'spray_duration_range',
+     'inter_device_delay_range', 'pre_delay_range'].forEach(function(f) {
+      var r = _readGroupRange(card, f);
+      if (r) entry[f] = r;
+    });
+    out.push(entry);
+  });
+  return out;
+}
+
+renderGroups();
+
+// ── Latency summary ───────────────────────────────────────────────────────
+
+async function refreshLatency() {
+  var tbody = document.getElementById('latency-body');
+  var countEl = document.getElementById('latency-count');
+  tbody.innerHTML = '<tr><td colspan="3" class="muted" style="padding:0.5rem;">Loading...</td></tr>';
+  try {
+    var resp = await fetch('/admin/deterrent/latency-summary?last_n=100');
+    var data = await resp.json();
+    if (!data || !data.count) {
+      tbody.innerHTML = '<tr><td colspan="3" class="muted" style="padding:0.5rem;">No actuation events recorded yet.</td></tr>';
+      countEl.textContent = '';
+      return;
+    }
+    function fmtMs(v) { return v == null ? '—' : v.toFixed(0) + ' ms'; }
+    function fmtS(v) { return v == null ? '—' : v.toFixed(1) + ' s'; }
+    tbody.innerHTML =
+      '<tr><td style="padding:0.4rem 0.5rem;">Trigger delay <span class="muted" style="font-size:0.75rem;">(detection → dequeue)</span></td>' +
+        '<td style="padding:0.4rem 0.5rem;">' + fmtMs(data.trigger_delay_ms.p50) + '</td>' +
+        '<td style="padding:0.4rem 0.5rem;">' + fmtMs(data.trigger_delay_ms.p95) + '</td></tr>' +
+      '<tr><td style="padding:0.4rem 0.5rem;">Cloud ack <span class="muted" style="font-size:0.75rem;">(ON command → Tuya success)</span></td>' +
+        '<td style="padding:0.4rem 0.5rem;">' + fmtMs(data.cloud_ack_ms.p50) + '</td>' +
+        '<td style="padding:0.4rem 0.5rem;">' + fmtMs(data.cloud_ack_ms.p95) + '</td></tr>' +
+      '<tr><td style="padding:0.4rem 0.5rem;">Total duration <span class="muted" style="font-size:0.75rem;">(wall-clock sequence)</span></td>' +
+        '<td style="padding:0.4rem 0.5rem;">' + fmtS(data.total_duration_sec.p50) + '</td>' +
+        '<td style="padding:0.4rem 0.5rem;">' + fmtS(data.total_duration_sec.p95) + '</td></tr>';
+    countEl.textContent = 'Based on ' + data.count + ' recent actuation(s).';
+  } catch (e) {
+    tbody.innerHTML = '<tr><td colspan="3" style="color:var(--danger);padding:0.5rem;">Failed to load: ' + esc(e.message) + '</td></tr>';
+  }
+}
 
 async function testFire(deviceId, btn) {
   var origText = btn.textContent;

--- a/services/web/tests/test_actuation_db.py
+++ b/services/web/tests/test_actuation_db.py
@@ -1,0 +1,126 @@
+"""Tests for services/web/src/actuation_db.py (read-only view of
+deterrent SQLite)."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import actuation_db
+
+
+@pytest.fixture
+def empty_db(tmp_path: Path, monkeypatch) -> Path:
+    """An empty file with the full v0.13.3 schema present."""
+    db = tmp_path / "deterrent.db"
+    conn = sqlite3.connect(db)
+    conn.executescript("""
+        CREATE TABLE actuation_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            trigger_class TEXT NOT NULL,
+            trigger_camera TEXT NOT NULL,
+            trigger_confidence REAL NOT NULL,
+            pre_delay_sec REAL NOT NULL,
+            total_duration_sec REAL NOT NULL,
+            device_count INTEGER NOT NULL,
+            success_count INTEGER NOT NULL,
+            group_name TEXT NOT NULL DEFAULT '',
+            trigger_delay_ms REAL,
+            queue_depth INTEGER
+        );
+        CREATE TABLE device_actions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id INTEGER NOT NULL REFERENCES actuation_events(id),
+            device_name TEXT NOT NULL,
+            device_id TEXT NOT NULL,
+            device_type TEXT NOT NULL,
+            duration_sec REAL NOT NULL,
+            delay_before_sec REAL NOT NULL,
+            success INTEGER NOT NULL DEFAULT 0,
+            error TEXT,
+            cloud_ack_ms REAL
+        );
+    """)
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(actuation_db, "DB_PATH", str(db))
+    return db
+
+
+def _insert_event(
+    db_path: Path,
+    *,
+    ts: str = "2026-04-20T10:00:00",
+    trigger_delay_ms: float | None = None,
+    total_duration_sec: float = 1.0,
+    actions: list[tuple[str, float | None]] | None = None,
+) -> int:
+    """Insert a minimal actuation row + optional device actions.
+
+    ``actions`` is a list of (device_name, cloud_ack_ms) pairs."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.execute(
+        "INSERT INTO actuation_events "
+        "(timestamp, trigger_class, trigger_camera, trigger_confidence, "
+        " pre_delay_sec, total_duration_sec, device_count, success_count, "
+        " group_name, trigger_delay_ms, queue_depth) "
+        "VALUES (?, 'bird', 'pond', 0.9, 0.0, ?, ?, ?, 'g', ?, 0)",
+        (ts, total_duration_sec, len(actions or []), len(actions or []),
+         trigger_delay_ms),
+    )
+    event_id = cur.lastrowid
+    for name, ack in (actions or []):
+        conn.execute(
+            "INSERT INTO device_actions "
+            "(event_id, device_name, device_id, device_type, duration_sec, "
+            " delay_before_sec, success, error, cloud_ack_ms) "
+            "VALUES (?, ?, 'x', 'sprinkler', 1.0, 0.0, 1, NULL, ?)",
+            (event_id, name, ack),
+        )
+    conn.commit()
+    conn.close()
+    assert event_id is not None
+    return event_id
+
+
+def test_latency_summary_empty_returns_nulls(empty_db):
+    out = actuation_db.get_latency_summary()
+    assert out["count"] == 0
+    assert out["trigger_delay_ms"] == {"p50": None, "p95": None}
+
+
+def test_latency_summary_basic_percentiles(empty_db):
+    # Insert 5 events: trigger_delay 100, 200, 300, 400, 500 ms
+    for i, delay in enumerate([100, 200, 300, 400, 500]):
+        _insert_event(
+            empty_db,
+            ts=f"2026-04-20T10:0{i}:00",
+            trigger_delay_ms=float(delay),
+            total_duration_sec=1.0 + i * 0.5,
+            actions=[("dev", float(delay / 2))],
+        )
+    out = actuation_db.get_latency_summary(last_n=10)
+    assert out["count"] == 5
+    assert out["trigger_delay_ms"]["p50"] == pytest.approx(300.0)
+    # p95 over 5 samples (linear interp): 500 at idx 4, k = 4*0.95 = 3.8 →
+    # 0.8 of the way from 400 to 500 → 480
+    assert out["trigger_delay_ms"]["p95"] == pytest.approx(480.0)
+    assert out["cloud_ack_ms"]["p50"] == pytest.approx(150.0)
+
+
+def test_latency_summary_missing_values_excluded(empty_db):
+    _insert_event(empty_db, trigger_delay_ms=None, actions=[("dev", None)])
+    _insert_event(empty_db, trigger_delay_ms=200.0, actions=[("dev", 50.0)])
+    out = actuation_db.get_latency_summary()
+    assert out["count"] == 2
+    # Only one row has a non-null trigger_delay_ms; p50 == p95 == 200
+    assert out["trigger_delay_ms"]["p50"] == pytest.approx(200.0)
+    assert out["cloud_ack_ms"]["p50"] == pytest.approx(50.0)
+
+
+def test_latency_summary_missing_db_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(actuation_db, "DB_PATH", str(tmp_path / "nope.db"))
+    out = actuation_db.get_latency_summary()
+    assert out["count"] == 0

--- a/services/web/tests/test_config_store.py
+++ b/services/web/tests/test_config_store.py
@@ -29,3 +29,79 @@ def test_load_cached_returns_empty_dict_when_config_file_missing(tmp_path, monke
     monkeypatch.setattr(config_store, "CONFIG_PATH", missing_cfg_path)
 
     assert config_store.load_cached() == {}
+
+
+class TestActionRulesMigration:
+    """v0.13.3 renamed per-camera action_rules → notification_rules."""
+
+    def test_load_migrates_action_rules(self, tmp_path, monkeypatch):
+        cfg_path = tmp_path / "scarguard.yml"
+        cfg_path.write_text(
+            "cameras:\n"
+            "- name: pond\n"
+            "  rtsp_url: rtsp://x\n"
+            "  action_rules:\n"
+            "  - class_name: bird\n"
+            "    channels: [discord]\n"
+        )
+        monkeypatch.setattr(config_store, "CONFIG_PATH", cfg_path)
+        loaded = config_store.load()
+        cam = loaded["cameras"][0]
+        assert "action_rules" not in cam
+        assert cam["notification_rules"] == [
+            {"class_name": "bird", "channels": ["discord"]}
+        ]
+
+    def test_save_strips_action_rules(self, tmp_path, monkeypatch):
+        cfg_path = tmp_path / "scarguard.yml"
+        monkeypatch.setattr(config_store, "CONFIG_PATH", cfg_path)
+        config_store.save({
+            "cameras": [{
+                "name": "pond",
+                "rtsp_url": "rtsp://x",
+                "action_rules": [{"class_name": "*", "channels": ["x"]}],
+            }],
+        })
+        reloaded = config_store.load()
+        cam = reloaded["cameras"][0]
+        assert "action_rules" not in cam
+        assert cam["notification_rules"] == [
+            {"class_name": "*", "channels": ["x"]}
+        ]
+
+    def test_load_preserves_existing_notification_rules_when_both_present(
+        self, tmp_path, monkeypatch,
+    ):
+        """If both keys exist, notification_rules wins; action_rules is dropped."""
+        cfg_path = tmp_path / "scarguard.yml"
+        cfg_path.write_text(
+            "cameras:\n"
+            "- name: pond\n"
+            "  rtsp_url: rtsp://x\n"
+            "  action_rules: [{class_name: old, channels: [old]}]\n"
+            "  notification_rules: [{class_name: new, channels: [new]}]\n"
+        )
+        monkeypatch.setattr(config_store, "CONFIG_PATH", cfg_path)
+        loaded = config_store.load()
+        cam = loaded["cameras"][0]
+        assert "action_rules" not in cam
+        assert cam["notification_rules"] == [
+            {"class_name": "new", "channels": ["new"]}
+        ]
+
+
+class TestCameraConfidenceThreshold:
+    """v0.13.3 added optional per-camera confidence_threshold override."""
+
+    def test_round_trip_preserves_confidence(self, tmp_path, monkeypatch):
+        cfg_path = tmp_path / "scarguard.yml"
+        monkeypatch.setattr(config_store, "CONFIG_PATH", cfg_path)
+        config_store.save({
+            "cameras": [
+                {"name": "pond", "rtsp_url": "rtsp://x", "confidence_threshold": 0.45},
+                {"name": "yard", "rtsp_url": "rtsp://y"},  # no override
+            ],
+        })
+        reloaded = config_store.load()
+        assert reloaded["cameras"][0]["confidence_threshold"] == 0.45
+        assert "confidence_threshold" not in reloaded["cameras"][1]

--- a/services/web/tests/test_routes.py
+++ b/services/web/tests/test_routes.py
@@ -216,7 +216,7 @@ class TestConfig:
         assert saved_cam["exclusion_zones"] == [{"x": 10, "y": 20, "w": 50, "h": 60, "label": "decoy"}]
 
     def test_structured_save_preserves_redis_and_unknown_keys(self, client, monkeypatch):
-        """Keys the form doesn't touch (redis, action_rules) must survive a structured save."""
+        """Keys the form doesn't touch (redis, webhooks) must survive a structured save."""
         existing = {
             "system": {"armed": True, "log_level": "info"},
             "cameras": [],
@@ -229,7 +229,7 @@ class TestConfig:
             },
             "notifications": {},
             "redis": {"host": "redis", "port": 6379},
-            "action_rules": [{"match": {"class": "bird"}, "actions": ["discord"]}],
+            "webhooks": [{"url": "https://example.test/hook", "method": "POST"}],
         }
         saved_cfgs = []
         monkeypatch.setattr("config_store.load", lambda: existing)
@@ -255,7 +255,7 @@ class TestConfig:
         assert resp.json()["ok"] is True
         saved = saved_cfgs[0]
         assert saved["redis"] == {"host": "redis", "port": 6379}
-        assert "action_rules" in saved
+        assert "webhooks" in saved
 
     def test_structured_save_preserves_existing_timezone_when_omitted(self, client, monkeypatch):
         """Structured saves that omit system.timezone must not reset it to UTC."""


### PR DESCRIPTION
## Summary

**Headline:** the deterrent no longer fires on every detection. Users now opt
in per camera/class through explicit `deterrent_rules`, and the fired devices
are scoped by named `deterrent.groups`.  Also ships per-camera confidence
override, tabbed UI refactors, and latency instrumentation.

### Per-camera deterrent scoping (breaking behavior change, see "Upgrade notes")
- New `deterrent.groups: [{name, devices[], cooldown_seconds, optional *_range overrides}]`.
- New per-camera `deterrent_rules: [{class_name, groups: [names]}]` (first-match-wins).
- Deterrent worker fires only the groups named in `matched_groups` on the
  event.  Two-layer cooldown: global (`deterrent.defaults.cooldown_seconds`)
  for cross-group rapid-fire + per-group for same-group repeats.

### Per-camera confidence override
- New optional `cameras[].confidence_threshold` overrides the global.
- `YOLODetector.predict()` gains a per-call `confidence` kwarg mirroring the
  existing `target_classes` override.

### `action_rules` → `notification_rules` rename
- Per-camera rename with auto-migration on load in `config_store`.
- Detector reads either key during the upgrade grace window.

### Latency instrumentation
- `trigger_delay_ms` (detection timestamp → deterrent dequeue),
  `queue_depth` at dequeue, per-`DeviceAction` `cloud_ack_ms` (ON sent →
  Tuya success).
- `actuation_db.get_latency_summary()` returns p50/p95 over last N; exposed
  at `GET /admin/deterrent/latency-summary` and on the new Latency tab.

### UI refactor
- Config page Settings panel → sub-tabs (System / Detection / Cameras /
  Notifications / Advanced) with URL-hash deep-linking; Advanced hidden
  unless expert mode is on.
- Deterrent admin page → tabs (Devices / Groups / Defaults / Battery /
  Latency) with a new Groups editor featuring multi-select device picker
  and per-group randomization overrides.

### Security
- `python-multipart` 0.0.22 → 0.0.26 (DoS fix, GHSA-mj87-hwqh-73pj,
  Dependabot alert #1).

### Schema migrations (additive, idempotent)
- `actuation_events`: `group_name`, `trigger_delay_ms`, `queue_depth`.
- `device_actions`: `cloud_ack_ms`.

## Upgrade notes

On first boot with v0.13.3, existing `deterrent` installs see:

1. **Deterrents stop firing** until the user creates at least one group on
   `/admin/deterrent` → Groups and adds a `deterrent_rules` entry to the
   cameras that should actuate.  This is intentional — deterrents are now
   explicit opt-in per the design Scott signed off on.
2. `cameras[].action_rules` is auto-renamed to `notification_rules` on next
   config save (or next read).  Both keys work until the next save.

## Test plan

- [x] Lint: `ruff check services/detector/src services/web/src services/notifier/src services/deterrent/src shared` — clean.
- [x] Type: mypy web / notifier / deterrent — clean.
- [x] Web tests: all 120 pass locally.
- [x] New tests cover the rename migration, confidence round-trip, deterrent
      rule matcher (first-match-wins, wildcard, empty-on-no-match), and
      latency percentile math.
- [x] Code Review Protocol: subagent review performed; one blocker
      (per-camera `confidence_threshold` clear-via-UI) fixed pre-commit
      plus three should-fixes (example config, comment, test fixture).
- [ ] Smoke in docker-compose on Orin after build.
- [ ] Manual: create a group, assign to camera rule, trigger detection,
      confirm actuation fires (and doesn't fire when rule absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)