### PR TITLE
fix(web): convert inline event handlers to addEventListener (CSP regression)

### DIFF
--- a/services/web/src/static/backups.js
+++ b/services/web/src/static/backups.js
@@ -62,3 +62,18 @@ function showBanner(msg, type) {
   banner.className = 'alert alert-' + type;
   banner.textContent = msg;
 }
+
+document.addEventListener('DOMContentLoaded', function() {
+  const createBtn = document.getElementById('create-btn');
+  if (createBtn) createBtn.addEventListener('click', createBackup);
+  const closeDiff = document.getElementById('close-diff-modal-btn');
+  if (closeDiff) closeDiff.addEventListener('click', function() {
+    document.getElementById('diff-modal').style.display = 'none';
+  });
+  document.querySelectorAll('button[data-action="show-diff"]').forEach(function(btn) {
+    btn.addEventListener('click', function() { showDiff(btn.dataset.backupName); });
+  });
+  document.querySelectorAll('button[data-action="restore-backup"]').forEach(function(btn) {
+    btn.addEventListener('click', function() { restoreBackup(btn.dataset.backupName); });
+  });
+});

--- a/services/web/src/static/config-tls.js
+++ b/services/web/src/static/config-tls.js
@@ -52,3 +52,13 @@ async function uploadCerts() {
   }
   btn.disabled = false;
 }
+
+(function wireTlsControls() {
+  var mode = document.getElementById('tls-mode');
+  if (mode) mode.addEventListener('change', toggleTlsFields);
+  document.querySelectorAll('.cert-tab-btn[data-cert-tab]').forEach(function(b) {
+    b.addEventListener('click', function() { switchCertTab(b.dataset.certTab, b); });
+  });
+  var upBtn = document.getElementById('cert-upload-btn');
+  if (upBtn) upBtn.addEventListener('click', uploadCerts);
+})();

