### PR TITLE
docs: add Charter section — codify workspace-author lane discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ Named after Scar (aka Kroger), a survivor fish badly injured by a heron who live
 
 A containerized wildlife detection and notification system. Watches RTSP camera feeds for target species (herons, ducks, raccoons) and sends real-time notifications (Discord, email, webhooks) enabling downstream response to protect a backyard koi pond. ScarGuard handles detection, notification, and physical deterrence (sprinklers, lights, sirens via Tuya Cloud API). Works with any RTSP camera and any Docker host with an NVIDIA GPU.
 
+## Charter
+
+This workspace is software. The "What this is" / product
+scope above is the charter. Software authors don't touch
+infrastructure outside their charter — even with credentials
+available. For work that needs out-of-charter access, use a
+sanctioned cross-system channel.
+
 ## Tech Stack (Reference Setup)
 
 - **Compute:** NVIDIA Jetson Orin Nano, JetPack 6.2.1 (L4T 36.4.7) — any NVIDIA GPU host works

--- a/services/web/src/static/chip-picker.js
+++ b/services/web/src/static/chip-picker.js
@@ -178,9 +178,12 @@ window.ChipPicker = (function() {
 
     function _removeIdx(idx) {
       if (idx < 0 || idx >= values.length) return;
+      var dropdownWasOpen = dropEl.style.display !== "none";
       values.splice(idx, 1);
       _renderChips();
-      _renderDropdown();
+      // Only re-render the dropdown if the user already had it open —
+      // clicking ✕ on a chip shouldn't pop a closed dropdown back open.
+      if (dropdownWasOpen) _renderDropdown();
       _emit();
     }
 
@@ -228,8 +231,12 @@ window.ChipPicker = (function() {
           var next = readValues();
           if (Array.isArray(next)) values = next.slice();
         }
+        var dropdownWasOpen = dropEl.style.display !== "none";
         _renderChips();
-        _renderDropdown();
+        // Background registry refreshes (async class-list fetch, channel
+        // mutation observer) shouldn't pop the dropdown open — only
+        // re-render if the user already had it open.
+        if (dropdownWasOpen) _renderDropdown();
       },
       getValues: function() { return values.slice(); },
       setValues: function(next) {

--- a/services/web/src/static/config.js
+++ b/services/web/src/static/config.js
@@ -913,6 +913,17 @@ function initZoneEditor(card, initialZones) {
     syncCanvasSize();
   }
 
+  // The Exclusion Zones section is wrapped in a collapsed <details>, so the
+  // bg image has 0×0 layout at init — without this re-sync, the canvas
+  // keeps its 300×150 HTML default and newly drawn zones land outside the
+  // internal pixel space.  Re-sync on every open.
+  const detailsEl = canvas.closest("details");
+  if (detailsEl) {
+    detailsEl.addEventListener("toggle", () => {
+      if (detailsEl.open) { syncCanvasSize(); drawZones(card); }
+    });
+  }
+
   drawZones(card);
 
   // Draw on mouse drag


### PR DESCRIPTION
Adds a Charter section to CLAUDE.md that codifies workspace-author lane discipline: software authors in this workspace do not touch infrastructure outside their charter even when credentials are available. Part of a parallel sweep across all Claude-enabled workspaces.