### PR TITLE
feat(v0.13.5): dashboard deterrent widget + chip-picker z-index fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -482,6 +482,13 @@ jobs:
           DETECTOR_IMAGE: scarguard-detector-x86
           IMAGE_TAG: smoke
           GHCR_OWNER: ""
+          # The self-hosted docker runner co-hosts other web services on
+          # :80/:443 — remap Caddy's host bindings so the smoke stack
+          # doesn't collide.  Health checks hit the web container via
+          # `docker compose exec`, so Caddy's external ports are unused
+          # here; production deploys still bind the defaults.
+          HTTP_PORT: "18080"
+          HTTPS_PORT: "18443"
         run: docker compose up -d
 
       - name: Health checks
@@ -490,6 +497,8 @@ jobs:
           DETECTOR_IMAGE: scarguard-detector-x86
           IMAGE_TAG: smoke
           GHCR_OWNER: ""
+          HTTP_PORT: "18080"
+          HTTPS_PORT: "18443"
         run: |
           REDIS_OK=false
           echo "Waiting for Redis..."
@@ -535,6 +544,8 @@ jobs:
           DETECTOR_IMAGE: scarguard-detector-x86
           IMAGE_TAG: smoke
           GHCR_OWNER: ""
+          HTTP_PORT: "18080"
+          HTTPS_PORT: "18443"
         run: |
           docker compose down -v || true
           docker rmi scarguard-detector-x86:smoke scarguard-web:smoke \