--- a/services/web/src/static/config.js
+++ b/services/web/src/static/config.js
@@ -158,7 +158,7 @@ function _buildRuleRow(rule) {
         <label>Channels (comma-separated names)</label>
         <input type="text" class="rule-channels" value="${_esc((rule.channels || []).join(", "))}" placeholder="pond-alerts, email-digest">
       </div>
-      <button type="button" class="btn-remove" onclick="this.closest('.rule-row').remove()">✕</button>
+      <button type="button" class="btn-remove" data-action="remove-rule-row">✕</button>
     </div>
   `;
   return row;
@@ -224,7 +224,7 @@ function _buildDeterrentRuleRow(rule) {
         <label>Groups (comma-separated names from /admin/deterrent)</label>
         <input type="text" class="drule-groups" value="${_esc((rule.groups || []).join(", "))}" placeholder="minor, thermonuclear">
       </div>
-      <button type="button" class="btn-remove" onclick="this.closest('.rule-row').remove()">✕</button>
+      <button type="button" class="btn-remove" data-action="remove-rule-row">✕</button>
     </div>
   `;
   return row;
@@ -312,7 +312,7 @@ function buildCameraCard(cam) {
   div.innerHTML = `
     <div class="camera-card-header">
       <span class="camera-card-title">Camera</span>
-      <button type="button" class="btn-remove" onclick="removeCamera(this)">Remove</button>
+      <button type="button" class="btn-remove" data-action="remove-camera">Remove</button>
     </div>
     <label class="toggle-label">
       <input type="checkbox" class="cam-enabled" ${enabled ? "checked" : ""}>
@@ -385,7 +385,7 @@ function buildCameraCard(cam) {
           Use <code>*</code> as a wildcard class to match any detection. Leave empty to notify all channels.
         </p>
         <div class="notif-rules-list"></div>
-        <button type="button" class="btn-add" style="margin-top:0.4rem;" onclick="addNotificationRule(this.closest('.camera-card'))">+ Add Rule</button>
+        <button type="button" class="btn-add" style="margin-top:0.4rem;" data-action="add-notification-rule">+ Add Rule</button>
       </div>
     </details>
     <details class="expert-only" style="margin-top:0.75rem;">
@@ -399,7 +399,7 @@ function buildCameraCard(cam) {
           <a href="/admin/deterrent#groups">Deterrent page</a> first.
         </p>
         <div class="det-rules-list"></div>
-        <button type="button" class="btn-add" style="margin-top:0.4rem;" onclick="addDeterrentRule(this.closest('.camera-card'))">+ Add Rule</button>
+        <button type="button" class="btn-add" style="margin-top:0.4rem;" data-action="add-deterrent-rule">+ Add Rule</button>
       </div>
     </details>
   `;
@@ -785,8 +785,8 @@ function buildChannelCard(ch) {
     <div class="camera-card-header">
       <span class="camera-card-title">${type.charAt(0).toUpperCase() + type.slice(1)} Channel</span>
       <span>
-        <button type="button" class="btn-add" onclick="sendTestNotification(this)" style="margin-right:0.5rem;">Send Test</button>
-        <button type="button" class="btn-remove" onclick="removeChannel(this)">Remove</button>
+        <button type="button" class="btn-add" data-action="send-test-notification" style="margin-right:0.5rem;">Send Test</button>
+        <button type="button" class="btn-remove" data-action="remove-channel">Remove</button>
       </span>
     </div>
     <label class="toggle-label">
@@ -860,7 +860,60 @@ function readChannels() {
   }
   // Chip-picker wiring (v0.13.4) — run after DOM is populated.
   requestAnimationFrame(() => _wireGlobalChipPickers());
+  _wireConfigStaticControls();
+  _wireConfigDelegation();
 })();
+
+function _wireConfigStaticControls() {
+  // Collapsible section headers
+  document.querySelectorAll(".config-section-header[data-toggle-section]").forEach(h => {
+    h.addEventListener("click", () => toggleSection(h.dataset.toggleSection));
+  });
+  // Expert-mode toggle
+  const expert = document.getElementById("expert-mode-toggle");
+  if (expert) expert.addEventListener("change", () => toggleExpertMode(expert.checked));
+  // Solar schedule toggle
+  const solar = document.getElementById("sched-use-solar");
+  if (solar) solar.addEventListener("change", () => toggleSolar(solar.checked));
+  // Add Camera button
+  const addCamBtn = document.getElementById("add-camera-btn");
+  if (addCamBtn) addCamBtn.addEventListener("click", addCamera);
+  // Add Channel buttons (per type)
+  document.querySelectorAll("[data-add-channel]").forEach(btn => {
+    btn.addEventListener("click", () => addChannel(btn.dataset.addChannel));
+  });
+  // Save button
+  const saveBtn = document.getElementById("save-btn");
+  if (saveBtn) saveBtn.addEventListener("click", saveConfig);
+}
+
+function _wireConfigDelegation() {
+  // Delegated handler for buttons inside dynamically-rendered camera/channel
+  // cards.  Survives card rebuilds and avoids per-render rebinding.
+  document.addEventListener("click", (e) => {
+    const btn = e.target.closest("button[data-action]");
+    if (!btn) return;
+    const action = btn.dataset.action;
+    if (action === "remove-rule-row") {
+      const r = btn.closest(".rule-row");
+      if (r) r.remove();
+    } else if (action === "remove-camera") {
+      removeCamera(btn);
+    } else if (action === "add-notification-rule") {
+      const card = btn.closest(".camera-card");
+      if (card) addNotificationRule(card);
+    } else if (action === "add-deterrent-rule") {
+      const card = btn.closest(".camera-card");
+      if (card) addDeterrentRule(card);
+    } else if (action === "send-test-notification") {
+      sendTestNotification(btn);
+    } else if (action === "remove-channel") {
+      removeChannel(btn);
+    } else if (action === "delete-zone") {
+      deleteZone(btn, parseInt(btn.dataset.zoneIdx, 10));
+    }
+  });
+}
 
 function _wireGlobalChipPickers() {
   // Shadow-channel registry — seeded from the channels list, refreshed via
@@ -1258,7 +1311,7 @@ function updateZoneList(card) {
       <input type="text" placeholder="Label (optional)" value="${_esc(z.label || "")}"
              style="flex:1;min-width:0;">
       <button type="button" class="btn-remove" style="flex:0 0 auto;"
-              onclick="deleteZone(this,${i})">&#x2715;</button>
+              data-action="delete-zone" data-zone-idx="${i}">&#x2715;</button>
     `;
     const enableCb = row.querySelector("input[type=checkbox]");
     const typeSelect = row.querySelector("select");

--- a/services/web/src/static/dashboard.js
+++ b/services/web/src/static/dashboard.js
@@ -77,3 +77,23 @@ async function sendSnapshotToChannel() {
 function closeSnapshotModal() {
   document.getElementById('snapshot-modal').style.display = 'none';
 }
+
+(function wireDashboardButtons() {
+  var dismissBtn = document.getElementById('dismiss-training-nudge-btn');
+  if (dismissBtn) {
+    dismissBtn.addEventListener('click', function() {
+      var nudge = document.getElementById('training-nudge');
+      if (nudge) nudge.style.display = 'none';
+    });
+  }
+  var closeBtn = document.getElementById('close-snapshot-modal-btn');
+  if (closeBtn) closeBtn.addEventListener('click', closeSnapshotModal);
+  var sendBtn = document.getElementById('snapshot-send-btn');
+  if (sendBtn) sendBtn.addEventListener('click', sendSnapshotToChannel);
+  // Per-camera Snapshot buttons (delegation on the table)
+  document.querySelectorAll('button[data-action="grab-snapshot"]').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      grabSnapshot(btn.dataset.cameraName);
+    });
+  });
+})();

--- a/services/web/src/static/db_backups.js
+++ b/services/web/src/static/db_backups.js
@@ -106,6 +106,17 @@ document.addEventListener('DOMContentLoaded', function() {
       if (e.key === 'Enter') { e.preventDefault(); submitReauth(); }
     });
   }
+  var triggerBtn = document.getElementById('trigger-btn');
+  if (triggerBtn) triggerBtn.addEventListener('click', triggerBackup);
+  var cancelBtn = document.getElementById('reauth-cancel-btn');
+  if (cancelBtn) cancelBtn.addEventListener('click', closeReauthModal);
+  var submitBtn = document.getElementById('reauth-submit');
+  if (submitBtn) submitBtn.addEventListener('click', submitReauth);
+  document.querySelectorAll('button[data-action="download-auth-backup"]').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      downloadAuthBackup(btn.dataset.db, btn.dataset.filename);
+    });
+  });
 });
 
 /* ── Live backup status (SSE) ────────────────────────────────────────────── */

--- a/services/web/src/static/deterrent.js
+++ b/services/web/src/static/deterrent.js
@@ -49,8 +49,8 @@ function renderDevices() {
           }).join('') +
         '</select></td>' +
         '<td style="padding:0.4rem 0.5rem;text-align:center;"><input type="checkbox" data-idx="' + i + '" data-field="enabled"' + (dev.enabled !== false ? ' checked' : '') + '></td>' +
-        '<td style="padding:0.4rem 0.5rem;"><button type="button" class="btn-secondary" style="font-size:0.75rem;padding:0.2em 0.6em;" onclick="testFire(\'' + esc(dev.device_id) + '\', this)" title="Test-fire for 3 seconds">Fire</button></td>' +
-        '<td style="padding:0.4rem 0.5rem;"><button type="button" class="btn-danger-sm" onclick="removeDevice(' + i + ')" title="Remove">x</button></td>';
+        '<td style="padding:0.4rem 0.5rem;"><button type="button" class="btn-secondary" data-action="test-fire" data-device-id="' + esc(dev.device_id) + '" style="font-size:0.75rem;padding:0.2em 0.6em;" title="Test-fire for 3 seconds">Fire</button></td>' +
+        '<td style="padding:0.4rem 0.5rem;"><button type="button" class="btn-danger-sm" data-action="remove-device" data-idx="' + i + '" title="Remove">x</button></td>';
     }
     tbody.appendChild(tr);
   });
@@ -216,6 +216,32 @@ renderDevices();
     }
     renderGroups();
   });
+  // Delegation for per-row action buttons (survives renderDevices() re-renders).
+  tbody.addEventListener('click', function(e) {
+    var btn = e.target.closest('button[data-action]');
+    if (!btn) return;
+    if (btn.dataset.action === 'test-fire') {
+      testFire(btn.dataset.deviceId, btn);
+    } else if (btn.dataset.action === 'remove-device') {
+      removeDevice(parseInt(btn.dataset.idx, 10));
+    }
+  });
+})();
+
+// ── Static button bindings ───────────────────────────────────────────────
+(function wireStaticButtons() {
+  var statusBtn = document.getElementById('status-btn');
+  if (statusBtn) statusBtn.addEventListener('click', checkDeviceStatus);
+  var forceOffBtn = document.getElementById('force-off-btn');
+  if (forceOffBtn) forceOffBtn.addEventListener('click', forceOffAll);
+  var addDevBtn = document.getElementById('add-device-btn');
+  if (addDevBtn) addDevBtn.addEventListener('click', addDevice);
+  var addGrpBtn = document.getElementById('add-group-btn');
+  if (addGrpBtn) addGrpBtn.addEventListener('click', addGroup);
+  var refreshLatBtn = document.getElementById('refresh-latency-btn');
+  if (refreshLatBtn) refreshLatBtn.addEventListener('click', refreshLatency);
+  var saveBtn = document.getElementById('save-deterrent-btn');
+  if (saveBtn) saveBtn.addEventListener('click', saveDeterrent);
 })();
 
 // ── Groups editor ────────────────────────────────────────────────────────

--- a/services/web/src/static/events.js
+++ b/services/web/src/static/events.js
@@ -2,6 +2,26 @@ var SCARGUARD_TARGET_CLASSES = JSON.parse(
   document.getElementById('events-page-data').textContent
 );
 
+// Delegated handlers for in-row feedback controls (event_rows.html partial,
+// which is swapped in by HTMX so per-element listeners would be lost).
+document.addEventListener('click', function(e) {
+  var btn = e.target.closest('button[data-action]');
+  if (!btn) return;
+  if (btn.dataset.action === 'show-feedback-form') {
+    var td = btn.closest('td');
+    if (!td) return;
+    var form = td.querySelector('.feedback-form');
+    if (form) form.style.display = 'block';
+    btn.style.display = 'none';
+    if (btn.previousElementSibling) btn.previousElementSibling.style.display = 'none';
+  } else if (btn.dataset.action === 'show-wrong-class-picker') {
+    var fb = btn.closest('.feedback-form');
+    if (!fb) return;
+    var picker = fb.querySelector('.wrong-class-picker');
+    if (picker) picker.style.display = 'block';
+  }
+});
+
 document.addEventListener('click', function(e) {
   var link = e.target.closest('.snapshot-link');
   if (!link) return;

--- a/services/web/src/static/logs.js
+++ b/services/web/src/static/logs.js
@@ -145,5 +145,22 @@ function setStatus(msg, style) {
   el.className = "log-status-text " + (style || "");
 }
 
+// ── Control wiring ──────────────────────────────────────────────────────────
+(function wireLogControls() {
+  document.querySelectorAll(".log-svc-btn[data-service]").forEach(btn => {
+    btn.addEventListener("click", () => selectService(btn.dataset.service, btn));
+  });
+  const level = document.getElementById("level-filter");
+  if (level) level.addEventListener("change", applyFilter);
+  const tail = document.getElementById("tail-lines");
+  if (tail) tail.addEventListener("change", reconnect);
+  const autoscroll = document.getElementById("autoscroll-toggle");
+  if (autoscroll) autoscroll.addEventListener("change", onAutoScrollChange);
+  const pauseBtn = document.getElementById("pause-btn");
+  if (pauseBtn) pauseBtn.addEventListener("click", togglePause);
+  const clearBtn = document.getElementById("clear-log-btn");
+  if (clearBtn) clearBtn.addEventListener("click", clearLog);
+})();
+
 // Start streaming the first service on page load
 startStream();

--- a/services/web/src/static/stats.js
+++ b/services/web/src/static/stats.js
@@ -467,4 +467,8 @@ function renderHistCharts(data) {
   }
 }
 
+document.querySelectorAll('.range-btn[data-range]').forEach(btn => {
+  btn.addEventListener('click', () => loadHistory(btn.dataset.range, btn));
+});
+
 loadHistory('1h', document.querySelector('.range-btn[data-range="1h"]'));

--- a/services/web/src/static/users.js
+++ b/services/web/src/static/users.js
@@ -1,0 +1,18 @@
+/* ScarGuard — users page logic */
+
+document.addEventListener('DOMContentLoaded', function() {
+  // Auto-submit role <select> on change.
+  document.querySelectorAll('select[data-action="submit-on-change"]').forEach(function(el) {
+    el.addEventListener('change', function() {
+      if (el.form) el.form.submit();
+    });
+  });
+  // Forms that require a confirm() before submitting.
+  document.querySelectorAll('form[data-confirm]').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+      if (!window.confirm(form.dataset.confirm)) {
+        e.preventDefault();
+      }
+    });
+  });
+});

--- a/services/web/src/templates/backups.html
+++ b/services/web/src/templates/backups.html
@@ -5,7 +5,7 @@
 <p class="hint">Automatic backups are created when the config file changes. You can also create manual backups and restore previous versions.</p>
 
 <div style="margin-bottom:1rem;">
-  <button onclick="createBackup()" id="create-btn">Create Backup Now</button>
+  <button type="button" id="create-btn">Create Backup Now</button>
 </div>
 
 <div id="backup-banner" style="display:none;" class="alert"></div>
@@ -19,8 +19,8 @@
     <td>{{ "%.1f"|format(b.size_bytes / 1024) }} KB</td>
     <td>{{ b.created }}</td>
     <td>
-      <button onclick="showDiff('{{ b.name }}')" class="btn-sm">Diff</button>
-      <button onclick="restoreBackup('{{ b.name }}')" class="btn-sm btn-danger">Restore</button>
+      <button type="button" data-action="show-diff" data-backup-name="{{ b.name }}" class="btn-sm">Diff</button>
+      <button type="button" data-action="restore-backup" data-backup-name="{{ b.name }}" class="btn-sm btn-danger">Restore</button>
     </td>
   </tr>
   {% endfor %}
@@ -33,7 +33,7 @@
 <div id="diff-modal" style="display:none;margin-top:1rem;">
   <h3>Diff: <span id="diff-name"></span></h3>
   <pre id="diff-content" style="background:var(--bg);padding:1rem;border-radius:4px;overflow-x:auto;font-size:0.85rem;max-height:500px;overflow-y:auto;border:1px solid var(--border);"></pre>
-  <button onclick="document.getElementById('diff-modal').style.display='none'">Close</button>
+  <button type="button" id="close-diff-modal-btn">Close</button>
 </div>
 
 <style>

--- a/services/web/src/templates/config.html
+++ b/services/web/src/templates/config.html
@@ -26,7 +26,7 @@
 
   <div class="mode-toggle" style="display:flex;gap:1.5rem;align-items:center;flex-wrap:wrap;">
     <label class="toggle-label">
-      <input type="checkbox" id="expert-mode-toggle" onchange="toggleExpertMode(this.checked)">
+      <input type="checkbox" id="expert-mode-toggle">
       <span class="toggle-track"></span>
       Expert mode
     </label>
@@ -46,7 +46,7 @@
 
   {# ── System ───────────────────────────────────────────────────────────────── #}
   <div class="config-section" id="section-system" data-subtab="system">
-    <div class="config-section-header" onclick="toggleSection('section-system')">
+    <div class="config-section-header" data-toggle-section="section-system">
       <span class="config-section-label">System</span>
       <span class="config-section-chevron">▾</span>
     </div>
@@ -137,7 +137,7 @@
 
   {# ── Summary Reports ──────────────────────────────────────────────────────── #}
   <div class="config-section expert-only" id="section-summary-report" data-subtab="system">
-    <div class="config-section-header" onclick="toggleSection('section-summary-report')">
+    <div class="config-section-header" data-toggle-section="section-summary-report">
       <span class="config-section-label">Summary Reports</span>
       <span class="config-section-chevron">▾</span>
     </div>
@@ -179,7 +179,7 @@
 
   {# ── Cameras ──────────────────────────────────────────────────────────────── #}
   <div class="config-section" id="section-cameras" data-subtab="cameras">
-    <div class="config-section-header" onclick="toggleSection('section-cameras')">
+    <div class="config-section-header" data-toggle-section="section-cameras">
       <span class="config-section-label">Cameras</span>
       <span class="config-section-chevron">▾</span>
     </div>
@@ -194,7 +194,7 @@
         <script type="application/json" id="config-page-data">{"availableModels": {{ available_models | tojson }}, "readOnly": {{ read_only|default(false)|tojson }}}</script>
         <div id="cameras-list"></div>
         {% if not read_only %}
-        <button type="button" class="btn-add" onclick="addCamera()">+ Add Camera</button>
+        <button type="button" class="btn-add" id="add-camera-btn">+ Add Camera</button>
         {% endif %}
       </div>
     </div>
@@ -202,7 +202,7 @@
 
   {# ── Detection ────────────────────────────────────────────────────────────── #}
   <div class="config-section" id="section-detection" data-subtab="detection">
-    <div class="config-section-header" onclick="toggleSection('section-detection')">
+    <div class="config-section-header" data-toggle-section="section-detection">
       <span class="config-section-label">Detection</span>
       <span class="config-section-chevron">▾</span>
     </div>
@@ -252,7 +252,7 @@
 
   {# ── Notification Channels (named, multi-instance) ───────────────────────── #}
   <div class="config-section" id="section-channels" data-subtab="notifications">
-    <div class="config-section-header" onclick="toggleSection('section-channels')">
+    <div class="config-section-header" data-toggle-section="section-channels">
       <span class="config-section-label">Notification Channels</span>
       <span class="config-section-chevron">▾</span>
     </div>
@@ -266,10 +266,10 @@
         <script id="channels-data" type="application/json">{{ channels_json | safe }}</script>
         <div id="channels-list"></div>
         <div style="margin-top:0.5rem;display:flex;gap:0.5rem;flex-wrap:wrap;">
-          <button type="button" class="btn-add" onclick="addChannel('discord')">+ Discord</button>
-          <button type="button" class="btn-add" onclick="addChannel('email')">+ Email</button>
-          <button type="button" class="btn-add" onclick="addChannel('webhook')">+ Webhook</button>
-          <button type="button" class="btn-add" onclick="addChannel('ntfy')">+ Ntfy</button>
+          <button type="button" class="btn-add" data-add-channel="discord">+ Discord</button>
+          <button type="button" class="btn-add" data-add-channel="email">+ Email</button>
+          <button type="button" class="btn-add" data-add-channel="webhook">+ Webhook</button>
+          <button type="button" class="btn-add" data-add-channel="ntfy">+ Ntfy</button>
         </div>
       </div>
     </div>
@@ -277,7 +277,7 @@
 
   {# ── Schedule ─────────────────────────────────────────────────────────────── #}
   <div class="config-section expert-only" id="section-schedule" data-subtab="advanced">
-    <div class="config-section-header" onclick="toggleSection('section-schedule')">
+    <div class="config-section-header" data-toggle-section="section-schedule">
       <span class="config-section-label">Schedule (Auto Arm/Disarm)</span>
       <span class="config-section-chevron">▾</span>
     </div>
@@ -311,8 +311,7 @@
         <div class="field-group">
           <label class="toggle-label">
             <input type="checkbox" id="sched-use-solar"
-                   {% if cfg.system.schedule.use_solar %}checked{% endif %}
-                   onchange="toggleSolar(this.checked)">
+                   {% if cfg.system.schedule.use_solar %}checked{% endif %}>
             <span class="toggle-track"></span>
             Use sunrise/sunset instead of fixed times
           </label>
@@ -337,7 +336,7 @@
 
   {# ── Auth ─────────────────────────────────────────────────────────────── #}
   <div class="config-section expert-only" id="section-auth" data-subtab="advanced">
-    <div class="config-section-header" onclick="toggleSection('section-auth')">
+    <div class="config-section-header" data-toggle-section="section-auth">
       <span class="config-section-label">Authentication</span>
       <span class="config-section-chevron">▾</span>
     </div>
@@ -394,7 +393,7 @@
 
   {# ── TLS ────────────────────────────────────────────────────────────────── #}
   <div class="config-section" id="section-deterrent" data-subtab="advanced">
-    <div class="config-section-header" onclick="toggleSection('section-deterrent')">
+    <div class="config-section-header" data-toggle-section="section-deterrent">
       <span class="config-section-label">Deterrent</span>
       <span class="config-section-chevron">▾</span>
     </div>
@@ -416,7 +415,7 @@
   </div>
 
   <div class="config-section expert-only" id="section-tls" data-subtab="advanced">
-    <div class="config-section-header" onclick="toggleSection('section-tls')">
+    <div class="config-section-header" data-toggle-section="section-tls">
       <span class="config-section-label">TLS</span>
       <span class="config-section-chevron">▾</span>
     </div>
@@ -428,7 +427,7 @@
         </p>
         <div class="field-group">
           <label>TLS Mode</label>
-          <select id="tls-mode" onchange="toggleTlsFields()">
+          <select id="tls-mode">
             <option value="off" {% if cfg.tls.mode == 'off' %}selected{% endif %}>Off (HTTP only &mdash; LAN use)</option>
             <option value="auto" {% if cfg.tls.mode == 'auto' %}selected{% endif %}>Automatic (Let's Encrypt)</option>
             <option value="manual" {% if cfg.tls.mode == 'manual' %}selected{% endif %}>Manual (own certificates)</option>
@@ -460,8 +459,8 @@
             Upload PEM files or paste their contents below. Files are written to <code>/config/certs/</code>.
           </p>
           <div class="cert-upload-tabs" style="display:flex;gap:0.5rem;margin-bottom:0.5rem;">
-            <button type="button" class="btn-secondary cert-tab-btn active" onclick="switchCertTab('upload',this)">Upload files</button>
-            <button type="button" class="btn-secondary cert-tab-btn" onclick="switchCertTab('paste',this)">Paste PEM</button>
+            <button type="button" class="btn-secondary cert-tab-btn active" data-cert-tab="upload">Upload files</button>
+            <button type="button" class="btn-secondary cert-tab-btn" data-cert-tab="paste">Paste PEM</button>
           </div>
           <div id="cert-tab-upload">
             <div class="field-row">
@@ -485,7 +484,7 @@
               <textarea id="tls-key-pem" rows="4" placeholder="-----BEGIN PRIVATE KEY-----&#10;...&#10;-----END PRIVATE KEY-----" style="font-family:var(--mono);font-size:0.8rem;"></textarea>
             </div>
           </div>
-          <button type="button" class="btn-secondary" onclick="uploadCerts()" style="margin-top:0.5rem;" id="cert-upload-btn">Upload certificates</button>
+          <button type="button" class="btn-secondary" style="margin-top:0.5rem;" id="cert-upload-btn">Upload certificates</button>
           <span id="cert-upload-status" class="hint" style="margin-left:0.5rem;"></span>
         </div>
       </div>
@@ -494,7 +493,7 @@
   <script src="/static/config-tls.js"></script>
 
   {% if not read_only %}
-  <button id="save-btn" type="button" onclick="saveConfig()">Save</button>
+  <button id="save-btn" type="button">Save</button>
   {% endif %}
 
 </div>{# /tab-settings #}

--- a/services/web/src/templates/dashboard.html
+++ b/services/web/src/templates/dashboard.html
@@ -12,7 +12,7 @@
     </div>
     <div style="display:flex;gap:0.5rem;align-items:center;">
       <a href="/admin/training" style="font-size:0.85rem;">View Training Data</a>
-      <button onclick="this.closest('#training-nudge').style.display='none'" style="background:none;border:none;color:var(--muted);cursor:pointer;font-size:1.2rem;" title="Dismiss">&#10005;</button>
+      <button type="button" id="dismiss-training-nudge-btn" style="background:none;border:none;color:var(--muted);cursor:pointer;font-size:1.2rem;" title="Dismiss">&#10005;</button>
     </div>
   </div>
   {% if training_nudge.by_class %}
@@ -70,7 +70,7 @@
         {{ camera_health.get(cam.name, {}).get('state', 'unknown') }}
       </td>
       <td>
-        <button class="btn-snapshot" onclick="grabSnapshot('{{ cam.name }}')" title="Grab live snapshot">Snapshot</button>
+        <button type="button" class="btn-snapshot" data-action="grab-snapshot" data-camera-name="{{ cam.name }}" title="Grab live snapshot">Snapshot</button>
       </td>
     </tr>
     {% endfor %}
@@ -82,7 +82,7 @@
 <!-- Snapshot modal -->
 <div id="snapshot-modal" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.7);z-index:1000;align-items:center;justify-content:center;">
   <div style="background:var(--card-bg, #1a1a2e);padding:1.5rem;border-radius:8px;max-width:60%;max-height:80%;overflow:auto;position:relative;">
-    <button onclick="closeSnapshotModal()" style="position:absolute;top:0.5rem;right:0.5rem;background:none;border:none;color:var(--fg);font-size:1.5rem;cursor:pointer;">&times;</button>
+    <button type="button" id="close-snapshot-modal-btn" style="position:absolute;top:0.5rem;right:0.5rem;background:none;border:none;color:var(--fg);font-size:1.5rem;cursor:pointer;">&times;</button>
     <h3 id="snapshot-title" style="margin-top:0;">Snapshot</h3>
     <div id="snapshot-status" class="hint">Requesting snapshot...</div>
     <img id="snapshot-img" style="display:none;max-width:100%;border-radius:4px;margin-top:0.5rem;">
@@ -95,7 +95,7 @@
           <option value="{{ ch }}">{{ ch }}</option>
           {% endfor %}
         </select>
-        <button class="btn-snapshot" onclick="sendSnapshotToChannel()" id="snapshot-send-btn" style="border-color:var(--accent);color:var(--accent);">Send</button>
+        <button type="button" class="btn-snapshot" id="snapshot-send-btn" style="border-color:var(--accent);color:var(--accent);">Send</button>
       </div>
       <span id="snapshot-send-status" class="hint" style="font-size:0.75rem;"></span>
     </div>

--- a/services/web/src/templates/db_backups.html
+++ b/services/web/src/templates/db_backups.html
@@ -21,7 +21,7 @@
       <div class="about-value">{{ total_size_human }}</div>
     </div>
   </div>
-  <button id="trigger-btn" class="btn-primary" onclick="triggerBackup()">
+  <button id="trigger-btn" type="button" class="btn-primary">
     Run Backup Now
   </button>
   <span id="trigger-status" class="muted" style="display:none;margin-left:0.5rem;"></span>
@@ -50,8 +50,9 @@
       <td style="padding:0.4rem 0.5rem;">{{ b.mtime_iso[:19] }}Z</td>
       <td style="padding:0.4rem 0.5rem;">
         {% if b.db == "auth" %}
-        <button class="btn-secondary" style="font-size:0.8rem;padding:0.2em 0.6em;"
-                onclick="downloadAuthBackup('{{ b.db }}', '{{ b.filename }}')">Download</button>
+        <button type="button" class="btn-secondary" style="font-size:0.8rem;padding:0.2em 0.6em;"
+                data-action="download-auth-backup"
+                data-db="{{ b.db }}" data-filename="{{ b.filename }}">Download</button>
         {% else %}
         <a href="/admin/db-backups/download/{{ b.db }}/{{ b.filename }}"
            class="btn-secondary" style="font-size:0.8rem;padding:0.2em 0.6em;"
@@ -82,8 +83,8 @@
     <label for="reauth-password">Password</label>
     <input type="password" id="reauth-password" style="width:100%;margin-bottom:1rem;" autocomplete="current-password">
     <div style="display:flex;gap:0.5rem;justify-content:flex-end;">
-      <button class="btn-secondary" onclick="closeReauthModal()">Cancel</button>
-      <button id="reauth-submit" class="btn-primary" onclick="submitReauth()">Download</button>
+      <button type="button" class="btn-secondary" id="reauth-cancel-btn">Cancel</button>
+      <button type="button" id="reauth-submit" class="btn-primary">Download</button>
     </div>
   </div>
 </div>

--- a/services/web/src/templates/deterrent.html
+++ b/services/web/src/templates/deterrent.html
@@ -52,12 +52,11 @@
   <p class="hint">
     Live device status from the Tuya Cloud API. Click to query all devices.
   </p>
-  <button type="button" id="status-btn" class="btn-secondary" onclick="checkDeviceStatus()">Check Status</button>
+  <button type="button" id="status-btn" class="btn-secondary">Check Status</button>
   <span id="status-spinner" class="muted" style="display:none;margin-left:0.5rem;">Querying devices...</span>
   {% if not read_only %}
   <button type="button" id="force-off-btn"
-          style="margin-left:1rem;background:var(--danger);color:white;border:none;padding:0.4em 0.9em;border-radius:4px;cursor:pointer;"
-          onclick="forceOffAll()">⚠ Emergency Off</button>
+          style="margin-left:1rem;background:var(--danger);color:white;border:none;padding:0.4em 0.9em;border-radius:4px;cursor:pointer;">⚠ Emergency Off</button>
   <span id="force-off-status" class="muted" style="display:none;margin-left:0.5rem;"></span>
   {% endif %}
   <div id="status-panel" style="margin-top:0.75rem;"></div>
@@ -97,7 +96,7 @@
   </table>
 
   {% if not read_only %}
-  <button type="button" class="btn-secondary" onclick="addDevice()" style="margin-top:0.75rem;">
+  <button type="button" id="add-device-btn" class="btn-secondary" style="margin-top:0.75rem;">
     + Add device
   </button>
   {% endif %}
@@ -116,7 +115,7 @@
   </p>
   <div id="groups-list"></div>
   {% if not read_only %}
-  <button type="button" class="btn-secondary" onclick="addGroup()" style="margin-top:0.75rem;">
+  <button type="button" id="add-group-btn" class="btn-secondary" style="margin-top:0.75rem;">
     + Add group
   </button>
   {% endif %}
@@ -233,7 +232,7 @@
     device deep-sleep latency.  See the
     <a href="/deterrent-log">deterrent log</a> for per-event timing.
   </p>
-  <button type="button" class="btn-secondary" onclick="refreshLatency()">Refresh</button>
+  <button type="button" id="refresh-latency-btn" class="btn-secondary">Refresh</button>
   <table id="latency-table" style="width:100%;border-collapse:collapse;font-size:0.9rem;margin-top:0.75rem;">
     <thead>
       <tr style="text-align:left;border-bottom:2px solid var(--border);">
@@ -251,7 +250,7 @@
 </div>{# /latency tab #}
 
 {% if not read_only %}
-<button type="button" id="save-deterrent-btn" onclick="saveDeterrent()">Save</button>
+<button type="button" id="save-deterrent-btn">Save</button>
 {% endif %}
 
 <script type="application/json" id="devices-data">{{ devices_json|safe }}</script>

--- a/services/web/src/templates/logs.html
+++ b/services/web/src/templates/logs.html
@@ -11,7 +11,7 @@
     <div class="log-svc-btns">
       {% for svc in services %}
       <button class="log-svc-btn {% if loop.first %}active{% endif %}"
-              data-service="{{ svc }}" onclick="selectService('{{ svc }}', this)">
+              data-service="{{ svc }}">
         {{ svc }}
       </button>
       {% endfor %}
@@ -20,7 +20,7 @@
 
   <div class="log-toolbar-group">
     <label for="level-filter">Level</label>
-    <select id="level-filter" onchange="applyFilter()">
+    <select id="level-filter">
       <option value="all">All</option>
       <option value="debug">Debug+</option>
       <option value="info">Info+</option>
@@ -31,7 +31,7 @@
 
   <div class="log-toolbar-group">
     <label for="tail-lines">Tail</label>
-    <select id="tail-lines" onchange="reconnect()">
+    <select id="tail-lines">
       <option value="200">200 lines</option>
       <option value="500" selected>500 lines</option>
       <option value="1000">1000 lines</option>
@@ -41,12 +41,12 @@
 
   <div class="log-toolbar-right">
     <label class="toggle-label" title="Scroll to bottom as new lines arrive">
-      <input type="checkbox" id="autoscroll-toggle" checked onchange="onAutoScrollChange()">
+      <input type="checkbox" id="autoscroll-toggle" checked>
       <span class="toggle-track"></span>
       Auto-scroll
     </label>
-    <button class="btn-secondary" id="pause-btn" onclick="togglePause()">Pause</button>
-    <button class="btn-secondary" onclick="clearLog()">Clear</button>
+    <button class="btn-secondary" id="pause-btn">Pause</button>
+    <button class="btn-secondary" id="clear-log-btn">Clear</button>
   </div>
 
 </div>

--- a/services/web/src/templates/partials/event_rows.html
+++ b/services/web/src/templates/partials/event_rows.html
@@ -30,16 +30,13 @@
   <td class="feedback-cell">
     {% if e.feedback == 'correct' %}
       <span class="badge badge-correct">Correct</span>
-      <button class="btn-edit-feedback"
-              onclick="this.closest('td').querySelector('.feedback-form').style.display='block';this.style.display='none';this.previousElementSibling.style.display='none'">edit</button>
+      <button type="button" class="btn-edit-feedback" data-action="show-feedback-form">edit</button>
     {% elif e.feedback == 'false_positive' %}
       <span class="badge badge-fp">False Positive</span>
-      <button class="btn-edit-feedback"
-              onclick="this.closest('td').querySelector('.feedback-form').style.display='block';this.style.display='none';this.previousElementSibling.style.display='none'">edit</button>
+      <button type="button" class="btn-edit-feedback" data-action="show-feedback-form">edit</button>
     {% elif e.feedback == 'wrong_class' %}
       <span class="badge badge-wrong">Wrong: {{ (e.corrected_class or '?').replace("_"," ").title() }}</span>
-      <button class="btn-edit-feedback"
-              onclick="this.closest('td').querySelector('.feedback-form').style.display='block';this.style.display='none';this.previousElementSibling.style.display='none'">edit</button>
+      <button type="button" class="btn-edit-feedback" data-action="show-feedback-form">edit</button>
     {% endif %}
     <div class="feedback-form" {% if e.feedback %}style="display:none"{% endif %}>
       <div class="feedback-btns">
@@ -59,8 +56,7 @@
           <input type="hidden" name="feedback" value="false_positive">
           <button type="submit" class="btn-fb btn-fb-fp" title="False positive">&#10007;</button>
         </form>
-        <button type="button" class="btn-fb btn-fb-wrong" title="Wrong class"
-                onclick="this.closest('.feedback-form').querySelector('.wrong-class-picker').style.display='block'">?</button>
+        <button type="button" class="btn-fb btn-fb-wrong" title="Wrong class" data-action="show-wrong-class-picker">?</button>
       </div>
       <div class="wrong-class-picker" style="display:none">
         <form method="post"

--- a/services/web/src/templates/stats.html
+++ b/services/web/src/templates/stats.html
@@ -92,10 +92,10 @@
   <h2>Historical Metrics</h2>
   <div style="display:flex;gap:0.5rem;margin-bottom:1rem;align-items:center;">
     <span class="stat-label" style="min-width:auto;">Range:</span>
-    <button class="range-btn active" data-range="1h" onclick="loadHistory('1h',this)">1h</button>
-    <button class="range-btn" data-range="24h" onclick="loadHistory('24h',this)">24h</button>
-    <button class="range-btn" data-range="7d" onclick="loadHistory('7d',this)">7d</button>
-    <button class="range-btn" data-range="30d" onclick="loadHistory('30d',this)">30d</button>
+    <button class="range-btn active" data-range="1h">1h</button>
+    <button class="range-btn" data-range="24h">24h</button>
+    <button class="range-btn" data-range="7d">7d</button>
+    <button class="range-btn" data-range="30d">30d</button>
     <a id="export-link" href="/admin/stats/export?range=1h&format=csv" style="margin-left:auto;font-size:0.85rem;">Export CSV</a>
   </div>
   <div class="chart-row">

--- a/services/web/src/templates/users.html
+++ b/services/web/src/templates/users.html
@@ -36,7 +36,7 @@
           <form method="post" action="/admin/users/{{ u.id }}/role"
                 style="display:inline;">
             <input type="hidden" name="_csrf_token" value="{{ request.state.csrf_token }}">
-            <select name="role" onchange="this.form.submit()"
+            <select name="role" data-action="submit-on-change"
                     {% if u.id == current_user_id %}disabled title="Cannot change your own role"{% endif %}
                     style="font-size:0.85rem;padding:0.15em 0.3em;">
               {% for r in valid_roles %}
@@ -62,7 +62,7 @@
             </button>
           </form>
           <form method="post" action="/admin/users/{{ u.id }}/delete" style="display:inline;"
-                onsubmit="return confirm('Delete user {{ u.username }}?');">
+                data-confirm="Delete user {{ u.username }}?">
             <input type="hidden" name="_csrf_token" value="{{ request.state.csrf_token }}">
             <button type="submit" class="btn-remove" style="font-size:0.78rem;"
                     {% if u.id == current_user_id %}disabled title="Cannot delete your own account"{% endif %}>Delete</button>
@@ -180,4 +180,5 @@
   </form>
 </section>
 
+<script src="/static/users.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- v1.15.0 dropped `'unsafe-inline'` from `script-src` after extracting inline `<script>` blocks, but **inline event-handler attributes** (`onclick=`, `onchange=`, `onsubmit=`) were missed. Browsers block those under the hardened CSP, so admin buttons silently failed (originally reported: Check Status / Test Fire / etc. on the deterrent page).
- This converts every remaining inline handler in the web service to `addEventListener` bindings, restoring functionality while keeping v1.15.0's CSP hardening intact.

## Affected pages

| Page | Handlers converted |
|---|---|
| `config.html` + `config.js` | ~29 |
| `deterrent.html` + `deterrent.js` | 8 |
| `logs.html` | 6 |
| `stats.html` | 4 |
| `dashboard.html` | 4 |
| `db_backups.html` | 4 |
| `backups.html` | 4 |
| `partials/event_rows.html` | 4 |
| `users.html` | 2 (plus a new `users.js`) |

19 files changed, +262/-72.

## Patterns

- **Static template buttons:** assigned a stable `id`, bound in the page's external `.js` via `getElementById(...).addEventListener(...)`.
- **Dynamically-generated buttons in JS template strings** (devices table, camera/channel/zone cards, feedback rows): switched to `data-action` attributes with delegated `click` listeners on the persistent parent container. Avoids per-render rebinding.
- **users.html** previously had no script file; added a minimal `users.js` and `<script>` tag. Confirm-on-submit preserved via `data-confirm` + a form `submit` listener using `e.preventDefault()`.

## Test plan

- [ ] CI green (ruff, mypy, pytest)
- [ ] Manual: Deterrent → Check Status, Emergency Off, Test Fire on a device row, Save, Add Device, Add Group
- [ ] Manual: Config → Save, Send Test (Discord/email/ntfy), Add Camera, expand/collapse sections
- [ ] Manual: Dashboard widget actions
- [ ] Manual: Logs filters, Stats refresh, DB Backups create/restore, Events feedback buttons (Correct / FP / Wrong)
- [ ] Browser console: zero `Refused to execute inline event handler` CSP violations

## Notes

- No CSP relaxation. `script-src 'self'` from v1.15.0 stays put.
- Function names unchanged — minimum-diff conversions.
- Pre-existing local verification: \`grep -rE 'on(click|change|submit|...)='\` in templates/static → empty; ruff + mypy clean; 233 web tests pass; \`node --check\` clean on every static `.js`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>