### PR TITLE
fix(web): exclusion zone canvas + chip-picker dropdown auto-open

### DIFF
--- a/services/web/src/static/chip-picker.js
+++ b/services/web/src/static/chip-picker.js
@@ -178,9 +178,12 @@ window.ChipPicker = (function() {
 
     function _removeIdx(idx) {
       if (idx < 0 || idx >= values.length) return;
+      var dropdownWasOpen = dropEl.style.display !== "none";
       values.splice(idx, 1);
       _renderChips();
-      _renderDropdown();
+      // Only re-render the dropdown if the user already had it open —
+      // clicking ✕ on a chip shouldn't pop a closed dropdown back open.
+      if (dropdownWasOpen) _renderDropdown();
       _emit();
     }
 
@@ -228,8 +231,12 @@ window.ChipPicker = (function() {
           var next = readValues();
           if (Array.isArray(next)) values = next.slice();
         }
+        var dropdownWasOpen = dropEl.style.display !== "none";
         _renderChips();
-        _renderDropdown();
+        // Background registry refreshes (async class-list fetch, channel
+        // mutation observer) shouldn't pop the dropdown open — only
+        // re-render if the user already had it open.
+        if (dropdownWasOpen) _renderDropdown();
       },
       getValues: function() { return values.slice(); },
       setValues: function(next) {

--- a/services/web/src/static/config.js
+++ b/services/web/src/static/config.js
@@ -913,6 +913,17 @@ function initZoneEditor(card, initialZones) {
     syncCanvasSize();
   }
 
+  // The Exclusion Zones section is wrapped in a collapsed <details>, so the
+  // bg image has 0×0 layout at init — without this re-sync, the canvas
+  // keeps its 300×150 HTML default and newly drawn zones land outside the
+  // internal pixel space.  Re-sync on every open.
+  const detailsEl = canvas.closest("details");
+  if (detailsEl) {
+    detailsEl.addEventListener("toggle", () => {
+      if (detailsEl.open) { syncCanvasSize(); drawZones(card); }
+    });
+  }
+
   drawZones(card);
 
   // Draw on mouse drag


### PR DESCRIPTION
## Summary

Two web-UI bug fixes from the open-issue triage:

- **#127** — Creating a new camera exclusion zone fails to draw the boundary box.
- **#126** — Chip-picker dropdowns appear extended without user interaction (Summary Reports channel, Camera Class override, Notification rules class selection).

Both are JS-only changes confined to `services/web/src/static/`.

## Root cause — #127

The "Exclusion Zones" section lives inside a collapsed `<details>`, so when `initZoneEditor` runs in `requestAnimationFrame` the background image has 0×0 layout and `syncCanvasSize()` skips. The canvas keeps its HTML-default internal pixel space (300×150). Once the user expands the section and drags, the mouse coordinates from `getBoundingClientRect()` on the now-visible canvas (e.g. 0–800 px wide) fall outside the canvas's internal bounds, the dragged rectangle is drawn off-canvas, and stored zone fractions exceed [0,1].

**Fix:** attach a `toggle` listener on the parent `<details>` that re-syncs canvas dimensions and redraws zones when it transitions to open.

## Root cause — #126

`ChipPicker.api.refresh()` and `_removeIdx()` unconditionally call `_renderDropdown()`, which sets `display=""` whenever the registry has any matching items. Background events trigger `refresh()` automatically:

- `_loadClassesForModel(...).then(_refreshChipPickers)` — fires after the async class-list fetch resolves on initial page load.
- `_rebuildChannelRegistry()` via the `channels-list` `MutationObserver` — fires when channel cards are populated into the DOM during page bootstrap.

The dropdown pops open as a side effect of these background refreshes, before the user ever clicks the picker. Same issue when the user clicks the ✕ on a chip with the dropdown closed.

**Fix:** gate both call sites on `dropEl.style.display !== "none"` — only re-render the dropdown if it was already open. Background refreshes no longer pop it open; user-initiated focus/typing/selection flow is unchanged.

## Verification

- `ruff check` — all services pass
- `mypy` — web service passes
- `pytest services/web/tests/` — 213 passed
- JS syntax — both files parse with `node -c`

## Test plan

- [ ] Open Config → Cameras → expand a camera card → expand "Exclusion Zones" → drag on the snapshot. Confirm the dashed box draws while dragging and the red zone persists on release.
- [ ] Reload Config admin. Confirm no chip-picker dropdowns are open at page-load time on Notification Rules, Camera Class override, or Summary Reports channel.
- [ ] Click into one of the chip-picker inputs. Confirm dropdown opens. Pick an item. Confirm dropdown stays open (multi-value) or closes (singleValue) as before.
- [ ] Click ✕ on a chip while dropdown is closed. Confirm the dropdown stays closed.
- [ ] Click ✕ on a chip while dropdown is open. Confirm the dropdown stays open and re-renders.

## Notes for review

- Marked **Draft** so Scott can review before merge per the protective-workspace rule.
- No core detection logic, API, or architecture changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)