--- a/services/web/src/actuation_db.py
+++ b/services/web/src/actuation_db.py
@@ -102,6 +102,23 @@ def count_actuations(
         conn.close()
 
 
+def get_latest_event() -> dict[str, Any] | None:
+    """Return the most recent actuation event, or None if none exist."""
+    conn = _connect()
+    if conn is None:
+        return None
+    try:
+        row = conn.execute(
+            "SELECT * FROM actuation_events ORDER BY id DESC LIMIT 1",
+        ).fetchone()
+        return dict(row) if row else None
+    except Exception:
+        logger.warning("Failed to query latest actuation event", exc_info=True)
+        return None
+    finally:
+        conn.close()
+
+
 def get_actuation_actions(event_id: int) -> list[dict[str, Any]]:
     """Return device actions for a specific actuation event."""
     conn = _connect()

--- a/services/web/src/config_store.py
+++ b/services/web/src/config_store.py
@@ -147,5 +147,10 @@ def set_armed(armed: bool) -> None:
 
 def set_deterrent_enabled(enabled: bool) -> None:
     cfg = load()
-    cfg.setdefault("deterrent", {})["enabled"] = enabled
+    # Tolerate a non-mapping `deterrent:` in YAML (e.g. `false`, null, or
+    # a stray scalar) — coerce to a fresh dict before subscripting,
+    # matching how _deterrent_context() defensively reads it.
+    if not isinstance(cfg.get("deterrent"), dict):
+        cfg["deterrent"] = {}
+    cfg["deterrent"]["enabled"] = enabled
     save(cfg)

--- a/services/web/src/config_store.py
+++ b/services/web/src/config_store.py
@@ -143,3 +143,9 @@ def set_armed(armed: bool) -> None:
     cfg = load()
     cfg.setdefault("system", {})["armed"] = armed
     save(cfg)
+
+
+def set_deterrent_enabled(enabled: bool) -> None:
+    cfg = load()
+    cfg.setdefault("deterrent", {})["enabled"] = enabled
+    save(cfg)

--- a/services/web/src/routes/dashboard.py
+++ b/services/web/src/routes/dashboard.py
@@ -396,13 +396,17 @@ def _deterrent_context(cfg: dict, *, can_toggle: bool) -> dict[str, Any]:
     """
     det = cfg.get("deterrent", {}) if isinstance(cfg.get("deterrent"), dict) else {}
     enabled = bool(det.get("enabled", False))
-    global_cd = int(det.get("defaults", {}).get("cooldown_seconds", 0) or 0)
+    # Mirror the deterrent service's Pydantic defaults (60s) — see
+    # services/deterrent/src/actuation_models.py ActuationDefaults /
+    # GroupConfig.  A missing value in YAML doesn't mean "no cooldown";
+    # the worker applies 60s, so the widget must match or it lies.
+    global_cd = int(det.get("defaults", {}).get("cooldown_seconds", 60) or 60)
     tz_name = cfg.get("system", {}).get("timezone") or "UTC"
 
     group_cd_by_name: dict[str, int] = {}
     for g in det.get("groups", []) or []:
         if isinstance(g, dict) and g.get("name"):
-            group_cd_by_name[str(g["name"])] = int(g.get("cooldown_seconds", 0) or 0)
+            group_cd_by_name[str(g["name"])] = int(g.get("cooldown_seconds", 60) or 60)
 
     latest = actuation_db.get_latest_event()
     last_fire: dict[str, Any] | None = None

--- a/services/web/src/routes/dashboard.py
+++ b/services/web/src/routes/dashboard.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+import actuation_db
 import config_store
 import db
 from fastapi import APIRouter, Request
@@ -252,6 +253,9 @@ async def dashboard(request: Request):
             if isinstance(ch, dict) and ch.get("enabled", True) and ch.get("name"):
                 notif_channels.append(ch["name"])
 
+    role = current_role(request)
+    deterrent_ctx = _deterrent_context(cfg, can_toggle=role in ("user", "admin"))
+
     return templates.TemplateResponse(
         request,
         "dashboard.html",
@@ -259,7 +263,7 @@ async def dashboard(request: Request):
             "armed": cfg.get("system", {}).get("armed", True),
             "rearm_at": rearm_at,
             "is_admin": _is_admin(request),
-            "user_role": current_role(request),
+            "user_role": role,
             "cameras": cameras,
             "camera_health": camera_health,
             "total_events": total,
@@ -268,6 +272,7 @@ async def dashboard(request: Request):
             "schedule": _get_schedule_info(cfg),
             "training_nudge": training_nudge,
             "notif_channels": notif_channels,
+            "deterrent": deterrent_ctx,
         },
     )
 
@@ -351,3 +356,121 @@ async def _arm_badge(
         "partials/arm_badge.html",
         {"armed": armed, "rearm_at": rearm_at, "is_admin": is_admin},
     )
+
+
+def _humanize_since(iso_ts: str, tz_name: str) -> str:
+    """Return a terse "Xm ago" / "Xh ago" string for *iso_ts*; falls back to local time."""
+    try:
+        dt = datetime.fromisoformat(iso_ts)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return iso_ts
+    delta = datetime.now(timezone.utc) - dt
+    secs = int(delta.total_seconds())
+    if secs < 60:
+        return f"{secs}s ago"
+    if secs < 3600:
+        return f"{secs // 60}m ago"
+    if secs < 86400:
+        return f"{secs // 3600}h ago"
+    return _to_local(iso_ts, tz_name)
+
+
+def _deterrent_context(cfg: dict, *, can_toggle: bool) -> dict[str, Any]:
+    """Build the template context for the dashboard deterrent widget.
+
+    Cooldown remaining is the MAX of the global cooldown
+    (``deterrent.defaults.cooldown_seconds``) and the per-group cooldown
+    of the group that fired last.  Both layers gate future actuations of
+    that same group, so showing the effective block is the accurate
+    signal — reporting only the global would say "Ready" while a
+    longer-cooldown group is still blocked.
+
+    Derived from the persisted wall-clock timestamp in actuation_db, not
+    the deterrent service's in-memory monotonic clock.  The sub-second
+    drift between fire and DB write is immaterial for a status readout.
+    Note: the UI reflects file-state immediately on toggle; the
+    deterrent service picks up the change when its config watcher fires
+    (typically <1 s).
+    """
+    det = cfg.get("deterrent", {}) if isinstance(cfg.get("deterrent"), dict) else {}
+    enabled = bool(det.get("enabled", False))
+    global_cd = int(det.get("defaults", {}).get("cooldown_seconds", 0) or 0)
+    tz_name = cfg.get("system", {}).get("timezone") or "UTC"
+
+    group_cd_by_name: dict[str, int] = {}
+    for g in det.get("groups", []) or []:
+        if isinstance(g, dict) and g.get("name"):
+            group_cd_by_name[str(g["name"])] = int(g.get("cooldown_seconds", 0) or 0)
+
+    latest = actuation_db.get_latest_event()
+    last_fire: dict[str, Any] | None = None
+    cooldown_remaining = 0
+    if latest and latest.get("timestamp"):
+        iso_ts = str(latest["timestamp"])
+        group_name = latest.get("group_name") or ""
+        last_fire = {
+            "iso": iso_ts,
+            "relative": _humanize_since(iso_ts, tz_name),
+            "trigger_class": latest.get("trigger_class", "?"),
+            "trigger_camera": latest.get("trigger_camera", "?"),
+            "trigger_confidence": float(latest.get("trigger_confidence") or 0.0),
+            "group_name": group_name,
+        }
+        effective_cd = max(global_cd, group_cd_by_name.get(group_name, 0))
+        if effective_cd > 0:
+            try:
+                dt = datetime.fromisoformat(iso_ts)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                elapsed = (datetime.now(timezone.utc) - dt).total_seconds()
+                cooldown_remaining = max(0, int(effective_cd - elapsed))
+            except (ValueError, TypeError):
+                cooldown_remaining = 0
+
+    return {
+        "enabled": enabled,
+        "can_toggle": can_toggle,
+        "last_fire": last_fire,
+        "cooldown_remaining": cooldown_remaining,
+    }
+
+
+async def _deterrent_partial(request: Request) -> HTMLResponse:
+    """Render the deterrent status partial for the current user."""
+    cfg = config_store.load()
+    role = current_role(request)
+    can_toggle = role in ("user", "admin")
+    ctx = _deterrent_context(cfg, can_toggle=can_toggle)
+    return templates.TemplateResponse(
+        request, "partials/deterrent_status.html", {"deterrent": ctx},
+    )
+
+
+@router.get("/deterrent-status", response_class=HTMLResponse)
+async def deterrent_status(request: Request) -> Response:
+    """HTMX poll endpoint — returns the deterrent widget fragment."""
+    return await _deterrent_partial(request)
+
+
+@router.post("/deterrent-enable", response_class=HTMLResponse)
+async def deterrent_enable(request: Request) -> Response:
+    """Flip deterrent.enabled=true.  Viewers are rejected; widget re-renders unchanged."""
+    role = current_role(request)
+    if role not in ("user", "admin"):
+        return await _deterrent_partial(request)
+    config_store.set_deterrent_enabled(True)
+    log.info("Deterrent enabled via dashboard (role=%s)", role)
+    return await _deterrent_partial(request)
+
+
+@router.post("/deterrent-disable", response_class=HTMLResponse)
+async def deterrent_disable(request: Request) -> Response:
+    """Flip deterrent.enabled=false.  Viewers are rejected; widget re-renders unchanged."""
+    role = current_role(request)
+    if role not in ("user", "admin"):
+        return await _deterrent_partial(request)
+    config_store.set_deterrent_enabled(False)
+    log.info("Deterrent disabled via dashboard (role=%s)", role)
+    return await _deterrent_partial(request)

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -927,6 +927,7 @@ body.expert-mode details.expert-only { display: block !important; }
 }
 .chip-picker:focus-within {
   outline: 1px solid var(--accent);
+  z-index: 60;
 }
 .chip-picker-chips {
   display: flex;

--- a/services/web/src/templates/dashboard.html
+++ b/services/web/src/templates/dashboard.html
@@ -44,6 +44,11 @@
 </section>
 
 <section class="card">
+  <h2>Deterrent</h2>
+  {% include "partials/deterrent_status.html" %}
+</section>
+
+<section class="card">
   <h2>Stats</h2>
   <dl>
     <dt>Total detections</dt><dd>{{ total_events }}</dd>

--- a/services/web/src/templates/partials/deterrent_status.html
+++ b/services/web/src/templates/partials/deterrent_status.html
@@ -1,0 +1,33 @@
+<div id="deterrent-status"
+     hx-get="/deterrent-status" hx-trigger="every 5s" hx-target="this" hx-swap="outerHTML">
+  <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;">
+    {% if deterrent.enabled %}
+    <span class="badge badge-armed">DETERRENT ON</span>
+    {% if deterrent.can_toggle %}
+    <button hx-post="/deterrent-disable" hx-target="#deterrent-status" hx-swap="outerHTML">Disable</button>
+    {% endif %}
+    {% else %}
+    <span class="badge badge-disarmed">DETERRENT OFF</span>
+    {% if deterrent.can_toggle %}
+    <button hx-post="/deterrent-enable" hx-target="#deterrent-status" hx-swap="outerHTML">Enable</button>
+    {% endif %}
+    {% endif %}
+    {% if deterrent.cooldown_remaining > 0 %}
+    <span class="hint" title="Time until the last-fired group is eligible to fire again">
+      Cooldown: <strong>{{ deterrent.cooldown_remaining }}s</strong> remaining
+    </span>
+    {% else %}
+    <span class="hint">Ready to fire</span>
+    {% endif %}
+  </div>
+  {% if deterrent.last_fire %}
+  <p class="hint" style="margin-top:0.5rem;">
+    Last fire: <strong>{{ deterrent.last_fire.relative }}</strong>
+    &mdash; {{ deterrent.last_fire.trigger_class }} from {{ deterrent.last_fire.trigger_camera }}
+    (conf {{ "%.2f" | format(deterrent.last_fire.trigger_confidence) }})
+    {% if deterrent.last_fire.group_name %}&rarr; {{ deterrent.last_fire.group_name }}{% endif %}
+  </p>
+  {% else %}
+  <p class="hint" style="margin-top:0.5rem;">No deterrent actuations recorded yet.</p>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary

- **Dashboard deterrent widget** — surfaces enable/disable toggle, last-fire line, and effective cooldown on the main dashboard. Motivated by a ~20h silent-non-actuation incident where the `deterrent.enabled` flag was off and the only indicator was buried on `/admin/deterrent`.
- **Chip-picker z-index fix** — deterrent/notification rule autocomplete dropdowns were being covered by the next camera card's content. `.chip-picker` now establishes a stacking context on `:focus-within`.

## What's in the widget

- ENABLED/DISABLED pill (mirrors the arm badge visual).
- Enable/Disable button for `role in (user, admin)`; viewers see status read-only.
- "Last fire: Xm ago — *class* from *camera* (conf X.XX) → *group*".
- Cooldown = `max(global_cooldown, per-group_cooldown_of_last_fired_group)` — an honest "time until that group can fire again" rather than just the global gate. "Ready to fire" when both layers are clear.
- HTMX `hx-trigger="every 5s"` so the countdown ticks without a page refresh.

## Implementation

- `templates/partials/deterrent_status.html` (new) — the widget.
- `routes/dashboard.py` — three routes (`GET /deterrent-status`, `POST /deterrent-enable`, `POST /deterrent-disable`) mirroring the existing `/arm` & `/disarm` pattern; `_deterrent_context()` helper that computes effective cooldown from the persisted wall-clock timestamp in `actuation_db` (avoids a Redis RPC for a status readout). Toggles emit an audit log line with the role.
- `config_store.set_deterrent_enabled()` + `actuation_db.get_latest_event()` — small helpers.
- `templates/dashboard.html` — new "Deterrent" card between System Status and Stats.
- `static/style.css` — `.chip-picker:focus-within { z-index: 60; }`.

## Test plan

- [ ] Deploy to Orin (GHCR → `docker compose pull && up -d web`).
- [ ] Dashboard as admin: toggle Disable → deterrent container log shows "Config reloaded — actuation disabled" within ~1s. Toggle Enable → same reload line, "enabled".
- [ ] Cooldown tick: trigger a test-fire or wait for a real bird; dashboard shows "Cooldown: Xs remaining" counting down, then "Ready to fire".
- [ ] As viewer role: Enable/Disable button is hidden; pill + status still visible.
- [ ] Config page / Deterrent Rules: open the Class chip-picker dropdown — no longer obscured by the next camera card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)