### PR TITLE
v1.14.4: training-export tuning + camera recovery notice

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -352,6 +352,69 @@ silently dropped.
 
 ---
 
+## v1.14.4 — training-data export tuning (planned)
+
+Organic items surfaced while preparing the first heron-tuned model
+training run (2026-04-29). All three are tweaks to the existing
+labeling/export flow — not new surface — so they fit a 1.14.x patch
+rather than a feature minor.
+
+1. **Export false positives as background samples.** Widen
+   `_EXPORTABLE_WHERE` in `services/web/src/db.py` to include
+   `feedback = 'false_positive'`. In `services/web/src/routes/training.py`
+   export loop, write the image but emit an empty `.txt` label file for
+   those rows. YOLO treats image-with-no-labels as the canonical
+   "background — no target here" signal; the training pipeline currently
+   drops these on the floor even though they're the highest-signal
+   background samples (the model thought it saw something and was
+   wrong). Enables third-party heron/duck/raccoon datasets to train
+   against actual pond/yard backgrounds without manual annotation.
+2. **Training dashboard groups by effective class.**
+   `db.get_feedback_stats` currently groups the per-class chart by the
+   model's `class_name`, so `wrong_class` corrections to "heron" / "duck"
+   / "raccoon" land under whatever the model originally guessed (person,
+   bird, etc.). Group by the same `_effective_class` rule the export
+   uses (corrected_class when feedback is `wrong_class`, else
+   class_name) so corrected labels actually appear in the dashboard, and
+   add a false-positive count column so background-sample volume is
+   visible alongside positive-class counts.
+3. **`training/README.md` updates.** Document the third-party dataset
+   merge workflow (drop `images/` + `labels/` into the extracted zip,
+   reconcile class indices in `data.yaml`); document that false
+   positives become background samples; document the corrected_class
+   bbox gotcha — the bbox stored on a `wrong_class` event is the model's
+   *original* detection, so the corrected label is only useful when the
+   model detected near the right place. UI affordance to redraw the
+   bbox while correcting class is the v1.15 follow-up below.
+
+Plus #131 (camera reconnect notice + flap suppression) bundled into
+the same patch — see GitHub.
+
+---
+
+## v1.15 — exclusion zone editor + label-correction tooling (planned)
+
+Feature work, not hardening — bumps the minor.
+
+1. **Polygon exclusion zones with edit affordance.** Replace the
+   rect-only zone tool with a polygon canvas tool, support editing
+   existing zones (currently delete-and-recreate), and migrate stored
+   rect zones into the polygon representation. Per-zone enable/disable
+   toggle and zone labels (so reports can say "suppressed by 'pump
+   area'") fold in naturally with the editor work. Inclusion zones
+   (the inverse — whitelist regions where detection is active) added
+   if nearly free once polygons exist. Closes #132.
+2. **Redraw bbox on feedback.** Organic follow-up to the v1.14.4
+   training-export tuning. When marking `wrong_class`, allow the user
+   to redraw the bbox so the corrected label is on the right pixels.
+   Currently the stored bbox is the model's original detection, which
+   limits training value when the model boxed the wrong object
+   entirely. Same canvas tooling as the polygon editor — natural
+   pairing, which is why this is bundled here rather than backported
+   to v1.14.x.
+
+---
+
 ## Future Ideas (Unprioritized)
 
 - Twilio SMS notifications — paid per-message, but works on any phone without an app

--- a/services/detector/src/camera_health.py
+++ b/services/detector/src/camera_health.py
@@ -17,10 +17,13 @@ class _CameraState:
     last_frame_at: float = 0.0  # monotonic timestamp of last successful frame
     last_failure_at: float = 0.0  # monotonic timestamp of last failure
     offline_since: float | None = None  # monotonic timestamp when camera went offline
+    online_since: float | None = None  # monotonic timestamp of most recent online transition
     reconnect_count: int = 0
     last_reconnect_start: float = 0.0
     last_reconnect_duration: float | None = None
-    alert_sent: bool = False  # True if offline alert already dispatched for this outage
+    alert_sent: bool = False  # offline alert dispatched for current continuous outage
+    outage_alerted: bool = False  # offline alert was sent during this outage cycle (cleared on recovery alert)
+    last_outage_duration: float | None = None  # captured at reconnect, used in the recovery alert payload
 
 
 class CameraHealthTracker:
@@ -47,16 +50,25 @@ class CameraHealthTracker:
             state.last_frame_at = now
             if state.offline_since is not None:
                 # Camera came back online
-                state.last_reconnect_duration = now - state.offline_since
+                duration = now - state.offline_since
+                state.last_reconnect_duration = duration
                 state.reconnect_count += 1
+                if state.outage_alerted:
+                    # Stash for the eventual recovery alert (only fired
+                    # after sustained uptime — see check_alerts).
+                    state.last_outage_duration = duration
+                state.offline_since = None
+                state.online_since = now
+                state.alert_sent = False
                 logger.info(
                     "[%s] Camera back online (was offline %.1fs, reconnect #%d)",
                     camera_name,
-                    state.last_reconnect_duration,
+                    duration,
                     state.reconnect_count,
                 )
-                state.offline_since = None
-                state.alert_sent = False
+            elif state.online_since is None:
+                # First-ever successful frame for this camera
+                state.online_since = now
 
     def record_failure(self, camera_name: str) -> None:
         """Record a failed frame read — camera may be going offline."""
@@ -68,12 +80,20 @@ class CameraHealthTracker:
                 # Only mark offline after debounce period with no frames
                 if state.last_frame_at == 0 or (now - state.last_frame_at) > self._debounce:
                     state.offline_since = now
+                    state.online_since = None
                     state.last_reconnect_start = now
 
     def check_alerts(self) -> list[dict]:
-        """Return alert events for cameras that have been offline beyond threshold.
+        """Return alert events for cameras whose state crossed an alerting threshold.
 
-        Each camera only generates one alert per outage (until it recovers).
+        Two alert types:
+          - ``camera_offline``: emitted once per continuous outage when the
+            camera has been offline >= ``alert_threshold_seconds``.
+          - ``camera_recovered``: emitted after the camera has been back
+            online >= ``alert_threshold_seconds`` *and* an offline alert was
+            sent during the prior outage. The sustained-uptime requirement
+            is the flap suppressor — a camera that reconnects briefly only
+            to fail again does not page the user with a "recovered" notice.
         """
         now = time.monotonic()
         alerts: list[dict] = []
@@ -85,6 +105,7 @@ class CameraHealthTracker:
                     and (now - state.offline_since) >= self._alert_threshold
                 ):
                     state.alert_sent = True
+                    state.outage_alerted = True
                     offline_secs = now - state.offline_since
                     alerts.append({
                         "type": "camera_offline",
@@ -96,6 +117,32 @@ class CameraHealthTracker:
                         "[%s] Camera offline alert — down for %.0fs",
                         name,
                         offline_secs,
+                    )
+
+            for name, state in self._cameras.items():
+                if (
+                    state.outage_alerted
+                    and state.offline_since is None
+                    and state.online_since is not None
+                    and (now - state.online_since) >= self._alert_threshold
+                ):
+                    outage_secs = state.last_outage_duration or 0.0
+                    online_secs = now - state.online_since
+                    alerts.append({
+                        "type": "camera_recovered",
+                        "camera_name": name,
+                        "offline_seconds": round(outage_secs, 1),
+                        "online_seconds": round(online_secs, 1),
+                        "reconnect_count": state.reconnect_count,
+                    })
+                    state.outage_alerted = False
+                    state.last_outage_duration = None
+                    logger.info(
+                        "[%s] Camera recovery alert — was down %.0fs, "
+                        "stable for %.0fs",
+                        name,
+                        outage_secs,
+                        online_secs,
                     )
         return alerts
 

--- a/services/detector/tests/test_camera_health.py
+++ b/services/detector/tests/test_camera_health.py
@@ -1,0 +1,164 @@
+"""Tests for CameraHealthTracker, focused on the v1.14.4 recovery alert
++ flap-suppression behaviour added for #131.
+"""
+
+import pytest
+from camera_health import CameraHealthTracker
+
+
+class FakeClock:
+    """Controllable replacement for time.monotonic() in tests."""
+
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    c = FakeClock()
+    monkeypatch.setattr("camera_health.time.monotonic", c)
+    return c
+
+
+def _alert_types(alerts: list[dict]) -> list[str]:
+    return [a["type"] for a in alerts]
+
+
+def test_clean_outage_emits_offline_then_recovery(clock):
+    """Camera offline >threshold fires offline alert. Stays online >threshold
+    after reconnect → recovery alert with both durations populated.
+    """
+    t = CameraHealthTracker(alert_threshold_seconds=10, debounce_seconds=2)
+
+    # t=0: first frame → online
+    t.record_frame("cam-a")
+    assert t.check_alerts() == []
+
+    # t=5: stream fails. Debounce (2s) is exceeded vs last_frame_at=0,
+    # so offline_since gets set immediately.
+    clock.advance(5)
+    t.record_failure("cam-a")
+
+    # t=20: 15s offline >= 10s threshold → offline alert
+    clock.advance(15)
+    alerts = t.check_alerts()
+    assert _alert_types(alerts) == ["camera_offline"]
+    assert alerts[0]["camera_name"] == "cam-a"
+    assert alerts[0]["offline_seconds"] == 15.0
+
+    # t=22: reconnect
+    clock.advance(2)
+    t.record_frame("cam-a")
+
+    # t=25: only 3s online, below threshold → no recovery alert yet
+    clock.advance(3)
+    assert t.check_alerts() == []
+
+    # t=33: 11s online >= 10s threshold → recovery alert
+    clock.advance(8)
+    alerts = t.check_alerts()
+    assert _alert_types(alerts) == ["camera_recovered"]
+    rec = alerts[0]
+    assert rec["camera_name"] == "cam-a"
+    assert rec["offline_seconds"] == 17.0  # 22 - 5
+    assert rec["online_seconds"] == 11.0  # 33 - 22
+    assert rec["reconnect_count"] == 1
+
+    # No duplicate recovery alert on subsequent checks
+    clock.advance(60)
+    assert t.check_alerts() == []
+
+
+def test_short_flap_below_threshold_emits_no_alerts(clock):
+    """A camera that bounces offline-then-online faster than the alert
+    threshold must NOT page the user with offline OR recovery alerts.
+    Flap suppression is the core promise of #131.
+    """
+    t = CameraHealthTracker(alert_threshold_seconds=10, debounce_seconds=2)
+
+    t.record_frame("cam-a")  # online at t=0
+
+    # Three short outages, each well below the 10s alert threshold
+    for _ in range(3):
+        clock.advance(5)
+        t.record_failure("cam-a")  # debounce satisfied → offline_since set
+        clock.advance(3)
+        t.record_frame("cam-a")  # back online quickly
+
+    # check_alerts at any point should produce nothing
+    assert t.check_alerts() == []
+    clock.advance(100)
+    assert t.check_alerts() == []
+
+
+def test_first_frame_startup_emits_no_alerts(clock):
+    """A camera that comes up cleanly at startup (never been offline) must
+    not produce a recovery alert just because it's been online a long time.
+    """
+    t = CameraHealthTracker(alert_threshold_seconds=10, debounce_seconds=2)
+
+    t.record_frame("cam-a")
+    clock.advance(60)  # well past threshold
+
+    assert t.check_alerts() == []
+
+
+def test_post_recovery_outage_cycles_cleanly(clock):
+    """After a full offline → recovery cycle, the next outage must produce
+    a fresh offline alert (not stuck in outage_alerted=True).
+    """
+    t = CameraHealthTracker(alert_threshold_seconds=10, debounce_seconds=2)
+
+    # First outage cycle
+    t.record_frame("cam-a")
+    clock.advance(5)
+    t.record_failure("cam-a")
+    clock.advance(15)
+    assert _alert_types(t.check_alerts()) == ["camera_offline"]
+
+    clock.advance(2)
+    t.record_frame("cam-a")  # reconnect
+    clock.advance(11)
+    assert _alert_types(t.check_alerts()) == ["camera_recovered"]
+
+    # Second outage cycle — must fire its own offline alert
+    clock.advance(5)
+    t.record_failure("cam-a")
+    clock.advance(15)
+    alerts = t.check_alerts()
+    assert _alert_types(alerts) == ["camera_offline"]
+    assert alerts[0]["reconnect_count"] == 1  # carries from prior cycle
+
+
+def test_brief_mid_outage_recovery_does_not_emit_premature_recovery(clock):
+    """Camera offline >threshold (offline alert fires) → reconnects briefly
+    (below stable-uptime threshold) → fails again. The brief reconnect
+    must NOT emit a recovery alert; the camera is still flapping.
+    """
+    t = CameraHealthTracker(alert_threshold_seconds=10, debounce_seconds=2)
+
+    t.record_frame("cam-a")
+    clock.advance(5)
+    t.record_failure("cam-a")
+    clock.advance(15)
+    assert _alert_types(t.check_alerts()) == ["camera_offline"]
+
+    # Brief 4s reconnect (below 10s threshold)
+    clock.advance(2)
+    t.record_frame("cam-a")
+    clock.advance(4)
+    assert t.check_alerts() == []  # no recovery yet — not stable
+
+    # Goes offline again before stability
+    t.record_failure("cam-a")
+    clock.advance(15)
+    # Per the design, this is treated as a new continuous outage and fires
+    # a fresh offline alert (alert_sent was reset on reconnect).
+    alerts = t.check_alerts()
+    assert _alert_types(alerts) == ["camera_offline"]

--- a/services/notifier/src/main.py
+++ b/services/notifier/src/main.py
@@ -278,19 +278,43 @@ def subscribe_loop(
 
                 # Health alerts get formatted as notification events
                 if message["channel"] == HEALTH_CHANNEL:
-                    alert_event = {
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
-                        "class_name": "camera_offline",
-                        "confidence": 1.0,
-                        "camera_name": event.get("camera_name", "unknown"),
-                        "snapshot_path": None,
-                    }
-                    logger.warning(
-                        "Camera health alert: %s offline for %ss",
-                        event.get("camera_name"),
-                        event.get("offline_seconds"),
-                    )
-                    dispatch(alert_event, notifiers, notifiers_lock, queue)
+                    alert_type = event.get("type")
+                    if alert_type == "camera_offline":
+                        alert_event = {
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "class_name": "camera_offline",
+                            "confidence": 1.0,
+                            "camera_name": event.get("camera_name", "unknown"),
+                            "snapshot_path": None,
+                        }
+                        logger.warning(
+                            "Camera health alert: %s offline for %ss",
+                            event.get("camera_name"),
+                            event.get("offline_seconds"),
+                        )
+                        dispatch(alert_event, notifiers, notifiers_lock, queue)
+                    elif alert_type == "camera_recovered":
+                        alert_event = {
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "class_name": "camera_recovered",
+                            "confidence": 1.0,
+                            "camera_name": event.get("camera_name", "unknown"),
+                            "snapshot_path": None,
+                            "offline_seconds": event.get("offline_seconds"),
+                            "online_seconds": event.get("online_seconds"),
+                            "reconnect_count": event.get("reconnect_count"),
+                        }
+                        logger.info(
+                            "Camera health alert: %s recovered (was offline %ss)",
+                            event.get("camera_name"),
+                            event.get("offline_seconds"),
+                        )
+                        dispatch(alert_event, notifiers, notifiers_lock, queue)
+                    else:
+                        logger.warning(
+                            "Unknown health alert type %r — dropping",
+                            alert_type,
+                        )
                     continue
 
                 # Inject base_url so notifiers can build feedback links

--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -231,13 +231,25 @@ def get_feedback_stats(
     clause = "WHERE " + " AND ".join(where)
 
     with _connect() as conn:
-        # Per-class feedback counts
+        # Per-class feedback counts.  Group by *effective* class so a
+        # wrong-class correction (e.g. model said 'person', user labelled
+        # 'heron') shows up under the corrected label, matching what the
+        # YOLO export will use as the training class.
         rows = conn.execute(
             f"""
-            SELECT class_name, feedback, COUNT(*) AS cnt
+            SELECT
+                CASE
+                    WHEN feedback = 'wrong_class'
+                         AND corrected_class IS NOT NULL
+                         AND corrected_class != ''
+                    THEN corrected_class
+                    ELSE class_name
+                END AS effective_class,
+                feedback,
+                COUNT(*) AS cnt
             FROM detection_events
             {clause} AND feedback IS NOT NULL
-            GROUP BY class_name, feedback
+            GROUP BY effective_class, feedback
             """,
             params,
         ).fetchall()
@@ -245,7 +257,7 @@ def get_feedback_stats(
         by_class: dict[str, dict[str, int]] = {}
         total_labeled = 0
         for r in rows:
-            cls = r["class_name"]
+            cls = r["effective_class"]
             fb = r["feedback"]
             cnt = r["cnt"]
             total_labeled += cnt
@@ -302,9 +314,12 @@ def count_pruneable_events() -> int:
 
 _EXPORTABLE_WHERE = (
     "camera_name != '_system'"
-    " AND feedback IN ('correct', 'wrong_class')"
-    " AND bbox IS NOT NULL"
+    " AND feedback IN ('correct', 'wrong_class', 'false_positive')"
     " AND snapshot_path IS NOT NULL"
+    " AND ("
+    "feedback = 'false_positive'"
+    " OR bbox IS NOT NULL"
+    ")"
 )
 
 

--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -312,6 +312,18 @@ def count_pruneable_events() -> int:
     return row[0]
 
 
+# Positives drive the dashboard "X exportable" count and the trainable
+# class definitions in data.yaml.
+_EXPORTABLE_POSITIVE_WHERE = (
+    "camera_name != '_system'"
+    " AND feedback IN ('correct', 'wrong_class')"
+    " AND bbox IS NOT NULL"
+    " AND snapshot_path IS NOT NULL"
+)
+
+# Exportable rows = positives + false positives (the latter ride along as
+# YOLO background samples — image + empty label file).  FPs without a
+# bbox are still valid backgrounds, so the bbox filter is positives-only.
 _EXPORTABLE_WHERE = (
     "camera_name != '_system'"
     " AND feedback IN ('correct', 'wrong_class', 'false_positive')"
@@ -327,8 +339,15 @@ def count_exportable_events(
     date_from: str | None = None,
     date_to: str | None = None,
 ) -> int:
-    """Count events eligible for YOLO dataset export."""
-    where = _EXPORTABLE_WHERE
+    """Count *positive* events that drive the trainable class definitions
+    in the export.  False positives ride along in the zip as background
+    samples (see ``get_exportable_events``) but they don't contribute a
+    class to data.yaml, so the dashboard "X exportable" headline counts
+    positives only.  Otherwise the UI would advertise an FP-only range as
+    exportable while the export endpoint correctly rejects that case as a
+    degenerate dataset.
+    """
+    where = _EXPORTABLE_POSITIVE_WHERE
     params: list[object] = []
     if date_from:
         where += " AND timestamp >= ?"

--- a/services/web/src/routes/training.py
+++ b/services/web/src/routes/training.py
@@ -49,25 +49,33 @@ async def training_dashboard(
     dto = date_to or None
     stats = db.get_feedback_stats(date_from=dfrom, date_to=dto)
 
-    # Build per-class data for the bar chart
+    # Build per-class data for the bar chart.  Training-positive count =
+    # correct + wrong_class (a wrong_class correction relabels the bbox to
+    # this effective class, so it's a training sample for it).  False
+    # positives are tracked separately — they become background samples in
+    # the export, not labeled instances.
     by_class = stats["by_class"]
-    max_correct = max(
-        (v["correct"] for v in by_class.values()), default=1
+    max_positive = max(
+        (v["correct"] + v["wrong_class"] for v in by_class.values()),
+        default=1,
     ) or 1
 
     class_chart: list[dict] = []
     for cls_name, counts in sorted(by_class.items()):
+        positive = counts["correct"] + counts["wrong_class"]
         class_chart.append({
             "name": cls_name.replace("_", " ").title(),
             "raw_name": cls_name,
             "correct": counts["correct"],
             "false_positive": counts["false_positive"],
             "wrong_class": counts["wrong_class"],
-            "bar_pct": (counts["correct"] / max_correct) * 100,
-            "low_data": counts["correct"] < 500,
+            "positive": positive,
+            "bar_pct": (positive / max_positive) * 100,
+            "low_data": positive < 500,
         })
 
-    # Count exportable events (correct or wrong_class with bbox)
+    # Count exportable events (correct + wrong_class with bbox + false_positive
+    # as background samples)
     exportable = db.count_exportable_events(date_from=dfrom, date_to=dto)
 
     return templates.TemplateResponse(
@@ -108,11 +116,14 @@ async def export_dataset(
             status_code=404,
         )
 
-    # Build class-to-index mapping from distinct labels
+    # Build class-to-index mapping from distinct labels.  Skip false
+    # positives — they become background samples (image with empty label
+    # file) and don't contribute a class to data.yaml.
     class_set: set[str] = set()
     for r in rows:
-        label = _effective_class(r)
-        class_set.add(label)
+        if r["feedback"] == "false_positive":
+            continue
+        class_set.add(_effective_class(r))
     class_names = sorted(class_set)
     class_to_idx = {name: idx for idx, name in enumerate(class_names)}
 
@@ -127,12 +138,10 @@ async def export_dataset(
             row = dict(r)
             event_id = row["id"]
             snapshot_path = row["snapshot_path"]
-            bbox = json.loads(row["bbox"]) if isinstance(row["bbox"], str) else row["bbox"]
-            frame_size = json.loads(row["frame_size"]) if isinstance(row["frame_size"], str) else row["frame_size"]
-            label = _effective_class(row)
-            class_idx = class_to_idx[label]
+            is_negative = row["feedback"] == "false_positive"
 
-            # Copy snapshot image
+            # Copy snapshot image (always — positives and negatives both
+            # need the pixels; only the label file differs)
             src_path = Path(snapshot_path)
             if not src_path.exists():
                 # Try in SNAPSHOT_DIR
@@ -144,7 +153,16 @@ async def export_dataset(
             img_name = f"{event_id}.jpg"
             zf.write(str(src_path), f"dataset/images/train/{img_name}")
 
-            # Write YOLO annotation
+            if is_negative:
+                # Background sample: empty label file is YOLO's canonical
+                # "no targets in this image" signal.
+                zf.writestr(f"dataset/labels/train/{event_id}.txt", "")
+                continue
+
+            # Positive (correct / wrong_class): emit YOLO bbox annotation
+            bbox = json.loads(row["bbox"]) if isinstance(row["bbox"], str) else row["bbox"]
+            frame_size = json.loads(row["frame_size"]) if isinstance(row["frame_size"], str) else row["frame_size"]
+            class_idx = class_to_idx[_effective_class(row)]
             x1, y1, x2, y2 = bbox
             fw, fh = frame_size
             x_center = ((x1 + x2) / 2) / fw

--- a/services/web/src/routes/training.py
+++ b/services/web/src/routes/training.py
@@ -127,6 +127,22 @@ async def export_dataset(
     class_names = sorted(class_set)
     class_to_idx = {name: idx for idx, name in enumerate(class_names)}
 
+    if not class_names:
+        # All matching rows are false positives.  A YOLO dataset with
+        # nc: 0 and only background images can't train anything; reject
+        # the export instead of returning a degenerate zip the user
+        # would only discover at training time.
+        return StreamingResponse(
+            iter([
+                b"No positive labels in the selected range. "
+                b"Exports require at least one Correct or Wrong-Class "
+                b"event with a bounding box; false positives alone are "
+                b"not a trainable dataset.",
+            ]),
+            media_type="text/plain",
+            status_code=404,
+        )
+
     # Stream a zip file
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:

--- a/services/web/src/templates/training.html
+++ b/services/web/src/templates/training.html
@@ -50,15 +50,15 @@
       {% if cls.low_data %}<span class="badge badge-warn" title="< 500 correct labels">&lt; 500</span>{% endif %}
     </div>
     <div class="class-chart-bars">
-      <div class="class-chart-bar bar-correct" style="width: {{ cls.bar_pct }}%" title="Correct: {{ cls.correct }}">
-        {{ cls.correct }}
+      <div class="class-chart-bar bar-correct" style="width: {{ cls.bar_pct }}%" title="Training samples: {{ cls.positive }} (correct {{ cls.correct }} + corrected-to {{ cls.wrong_class }})">
+        {{ cls.positive }}
       </div>
     </div>
     <div class="class-chart-meta">
-      <span class="muted">FP: {{ cls.false_positive }}</span>
       {% if cls.wrong_class > 0 %}
-      <span class="muted">WC: {{ cls.wrong_class }}</span>
+      <span class="muted" title="Wrong-class corrections relabelled to this class">WC: {{ cls.wrong_class }}</span>
       {% endif %}
+      <span class="muted" title="False positives — exported as background samples (empty labels)">FP/BG: {{ cls.false_positive }}</span>
     </div>
   </div>
   {% endfor %}
@@ -70,8 +70,8 @@
 <h2>Export</h2>
 
 {% if exportable > 0 %}
-<p>Export <strong>{{ exportable }}</strong> confirmed detections as a YOLO-format dataset (images + annotation .txt files + data.yaml).</p>
-<p class="hint">Only events with feedback (correct or wrong-class with corrected label) and stored bounding box data are included. Pre-migration events without bbox data are excluded.</p>
+<p>Export <strong>{{ exportable }}</strong> labelled detections as a YOLO-format dataset (images + annotation .txt files + data.yaml).</p>
+<p class="hint">Includes correct labels, wrong-class corrections (using the corrected label), and false positives as background samples (image with empty label file — YOLO's "no targets here" signal). Positive events without bbox data (pre-migration) are excluded.</p>
 <a href="/admin/training/export?date_from={{ filter_date_from | urlencode }}&amp;date_to={{ filter_date_to | urlencode }}"
    class="btn-export" download>
   Download Dataset (.zip)

--- a/training/README.md
+++ b/training/README.md
@@ -17,6 +17,37 @@ Fine-tune a YOLO model on detection data collected and labeled through ScarGuard
 4. **Evaluate** the trained model against stored snapshots using the Model Evaluation page
 5. **Promote** the model by copying the `.pt` file to your models directory and selecting it in config
 
+### How feedback maps to training data
+
+| Feedback | What lands in the export |
+|---|---|
+| **Correct** | Image + bbox label using the model's predicted class |
+| **Wrong Class** + corrected label | Image + bbox label using the *corrected* class. The bbox is the model's *original* detection — see the gotcha below. |
+| **False Positive** | Image + **empty** `.txt` label file. YOLO treats this as a background sample ("nothing of interest here") and learns what the *absence* of a target looks like in your specific environment. |
+
+### Gotcha: corrected_class bbox
+
+When you mark an event as **Wrong Class** and provide a corrected label
+(e.g. model said "person", you typed "heron"), the **bbox stored on
+that event is the model's original detection**, not a fresh box around
+the actual heron. So the corrected label is only useful when the model
+detected *near* the right place — i.e. it boxed something that overlaps
+the real target.
+
+For events where the model boxed the wrong thing entirely (heron in the
+upper-right of the frame, model boxed a person in the foreground), the
+corrected label points YOLO at the wrong pixels. Two ways to handle:
+
+- **Skip those events** when labelling — leave them unlabelled rather
+  than corrupting the training set with bad bboxes.
+- **Wait for v1.15** — a "redraw bbox" UI affordance is planned for
+  v1.15 (paired with the polygon zone editor — same canvas tooling) so
+  you can drop a fresh box on the actual target when correcting class.
+
+For the missing-detection case (heron in the frame, model didn't detect
+at all), no event = no training sample. Mix in a third-party heron
+dataset to fill that gap (see "Mixing third-party datasets" below).
+
 ## Usage
 
 ```bash
@@ -70,9 +101,46 @@ dataset/
 └── labels/
     └── train/
         ├── 123.txt    # YOLO annotation: class_id x_center y_center width height
-        ├── 456.txt
+        ├── 456.txt    # (empty file — false-positive event = background sample)
         └── ...
 ```
+
+Empty `.txt` files are intentional: false-positive feedback exports
+the snapshot with a zero-byte label file, which YOLO interprets as
+"no targets in this image." These act as negative / background
+samples during training.
+
+## Mixing third-party datasets
+
+The exported zip is a standard YOLO dataset, so you can extend it
+with public heron / duck / raccoon datasets to bulk up positive
+samples while keeping your captured snapshots as the source of
+*background* truth (what your pond and yard actually look like,
+without targets).
+
+Workflow:
+
+1. Extract the ScarGuard export: `unzip scarguard_dataset.zip -d my_dataset`
+2. Note its `dataset/data.yaml` — list of class names and their
+   indices (e.g. `names: ['heron', 'person', 'raccoon']`).
+3. For each third-party dataset, **renumber its label files** so the
+   class indices match your `data.yaml`. If a third-party heron
+   dataset uses class `0` for heron and your export uses class `0`
+   for heron, no change needed. If indices differ, run `sed` over
+   the `.txt` files: `sed -i 's/^0 /N /' labels/train/*.txt` where
+   `N` is the right index in your data.yaml.
+4. Copy the third-party `images/train/*` into your dataset's
+   `images/train/` and the renumbered `labels/train/*.txt` into
+   `labels/train/`. Filename collisions: rename third-party files
+   with a prefix (e.g. `coco-`, `oid-`) to avoid clashing with
+   ScarGuard's numeric event IDs.
+5. Add any third-party class names to `data.yaml` `names:` if you
+   added new ones. Update `nc:` to match `len(names)`.
+6. Train against the merged `data.yaml`.
+
+Result: model learns heron / duck / raccoon shape from the public
+datasets *plus* learns what's-not-a-target in your specific yard
+from your own false-positive captures.
 
 ## Jetson Orin Tips
 


### PR DESCRIPTION
## Summary

Four organic items for v1.14.4, surfaced while preparing the first
heron-tuned model training run on 2026-04-29. All four are tweaks
to existing flows — labelling/export and camera health — rather
than new surface, hence a 1.14.x patch instead of a feature minor.

## What's in here

**`e12b786` — `docs(roadmap)`**
Plans v1.14.4 (this PR) and v1.15 (polygon zone editor + bbox redraw).
Frames the four items as organic from the training-prep session, not
external GH-issue-driven (though #131 from this PR is here).

**`71025e2` — `feat(training)`: false-positive backgrounds + dashboard by effective class**
- `_EXPORTABLE_WHERE` widened to include `feedback='false_positive'`.
  The export loop emits an empty `.txt` label file for those rows —
  YOLO's canonical "no targets in this image" signal — turning false
  positives into the high-signal background samples the trainer needs
  to learn what *not* to flag in *this specific yard*.
- `db.get_feedback_stats` now `GROUP BY` an effective-class CASE
  expression (corrected_class when feedback='wrong_class' and
  non-empty, else class_name). Heron/duck/raccoon corrections now
  show up in the per-class chart instead of being buried under
  whatever the model originally guessed.
- Dashboard chart's `positive` count = correct + wrong_class drives
  bar width and the <500 low-data badge; FP shown separately tagged
  FP/BG to make its background-sample role explicit.
- `training/README.md` adds a feedback→export mapping table, the
  corrected_class bbox gotcha, and a step-by-step "Mixing third-party
  datasets" section.

**`d142d45` — `feat(notifier)`: camera_recovered alert + flap suppression (closes #131)**
Symmetric to the existing `camera_offline` alert. Recovery fires only
when:

1. An offline alert was actually sent during the prior outage cycle
   (`outage_alerted=True`). Cameras that bounced for less than
   `alert_threshold_seconds` never produced an offline alert and so
   never produce a recovery alert either — the user isn't paged about
   events they were never paged about.
2. The camera has been continuously online for at least
   `alert_threshold_seconds`. Brief reconnects during a flap don't
   emit a premature "recovered" notice.

This means no new config knob — flap suppression is structural. A user
who set `alert_threshold_minutes: 10` implicitly gets a 10-minute
sustained-uptime gate on the recovery notice too, mirroring the
offline gate.

**`a7e38f7` — `test(detector)`: 5 scenarios for the recovery state machine**
- Clean outage → offline alert → sustained reconnect → recovery alert
- Sub-threshold flapping → no alerts at all
- First-frame startup → no spurious recovery alert
- Post-recovery re-outage → fresh offline alert (clean cycle reset)
- Brief mid-outage reconnect → no premature recovery alert

`FakeClock` fixture monkeypatches `time.monotonic` so transitions are
deterministic without real waiting.

## Test plan

- [x] Ruff passes across all six service trees + `shared`
- [x] Mypy passes on `services/web` and `services/notifier` (detector
      excluded from CI per `CLAUDE.md` — torch/opencv not available
      outside L4T)
- [x] New unit tests pass (`pytest services/detector/tests/test_camera_health.py` — 5/5)
- [x] CONTRIBUTING.md self-review subagent run on each non-trivial
      commit; no blocking issues
- [ ] CI green (this PR)
- [ ] Manual: export a dataset on a system with at least one
      false-positive event, confirm the zip contains a `.txt` of size
      0 alongside its `.jpg`
- [ ] Manual: training dashboard shows wrong-class corrections
      grouped under their corrected label

## Notes for review

- **Pre-existing awkward verbiage.** Notifier channels render
  `class_name="camera_recovered"` as "Camera Recovered detected!"
  via the `class_name.replace('_', ' ').title() + " detected!"`
  pattern, mirroring today's "Camera Offline detected!". Did not
  refactor — out of scope, and would touch every notifier channel.
  Worth a separate ticket if you want camera_* events to render
  with their own template path.
- **No new config knobs.** Flap suppression reuses
  `alert_threshold_seconds`. If a user wants a different stable-uptime
  gate from their offline-alert threshold, that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)