### PR TITLE
fix(v1.14.2): run redis + caddy as non-root uid 999

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,9 +354,12 @@ docker compose down
 docker run --rm \
     -v scarguard-redis-data:/redis \
     -v scarguard-caddy-data:/caddy \
-    alpine:3 chown -R 999:999 /redis /caddy
+    -v scarguard-config:/config \
+    alpine:3 chown -R 999:999 /redis /caddy /config
 docker compose up -d
 ```
+
+The `/config` chown is the one manual-TLS users (Mode 3 above) in particular need — copies of `cert.pem`/`key.pem` placed via the documented `docker run … alpine` flow land as root-owned and are otherwise unreadable by the non-root caddy.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,23 @@ docker compose up -d
 
 That's all that's needed. HTTP continues to work on your existing port with no config changes.
 
+#### Breaking change in v1.14.2 — non-root containers (handled automatically)
+
+Starting in v1.14.2 the `redis` and `caddy` containers run as non-root (uid 999) to match every other service in the stack. Installations from **0.13.x, v1.14.0, or v1.14.1** have volume data owned by root that the new non-root containers cannot read on their own.
+
+A `volume-init` sidecar runs on every `docker compose up` to chown the `redis-data` and `scarguard-caddy-data` volumes to uid 999. It's idempotent and adds ~0.5s to startup. The standard upgrade command above handles the migration with no additional steps.
+
+The sidecar is scheduled for removal in **v1.16**, and no earlier than **2026-10-23** (six months after v1.14.2). After that point, upgraders from a pre-v1.14.2 install who missed the automatic migration window will need to run the chown manually:
+
+```bash
+docker compose down
+docker run --rm \
+    -v scarguard-redis-data:/redis \
+    -v scarguard-caddy-data:/caddy \
+    alpine:3 chown -R 999:999 /redis /caddy
+docker compose up -d
+```
+
 ---
 
 ## Feature Guides

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,44 @@ name: scarguard
 
 services:
 
+  # ── Volume init (one-shot migration helper) ───────────────────────────────
+  # v1.14.2 upgrade migration: chown the redis-data and caddy-data volumes
+  # to uid 999 so the non-root redis/caddy containers can read pre-existing
+  # files written by the old root-user containers (any install from 0.13.x,
+  # v1.14.0, or v1.14.1). Runs to completion on every `up` — chown is
+  # idempotent, so steady-state is a no-op (~0.5s). Redis and caddy gate on
+  # this via `service_completed_successfully` so they never start ahead of it.
+  #
+  # RETIREMENT: remove in v1.16, and no earlier than 2026-10-23 (six months
+  # after v1.14.2 ship date) — whichever is later. After retirement, the
+  # rare stale-installer upgrading from a pre-v1.14.2 volume gets a
+  # one-time manual chown instruction (see README "Upgrading from a
+  # previous version"). Fresh v1.14.2+ installs never needed this.
+  volume-init:
+    image: alpine:3.19
+    command: >-
+      sh -c 'chown -R 999:999 /redis /caddy 2>/dev/null || true;
+             echo "volume-init: ownership set to 999:999 on /redis and /caddy"'
+    volumes:
+      - redis-data:/redis
+      - scarguard-caddy-data:/caddy
+    restart: "no"
+    mem_limit: 32m
+    pids_limit: 10
+
   # ── Redis ─────────────────────────────────────────────────────────────────
   redis:
     image: redis:7-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
+    # Run as the non-root `redis` user built into the alpine image (uid 999).
+    # The image's entrypoint only drops privileges when arg[0] is
+    # `redis-server`; our `sh -c` wrapper defeats that path, so we pin the
+    # uid explicitly here. Existing deployments must chown the redis-data
+    # volume to 999:999 once before upgrading — handled automatically by
+    # the volume-init service above.
+    user: "999:999"
+    depends_on:
+      volume-init:
+        condition: service_completed_successfully
     restart: unless-stopped
     # v1.14: --maxmemory caps Redis at 200MB and evicts least-recently-used
     # keys when full. Pre-v1.14 Redis would grow unbounded; a misbehaving
@@ -60,6 +95,14 @@ services:
       context: .
       dockerfile: services/caddy/Dockerfile
     image: ghcr.io/${GHCR_OWNER:-sentania-labs}/scarguard-caddy:${IMAGE_TAG:-latest}
+    # Run as uid 999 to match scarguard.yml's owner (all other services do
+    # the same). This removes the prior reliance on DAC_OVERRIDE /
+    # DAC_READ_SEARCH to bypass unix perms. The upstream caddy:2-alpine
+    # image already ships /usr/bin/caddy with cap_net_bind_service=ep, so
+    # the non-root user can still bind :80/:443. Existing deployments
+    # must chown the
+    # scarguard-caddy-data volume to 999:999 once before upgrading.
+    user: "999:999"
     ports:
       # Falls back to legacy WEB_PORT / WEB_HTTPS_PORT for in-place upgrades.
       - "${HTTP_PORT:-${WEB_PORT:-80}}:80"
@@ -72,7 +115,10 @@ services:
       HTTPS_PORT: ${HTTPS_PORT:-${WEB_HTTPS_PORT:-443}}
       XDG_CONFIG_HOME: /data/caddy/config
     depends_on:
-      - web
+      web:
+        condition: service_started
+      volume-init:
+        condition: service_completed_successfully
     restart: unless-stopped
     mem_limit: 128m
     cpus: 0.5
@@ -82,7 +128,10 @@ services:
     cap_drop:
       - ALL
     cap_add:
-      # Caddy needs to bind 80/443 — the only privileged ports we use.
+      # Caddy binds 80/443. The upstream caddy:2-alpine image already
+      # ships /usr/bin/caddy with cap_net_bind_service=ep, so the non-root
+      # uid 999 process claims the cap from its bounding set at execve
+      # (this line keeps it in the bounding set after cap_drop: ALL).
       - NET_BIND_SERVICE
 
   # ── Detector ──────────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,12 +28,25 @@ services:
   # previous version"). Fresh v1.14.2+ installs never needed this.
   volume-init:
     image: alpine:3.19
+    # `set -e` + no error suppression: if chown actually fails (e.g., a
+    # volume backend that rejects the op), the sidecar exits non-zero,
+    # the `service_completed_successfully` gate on redis/caddy fails,
+    # and the stack refuses to start with a clear error — preferable to
+    # redis/caddy booting against unchanged ownership and hitting the
+    # same permission wall the sidecar was meant to prevent.
+    #
+    # /config is included because manual-TLS users (README: Enabling
+    # HTTPS → Mode 3) copy `cert.pem`/`key.pem` into /config/certs via a
+    # root `docker run`, producing root:root mode 600 files that a
+    # non-root caddy can't read. Every service that touches /config
+    # runs as uid 999, so recursive chown is safe.
     command: >-
-      sh -c 'chown -R 999:999 /redis /caddy 2>/dev/null || true;
-             echo "volume-init: ownership set to 999:999 on /redis and /caddy"'
+      sh -euc 'chown -R 999:999 /redis /caddy /config;
+               echo "volume-init: ownership set to 999:999 on /redis, /caddy, /config"'
     volumes:
       - redis-data:/redis
       - scarguard-caddy-data:/caddy
+      - scarguard-config:/config
     restart: "no"
     mem_limit: 32m
     pids_limit: 10

--- a/services/caddy/Dockerfile
+++ b/services/caddy/Dockerfile
@@ -3,11 +3,21 @@
 # v0.13.4: authenticated Docker Hub pull via DOCKER_HUB_USERNAME/_API_KEY
 # org secrets (docker/login-action step in build.yml) — per-user quota
 # (5000/day) instead of the anonymous-IP quota (~100/6h).
+# v1.14.2: runs as non-root uid 999 (matches the scarguard user on the
+# other services). The upstream caddy:2-alpine image already ships
+# /usr/bin/caddy with cap_net_bind_service=ep, so the non-root user can
+# still bind :80/:443 (combined with `cap_add: NET_BIND_SERVICE` in
+# docker-compose.yml to keep the cap in the bounding set after
+# cap_drop: ALL). We don't add a named user — gid 999 is already taken
+# by Alpine's `ping` group. The process just runs as the numeric uid/gid.
 FROM docker.io/library/caddy:2-alpine@sha256:fce4f15aad23222c0ac78a1220adf63bae7b94355d5ea28eee53910624acedfa
 
-RUN apk add --no-cache python3 py3-yaml
+RUN apk add --no-cache python3 py3-yaml \
+    && chown -R 999:999 /etc/caddy /data
 
-COPY config/caddy-entrypoint.sh /entrypoint.sh
+COPY --chown=999:999 config/caddy-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+USER 999:999
 
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]


### PR DESCRIPTION
## Summary

- Fixes a production-down regression surfaced today: after the v1.14.0 `cap_drop: ALL` hardening, redis and caddy (still running as container-root while every other service runs as uid 999) lost the DAC caps they relied on to bypass unix perms on 999-owned data — caddy couldn't read `scarguard.yml` and fell back to `tls mode=off`, redis couldn't write its RDB temp file and flipped to `stop-writes-on-bgsave-error`, blocking all stat writes and breaking the UI.
- Converts both services to run as non-root uid 999 (matching the rest of the stack), drops the reliance on `CAP_DAC_OVERRIDE` / `CAP_DAC_READ_SEARCH` entirely. Caddy still binds :80/:443 via the upstream image's `cap_net_bind_service=ep` file cap + `NET_BIND_SERVICE` in the bounding set.
- Adds a `volume-init` sidecar that auto-chowns the redis + caddy volumes to 999:999 on every `docker compose up`, so upgraders from 0.13.x / v1.14.0 / v1.14.1 migrate transparently with no manual steps. Idempotent; ~0.5s no-op in steady state.
- README documents the breaking change under "Upgrading from a previous version" including the post-retirement manual-chown escape hatch.

## Retirement of the migration sidecar

Remove in **v1.16**, no earlier than **2026-10-23** (six months after v1.14.2 ship), whichever is later. Policy is recorded in both the README and the compose comment so future maintainers find it at either site.

## Test plan

- [x] Deployed the non-root compose changes directly to orin (the affected prod system), confirmed redis BGSAVE works, `scarguard:stats` + `logs:buffer:*` keys flowing, `https://scarguard.sentania.net/` serving (401 auth challenge = working).
- [x] Isolated 0.13.5 → 1.14.2 migration test in `/tmp/`: fresh clone at v0.13.5, minimal scarguard.yml seeded, brought up redis+caddy with v0.13.5 images (runs as root), wrote `SET test:migration "hello from 0.13.5"` + BGSAVE, confirmed volume state matched the real-world 0.13.x pattern (dump.rdb root-owned mode 600). Tore down, overlaid the 1.14.2 compose + Dockerfile + updated caddy-entrypoint, rebuilt caddy image, brought up volume-init + redis + caddy. Sidecar logged `ownership set to 999:999` and exited cleanly, redis came up healthy as uid 999, `GET test:migration` returned `hello from 0.13.5` — data preserved across the ownership migration. BGSAVE post-migration also works.
- [x] Verified caddy starts healthy as uid 999, generates Caddyfile from `scarguard.yml`, binds :80 via the upstream image's file cap, writes to `/data/caddy` without DAC bypass.

## Notes

- No CI-relevant Python changes — compose / Dockerfile / docs only, so ruff + mypy have nothing new to check.
- One operational cleanup item on orin (stray `scarguard_redis-data` empty volume from a typo during the live debug session + timestamped `docker-compose.yml.bak-*` files) is not in scope for this PR; will handle separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)