### PR TITLE
fix(v1.14.1): add backup service to build + release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,6 +251,74 @@ jobs:
         if: always() && github.event_name != 'push'
         run: docker rmi scarguard-deterrent:test || true
 
+  # ── Build backup (x86 runner) ───────────────────────────────────────────────
+  build-backup:
+    name: Build backup image
+    runs-on: [self-hosted, linux, docker]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_API_KEY }}
+
+      - name: Build backup (validate only, no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/backup/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          provenance: false
+          cache-from: type=gha,scope=backup
+          cache-to: type=gha,scope=backup,mode=max
+
+      # ── Test + scan (PR only — main push only warms build cache) ──────────
+      - name: Build backup (amd64, load for test)
+        if: github.event_name != 'push'
+        run: |
+          docker build \
+            --tag scarguard-backup:test \
+            --file services/backup/Dockerfile \
+            .
+
+      - name: Test backup in container
+        if: github.event_name != 'push'
+        run: |
+          cid=$(docker create --user root --entrypoint "" scarguard-backup:test sh -c "pip install --quiet pytest && python3 -m pytest /app/tests/ -v --tb=short")
+          docker cp ${{ github.workspace }}/services/backup/tests/. "$cid:/app/tests/"
+          docker cp ${{ github.workspace }}/shared/. "$cid:/app/shared/"
+          docker start -a "$cid"
+          rc=$?
+          docker rm "$cid" > /dev/null
+          exit $rc
+
+      - name: Trivy scan — backup
+        if: github.event_name != 'push'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: scarguard-backup:test
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          timeout: 20m0s
+
+      - name: Clean up
+        if: always() && github.event_name != 'push'
+        run: docker rmi scarguard-backup:test || true
+
   # ── Build caddy (x86 runner) ────────────────────────────────────────────────
   build-caddy:
     name: Build caddy image
@@ -438,7 +506,7 @@ jobs:
       github.event_name != 'push' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.owner.login == 'sentania-labs')
-    needs: [build-detector-x86, build-web, build-notifier, build-deterrent, build-caddy, build-log-streamer]
+    needs: [build-detector-x86, build-web, build-notifier, build-deterrent, build-backup, build-caddy, build-log-streamer]
     runs-on: [self-hosted, linux, docker]
 
     steps:
@@ -464,6 +532,7 @@ jobs:
             --build-arg GIT_COMMIT=${{ github.sha }} .
           docker build -f services/notifier/Dockerfile -t scarguard-notifier:smoke .
           docker build -f services/deterrent/Dockerfile -t scarguard-deterrent:smoke .
+          docker build -f services/backup/Dockerfile -t scarguard-backup:smoke .
           docker build -f services/caddy/Dockerfile -t scarguard-caddy:smoke .
           docker build -f services/log-streamer/Dockerfile -t scarguard-log-streamer:smoke .
 
@@ -550,4 +619,5 @@ jobs:
           docker compose down -v || true
           docker rmi scarguard-detector-x86:smoke scarguard-web:smoke \
             scarguard-notifier:smoke scarguard-deterrent:smoke \
-            scarguard-caddy:smoke scarguard-log-streamer:smoke 2>/dev/null || true
+            scarguard-backup:smoke scarguard-caddy:smoke \
+            scarguard-log-streamer:smoke 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,46 @@ jobs:
         if: always()
         run: docker image prune -f
 
+  # ── Build & push — backup (x86 runner) ─────────────────────────────────────
+  release-backup:
+    name: Release backup image
+    runs-on: [self-hosted, linux, docker]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push — backup
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/backup/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/scarguard-backup:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/scarguard-backup:latest
+          cache-from: type=gha,scope=backup
+          cache-to: type=gha,scope=backup,mode=max
+
+      - name: Prune dangling images
+        if: always()
+        run: docker image prune -f
+
   # ── Build & push — caddy (x86 runner) ──────────────────────────────────────
   release-caddy:
     name: Release caddy image
@@ -452,7 +492,7 @@ jobs:
   # with auto-generated notes so there's a visible changelog on the repo.
   create-release:
     name: Create GitHub Release
-    needs: [release-web, release-notifier, release-deterrent, release-caddy, release-log-streamer, release-detector, release-detector-x86]
+    needs: [release-web, release-notifier, release-deterrent, release-backup, release-caddy, release-log-streamer, release-detector, release-detector-x86]
     runs-on: [self-hosted, linux, generic]
     permissions:
       contents: write
@@ -501,6 +541,7 @@ jobs:
           | web | `ghcr.io/{owner}/scarguard-web:{tag}` | amd64, arm64 |
           | notifier | `ghcr.io/{owner}/scarguard-notifier:{tag}` | amd64, arm64 |
           | deterrent | `ghcr.io/{owner}/scarguard-deterrent:{tag}` | amd64, arm64 |
+          | backup | `ghcr.io/{owner}/scarguard-backup:{tag}` | amd64, arm64 |
           | caddy | `ghcr.io/{owner}/scarguard-caddy:{tag}` | amd64, arm64 |
           | log-streamer | `ghcr.io/{owner}/scarguard-log-streamer:{tag}` | amd64, arm64 |
 


### PR DESCRIPTION
## Summary

v1.14.0 shipped the SQLite backup sidecar (`services/backup/`) and wired it into `docker-compose.yml`, but **no CI jobs were added to build or push the image**. Deploys that pull from GHCR fail:

```
ghcr.io/sentania-labs/scarguard-backup:latest: denied
```

This PR adds the missing jobs so `v1.14.1` publishes a working image.

## Changes

- **`build.yml`** — new `build-backup` job (multi-arch validate, amd64 pytest-in-container, Trivy CRITICAL/HIGH scan). Mirrors `build-notifier` / `build-deterrent` exactly.
- **`build.yml`** — `compose-smoke-test` now builds the backup image explicitly and tears it down; `needs:` includes `build-backup`.
- **`release.yml`** — new `release-backup` job pushing `ghcr.io/<owner>/scarguard-backup:{tag}` and `:latest`.
- **`release.yml`** — `create-release` `needs:` and the release-body image table now include backup.

No code changes to the backup service itself. Every other service (web, notifier, deterrent, caddy, log-streamer, detector, detector-x86) already had both jobs — this just brings backup to parity.

## Test plan

- [ ] PR CI: `build-backup` job runs (multi-arch build + pytest + Trivy) and passes
- [ ] PR CI: `compose-smoke-test` continues to pass with the explicit backup build
- [ ] After merge + `v1.14.1` tag push: `release-backup` pushes `ghcr.io/sentania-labs/scarguard-backup:v1.14.1` and `:latest`
- [ ] After release: `docker compose pull` succeeds on the backup service from a clean host

🤖 Generated with [Claude Code](https://claude.com/claude-code)