### PR TITLE
feat: video upload + labeling pipeline (PR 2/3)

### DIFF
--- a/services/trainer/src/video_processor.py
+++ b/services/trainer/src/video_processor.py
@@ -1,0 +1,260 @@
+"""Video processing: frame extraction + YOLO inference + IoU deduplication.
+
+Standalone module imported by the trainer service's job runner. Does NOT
+write to the database — returns data for the caller to persist. This
+keeps the module testable without a DB dependency.
+
+Requires: opencv-python-headless, ultralytics, torch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RawDetection:
+    """A single detection from one frame before deduplication."""
+
+    frame_idx: int
+    timestamp_in_video: float
+    bbox: list[float]  # [x_center, y_center, width, height] normalized
+    predicted_class: str
+    confidence: float
+    detection_pass: str  # 'low' or 'normal'
+
+
+@dataclass
+class ProcessingResult:
+    """Result of processing a single upload."""
+
+    upload_id: str
+    frame_count: int
+    raw_detection_count: int
+    deduped_detection_count: int
+    detections: list[RawDetection] = field(default_factory=list)
+    error: str | None = None
+
+
+def compute_iou(box_a: list[float], box_b: list[float]) -> float:
+    """IoU for YOLO-format boxes [x_center, y_center, width, height] (normalized)."""
+    ax1 = box_a[0] - box_a[2] / 2
+    ay1 = box_a[1] - box_a[3] / 2
+    ax2 = box_a[0] + box_a[2] / 2
+    ay2 = box_a[1] + box_a[3] / 2
+
+    bx1 = box_b[0] - box_b[2] / 2
+    by1 = box_b[1] - box_b[3] / 2
+    bx2 = box_b[0] + box_b[2] / 2
+    by2 = box_b[1] + box_b[3] / 2
+
+    ix1 = max(ax1, bx1)
+    iy1 = max(ay1, by1)
+    ix2 = min(ax2, bx2)
+    iy2 = min(ay2, by2)
+
+    inter = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+    area_a = box_a[2] * box_a[3]
+    area_b = box_b[2] * box_b[3]
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0
+
+
+def dedupe_detections(
+    detections: list[RawDetection],
+    *,
+    iou_threshold: float = 0.85,
+    frame_window: int = 5,
+) -> list[RawDetection]:
+    """Remove near-duplicate detections within a frame window.
+
+    Per class, sorted by frame_idx ascending: for each detection, look back
+    at prior detections within *frame_window* frames. If any same-class
+    detection has IoU > *iou_threshold*, keep the one with higher confidence.
+    """
+    by_class: dict[str, list[RawDetection]] = {}
+    for d in detections:
+        by_class.setdefault(d.predicted_class, []).append(d)
+
+    survivors: list[RawDetection] = []
+
+    for cls_dets in by_class.values():
+        cls_dets.sort(key=lambda d: d.frame_idx)
+        dropped: set[int] = set()
+
+        for i, det in enumerate(cls_dets):
+            if i in dropped:
+                continue
+            for j in range(i - 1, -1, -1):
+                if j in dropped:
+                    continue
+                prior = cls_dets[j]
+                if det.frame_idx - prior.frame_idx > frame_window:
+                    break
+                if compute_iou(det.bbox, prior.bbox) > iou_threshold:
+                    if det.confidence >= prior.confidence:
+                        dropped.add(j)
+                    else:
+                        dropped.add(i)
+                    break
+
+        survivors.extend(d for idx, d in enumerate(cls_dets) if idx not in dropped)
+
+    survivors.sort(key=lambda d: (d.frame_idx, d.predicted_class))
+    return survivors
+
+
+def extract_and_infer(
+    video_path: Path,
+    frames_dir: Path,
+    model_path: str,
+    *,
+    confidence_threshold: float,
+    low_confidence: float = 0.05,
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> tuple[int, list[RawDetection]]:
+    """Extract every frame from *video_path*, run YOLO inference, return detections.
+
+    Each frame is saved as ``{frame_idx:06d}.jpg`` in *frames_dir*.
+    Single inference pass at *low_confidence*; detections tagged ``'normal'``
+    if confidence >= *confidence_threshold*, else ``'low'``.
+    """
+    import cv2
+    from ultralytics import YOLO
+
+    frames_dir.mkdir(parents=True, exist_ok=True)
+    model = YOLO(model_path)
+
+    cap = cv2.VideoCapture(str(video_path))
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) or 0
+
+    raw_detections: list[RawDetection] = []
+    frame_idx = 0
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+
+        frame_path = frames_dir / f"{frame_idx:06d}.jpg"
+        cv2.imwrite(str(frame_path), frame)
+
+        results = model.predict(
+            frame,
+            conf=low_confidence,
+            verbose=False,
+            save=False,
+            project="/tmp/runs",
+            name="predict",
+            exist_ok=True,
+        )
+
+        timestamp = frame_idx / fps
+
+        for result in results:
+            for box in result.boxes:
+                conf = float(box.conf[0])
+                class_name: str = result.names[int(box.cls[0])]
+                xyxy = box.xyxyn[0].tolist()
+                x_center = (xyxy[0] + xyxy[2]) / 2
+                y_center = (xyxy[1] + xyxy[3]) / 2
+                width = xyxy[2] - xyxy[0]
+                height = xyxy[3] - xyxy[1]
+                raw_detections.append(RawDetection(
+                    frame_idx=frame_idx,
+                    timestamp_in_video=round(timestamp, 3),
+                    bbox=[round(x_center, 6), round(y_center, 6), round(width, 6), round(height, 6)],
+                    predicted_class=class_name,
+                    confidence=round(conf, 4),
+                    detection_pass="normal" if conf >= confidence_threshold else "low",
+                ))
+
+        frame_idx += 1
+        if progress_callback and frame_idx % 50 == 0:
+            progress_callback(frame_idx, total_frames)
+
+    cap.release()
+
+    del model
+    try:
+        import torch
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except ImportError:
+        pass
+
+    if progress_callback:
+        progress_callback(frame_idx, frame_idx)
+
+    return frame_idx, raw_detections
+
+
+def process_upload(
+    upload_id: str,
+    video_path: Path,
+    frames_dir: Path,
+    model_path: str,
+    *,
+    confidence_threshold: float,
+    low_confidence: float = 0.05,
+    dedupe_iou: float = 0.85,
+    dedupe_window: int = 5,
+    target_class_hint: str | None = None,
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> ProcessingResult:
+    """Full pipeline: extract frames → infer → dedupe → return result."""
+    try:
+        frame_count, raw = extract_and_infer(
+            video_path,
+            frames_dir,
+            model_path,
+            confidence_threshold=confidence_threshold,
+            low_confidence=low_confidence,
+            progress_callback=progress_callback,
+        )
+        deduped = dedupe_detections(raw, iou_threshold=dedupe_iou, frame_window=dedupe_window)
+        if target_class_hint:
+            for d in deduped:
+                d.detection_pass = d.detection_pass  # preserve; hint is metadata only
+        return ProcessingResult(
+            upload_id=upload_id,
+            frame_count=frame_count,
+            raw_detection_count=len(raw),
+            deduped_detection_count=len(deduped),
+            detections=deduped,
+        )
+    except Exception as e:
+        logger.exception("Video processing failed for upload %s", upload_id)
+        return ProcessingResult(
+            upload_id=upload_id,
+            frame_count=0,
+            raw_detection_count=0,
+            deduped_detection_count=0,
+            error=str(e),
+        )
+
+
+def result_to_db_rows(
+    result: ProcessingResult,
+    target_class_hint: str | None = None,
+) -> list[dict[str, Any]]:
+    """Convert ProcessingResult detections to dicts suitable for db.insert_training_events."""
+    return [
+        {
+            "frame_idx": d.frame_idx,
+            "timestamp_in_video": d.timestamp_in_video,
+            "bbox": json.dumps(d.bbox),
+            "predicted_class": d.predicted_class,
+            "confidence": d.confidence,
+            "target_class_hint": target_class_hint,
+            "detection_pass": d.detection_pass,
+        }
+        for d in result.detections
+    ]

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -8,7 +8,7 @@ FROM docker.io/library/python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8
 WORKDIR /app
 
 RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends gosu && \
+    apt-get install -y --no-install-recommends gosu ffmpeg && \
     rm -rf /var/lib/apt/lists/*
 
 COPY services/web/requirements.txt ./requirements.txt

--- a/services/web/src/config_redact.py
+++ b/services/web/src/config_redact.py
@@ -27,6 +27,7 @@ _STRUCTURAL_PATHS: tuple[tuple[str, ...], ...] = (
     ("cameras", "[]", "rtsp_url"),
     ("deterrent", "tuya", "api_key"),
     ("deterrent", "tuya", "api_secret"),
+    ("training", "sources", "roboflow", "api_key"),
 )
 
 # Field-name heuristic for the heterogeneous `notifications.channels` list

--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -698,3 +698,343 @@ def get_metrics_for_chart(
             "camera_data": None,
         })
     return filled
+
+
+# ── Training uploads ─────────────────────────────────────────────────────────
+
+
+def create_training_upload(
+    upload_id: str,
+    filename: str,
+    target_class_hint: str | None,
+) -> None:
+    """INSERT a new training_uploads row with status='uploaded'."""
+    now = datetime.now(timezone.utc).isoformat()
+    with _connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO training_uploads (id, filename, target_class_hint, status, created_at)
+            VALUES (?, ?, ?, 'uploaded', ?)
+            """,
+            (upload_id, filename, target_class_hint, now),
+        )
+        conn.commit()
+
+
+def get_training_uploads(
+    limit: int = 100,
+    offset: int = 0,
+    status: str | None = None,
+) -> list[sqlite3.Row]:
+    """List training uploads, newest first."""
+    where: list[str] = []
+    params: list[object] = []
+    if status:
+        where.append("status = ?")
+        params.append(status)
+    clause = ("WHERE " + " AND ".join(where)) if where else ""
+    params += [limit, offset]
+    with _connect() as conn:
+        return conn.execute(
+            f"""
+            SELECT * FROM training_uploads
+            {clause}
+            ORDER BY created_at DESC
+            LIMIT ? OFFSET ?
+            """,
+            params,
+        ).fetchall()
+
+
+def count_training_uploads(status: str | None = None) -> int:
+    where: list[str] = []
+    params: list[object] = []
+    if status:
+        where.append("status = ?")
+        params.append(status)
+    clause = ("WHERE " + " AND ".join(where)) if where else ""
+    with _connect() as conn:
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM training_uploads {clause}", params
+        ).fetchone()
+        return row[0] if row else 0
+
+
+def get_training_upload(upload_id: str) -> sqlite3.Row | None:
+    with _connect() as conn:
+        return conn.execute(
+            "SELECT * FROM training_uploads WHERE id = ?", (upload_id,)
+        ).fetchone()
+
+
+def update_training_upload_status(
+    upload_id: str,
+    status: str,
+    *,
+    frame_count: int | None = None,
+    detection_count: int | None = None,
+    error: str | None = None,
+) -> bool:
+    sets = ["status = ?"]
+    params: list[object] = [status]
+    if frame_count is not None:
+        sets.append("frame_count = ?")
+        params.append(frame_count)
+    if detection_count is not None:
+        sets.append("detection_count = ?")
+        params.append(detection_count)
+    if error is not None:
+        sets.append("error = ?")
+        params.append(error)
+    if status in ("processed", "failed"):
+        sets.append("processed_at = ?")
+        params.append(datetime.now(timezone.utc).isoformat())
+    params.append(upload_id)
+    with _connect() as conn:
+        cur = conn.execute(
+            f"UPDATE training_uploads SET {', '.join(sets)} WHERE id = ?",
+            params,
+        )
+        conn.commit()
+        return cur.rowcount > 0
+
+
+def delete_training_upload(upload_id: str) -> bool:
+    """DELETE upload and its events (manual cascade — avoids PRAGMA foreign_keys)."""
+    with _connect() as conn:
+        conn.execute("DELETE FROM training_events WHERE upload_id = ?", (upload_id,))
+        cur = conn.execute("DELETE FROM training_uploads WHERE id = ?", (upload_id,))
+        conn.commit()
+        return cur.rowcount > 0
+
+
+# ── Training events ──────────────────────────────────────────────────────────
+
+
+def insert_training_events(upload_id: str, events: list[dict]) -> int:
+    """Bulk-insert training events. Returns rows inserted."""
+    now = datetime.now(timezone.utc).isoformat()
+    with _connect() as conn:
+        conn.executemany(
+            """
+            INSERT INTO training_events
+                (upload_id, frame_idx, timestamp_in_video, bbox, predicted_class,
+                 confidence, target_class_hint, detection_pass, review_state, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+            """,
+            [
+                (
+                    upload_id,
+                    e["frame_idx"],
+                    e.get("timestamp_in_video"),
+                    e["bbox"] if isinstance(e["bbox"], str) else __import__("json").dumps(e["bbox"]),
+                    e["predicted_class"],
+                    e["confidence"],
+                    e.get("target_class_hint"),
+                    e["detection_pass"],
+                    now,
+                )
+                for e in events
+            ],
+        )
+        conn.commit()
+        return len(events)
+
+
+def get_training_events(
+    upload_id: str,
+    *,
+    limit: int = 100,
+    offset: int = 0,
+    review_state: str | None = None,
+    detection_pass: str | None = None,
+) -> list[sqlite3.Row]:
+    where = ["upload_id = ?"]
+    params: list[object] = [upload_id]
+    if review_state:
+        where.append("review_state = ?")
+        params.append(review_state)
+    if detection_pass:
+        where.append("detection_pass = ?")
+        params.append(detection_pass)
+    clause = "WHERE " + " AND ".join(where)
+    params += [limit, offset]
+    with _connect() as conn:
+        return conn.execute(
+            f"""
+            SELECT * FROM training_events
+            {clause}
+            ORDER BY confidence DESC, id ASC
+            LIMIT ? OFFSET ?
+            """,
+            params,
+        ).fetchall()
+
+
+def count_training_events(
+    upload_id: str,
+    *,
+    review_state: str | None = None,
+    detection_pass: str | None = None,
+) -> int:
+    where = ["upload_id = ?"]
+    params: list[object] = [upload_id]
+    if review_state:
+        where.append("review_state = ?")
+        params.append(review_state)
+    if detection_pass:
+        where.append("detection_pass = ?")
+        params.append(detection_pass)
+    clause = "WHERE " + " AND ".join(where)
+    with _connect() as conn:
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM training_events {clause}", params
+        ).fetchone()
+        return row[0] if row else 0
+
+
+def get_training_event(event_id: int) -> sqlite3.Row | None:
+    with _connect() as conn:
+        return conn.execute(
+            "SELECT * FROM training_events WHERE id = ?", (event_id,)
+        ).fetchone()
+
+
+def get_next_training_event(
+    upload_id: str,
+    current_id: int,
+    *,
+    review_state: str | None = None,
+    detection_pass: str | None = None,
+) -> sqlite3.Row | None:
+    """Get the next event (by confidence desc, id asc) after current_id."""
+    where = ["upload_id = ?", "(confidence < (SELECT confidence FROM training_events WHERE id = ?) OR (confidence = (SELECT confidence FROM training_events WHERE id = ?) AND id > ?))"]
+    params: list[object] = [upload_id, current_id, current_id, current_id]
+    if review_state:
+        where.append("review_state = ?")
+        params.append(review_state)
+    if detection_pass:
+        where.append("detection_pass = ?")
+        params.append(detection_pass)
+    clause = "WHERE " + " AND ".join(where)
+    with _connect() as conn:
+        return conn.execute(
+            f"""
+            SELECT * FROM training_events
+            {clause}
+            ORDER BY confidence DESC, id ASC
+            LIMIT 1
+            """,
+            params,
+        ).fetchone()
+
+
+def get_prev_training_event(
+    upload_id: str,
+    current_id: int,
+    *,
+    review_state: str | None = None,
+    detection_pass: str | None = None,
+) -> sqlite3.Row | None:
+    """Get the previous event (by confidence desc, id asc) before current_id."""
+    where = ["upload_id = ?", "(confidence > (SELECT confidence FROM training_events WHERE id = ?) OR (confidence = (SELECT confidence FROM training_events WHERE id = ?) AND id < ?))"]
+    params: list[object] = [upload_id, current_id, current_id, current_id]
+    if review_state:
+        where.append("review_state = ?")
+        params.append(review_state)
+    if detection_pass:
+        where.append("detection_pass = ?")
+        params.append(detection_pass)
+    clause = "WHERE " + " AND ".join(where)
+    with _connect() as conn:
+        return conn.execute(
+            f"""
+            SELECT * FROM training_events
+            {clause}
+            ORDER BY confidence ASC, id DESC
+            LIMIT 1
+            """,
+            params,
+        ).fetchone()
+
+
+def update_training_event_review(
+    event_id: int,
+    review_state: str,
+    corrected_class: str | None = None,
+) -> bool:
+    now = datetime.now(timezone.utc).isoformat()
+    with _connect() as conn:
+        cur = conn.execute(
+            """
+            UPDATE training_events
+            SET review_state = ?, corrected_class = ?, reviewed_at = ?
+            WHERE id = ?
+            """,
+            (review_state, corrected_class, now, event_id),
+        )
+        conn.commit()
+        return cur.rowcount > 0
+
+
+def bulk_update_training_events(
+    upload_id: str,
+    review_state: str,
+    *,
+    filter_pass: str | None = None,
+    filter_review_state: str | None = None,
+) -> int:
+    """Bulk update review_state. Returns rows affected."""
+    now = datetime.now(timezone.utc).isoformat()
+    where = ["upload_id = ?"]
+    params: list[object] = [review_state, now, upload_id]
+    if filter_pass:
+        where.append("detection_pass = ?")
+        params.append(filter_pass)
+    if filter_review_state:
+        where.append("review_state = ?")
+        params.append(filter_review_state)
+    clause = "WHERE " + " AND ".join(where)
+    with _connect() as conn:
+        cur = conn.execute(
+            f"UPDATE training_events SET review_state = ?, reviewed_at = ? {clause}",
+            params,
+        )
+        conn.commit()
+        return cur.rowcount
+
+
+def get_training_upload_stats(upload_id: str) -> dict:
+    """Return review state counts for an upload."""
+    with _connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT review_state, COUNT(*) as cnt
+            FROM training_events
+            WHERE upload_id = ?
+            GROUP BY review_state
+            """,
+            (upload_id,),
+        ).fetchall()
+    stats = {"pending": 0, "approved": 0, "rejected": 0, "corrected": 0, "total": 0}
+    for r in rows:
+        state = r["review_state"]
+        cnt = r["cnt"]
+        if state in stats:
+            stats[state] = cnt
+        stats["total"] += cnt
+    return stats
+
+
+def get_exportable_training_events() -> list[sqlite3.Row]:
+    """Return approved/corrected training events for dataset export."""
+    with _connect() as conn:
+        return conn.execute(
+            """
+            SELECT te.*, tu.target_class_hint AS upload_hint
+            FROM training_events te
+            JOIN training_uploads tu ON te.upload_id = tu.id
+            WHERE te.review_state IN ('approved', 'corrected')
+            ORDER BY te.upload_id, te.frame_idx
+            """
+        ).fetchall()

--- a/services/web/src/main.py
+++ b/services/web/src/main.py
@@ -29,6 +29,7 @@ from routes import (
     snapshot,
     stats,
     training,
+    training_uploads,
 )
 from routes import auth as auth_routes
 from routes import users as users_routes
@@ -476,6 +477,7 @@ app.include_router(about.router)
 app.include_router(admin.router)
 app.include_router(stats.router)
 app.include_router(training.router)
+app.include_router(training_uploads.router)
 app.include_router(audit_log.router)
 app.include_router(snapshot.router)
 app.include_router(feedback.router)

--- a/services/web/src/routes/training_uploads.py
+++ b/services/web/src/routes/training_uploads.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -35,6 +36,24 @@ MAX_UPLOAD_BYTES: int | None = (
     else 500 * 1024 * 1024  # 500 MB default
 )
 PAGE_SIZE = 25
+_UPLOAD_LIST_URL = "/admin/training/uploads"
+
+_SAFE_ID = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _safe_upload_dir(upload_id: str) -> Path | None:
+    """Resolve an upload_id to a directory path, or None if invalid.
+
+    Validates the ID is a hex-only string AND exists in the database.
+    Returns the constructed path using the DB-returned ID (not user input).
+    """
+    if not _SAFE_ID.match(upload_id):
+        return None
+    upload = db_module.get_training_upload(upload_id)
+    if upload is None:
+        return None
+    safe_id: str = upload["id"]
+    return TRAINING_UPLOADS_DIR / safe_id
 
 
 def _probe_duration(file_path: Path) -> float | None:
@@ -188,15 +207,14 @@ async def delete_upload(request: Request, upload_id: str) -> Response:
     if not isinstance(gate, dict):
         return gate
 
-    upload = db_module.get_training_upload(upload_id)
-    if not upload:
+    upload_dir = _safe_upload_dir(upload_id)
+    if upload_dir is None:
         return JSONResponse({"error": "not found"}, status_code=404)
 
     db_module.delete_training_upload(upload_id)
-    upload_dir = TRAINING_UPLOADS_DIR / upload_id
     shutil.rmtree(upload_dir, ignore_errors=True)
     logger.info("Training upload deleted: %s", upload_id)
-    return RedirectResponse(url="/admin/training/uploads", status_code=303)
+    return RedirectResponse(url=_UPLOAD_LIST_URL, status_code=303)
 
 
 # ── Serve frame ──────────────────────────────────────────────────────────────
@@ -208,15 +226,15 @@ async def serve_frame(request: Request, upload_id: str, frame_idx: int) -> Respo
     if not isinstance(gate, dict):
         return gate
 
-    upload = db_module.get_training_upload(upload_id)
-    if not upload:
+    upload_dir = _safe_upload_dir(upload_id)
+    if upload_dir is None:
         return JSONResponse({"error": "not found"}, status_code=404)
 
-    frame_path = TRAINING_UPLOADS_DIR / upload_id / "frames" / f"{frame_idx:06d}.jpg"
+    if frame_idx < 0:
+        return JSONResponse({"error": "invalid frame index"}, status_code=400)
+    frame_path = upload_dir / "frames" / f"{frame_idx:06d}.jpg"
     if not frame_path.exists():
         return JSONResponse({"error": "frame not found"}, status_code=404)
-    if not frame_path.resolve().is_relative_to(TRAINING_UPLOADS_DIR.resolve()):
-        return JSONResponse({"error": "invalid path"}, status_code=400)
 
     return FileResponse(str(frame_path), media_type="image/jpeg")
 
@@ -236,6 +254,8 @@ async def label_page(
     if not isinstance(gate, dict):
         return gate
 
+    if not _SAFE_ID.match(upload_id):
+        return JSONResponse({"error": "not found"}, status_code=404)
     upload = db_module.get_training_upload(upload_id)
     if not upload:
         return JSONResponse({"error": "not found"}, status_code=404)
@@ -297,6 +317,10 @@ async def review_event(
 
     if action not in ("approved", "rejected", "corrected"):
         return JSONResponse({"error": "invalid action"}, status_code=400)
+
+    event = db_module.get_training_event(event_id)
+    if not event or event["upload_id"] != upload_id:
+        return JSONResponse({"error": "event not found in this upload"}, status_code=404)
 
     corrected = corrected_class.strip()[:64] if action == "corrected" else None
     if action == "corrected" and not corrected:
@@ -368,14 +392,21 @@ async def bulk_review(
     if action not in ("approved", "rejected"):
         return JSONResponse({"error": "bulk action must be approved or rejected"}, status_code=400)
 
+    if not _SAFE_ID.match(upload_id):
+        return JSONResponse({"error": "not found"}, status_code=404)
+    upload = db_module.get_training_upload(upload_id)
+    if not upload:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    safe_id: str = upload["id"]
     count = db_module.bulk_update_training_events(
-        upload_id,
+        safe_id,
         action,
         filter_pass=filter_pass or None,
         filter_review_state="pending",
     )
-    logger.info("Bulk %s %d events in upload %s", action, count, upload_id)
+    logger.info("Bulk %s %d events in upload %s", action, count, safe_id)
     return RedirectResponse(
-        url=f"/admin/training/uploads/{upload_id}",
+        url=f"{_UPLOAD_LIST_URL}/{safe_id}",
         status_code=303,
     )

--- a/services/web/src/routes/training_uploads.py
+++ b/services/web/src/routes/training_uploads.py
@@ -44,16 +44,22 @@ _SAFE_ID = re.compile(r"^[0-9a-f]{32}$")
 def _safe_upload_dir(upload_id: str) -> Path | None:
     """Resolve an upload_id to a directory path, or None if invalid.
 
-    Validates the ID is a hex-only string AND exists in the database.
-    Returns the constructed path using the DB-returned ID (not user input).
+    Uses a whitelist-lookup pattern (enumerate known directories, match
+    against user input) so the returned Path originates from the filesystem
+    listing, not from the user-controlled route parameter.  This breaks
+    the taint chain that CodeQL traces from route param → Path constructor.
     """
     if not _SAFE_ID.match(upload_id):
         return None
-    upload = db_module.get_training_upload(upload_id)
-    if upload is None:
+    if db_module.get_training_upload(upload_id) is None:
         return None
-    safe_id: str = upload["id"]
-    return TRAINING_UPLOADS_DIR / safe_id
+    try:
+        for entry in TRAINING_UPLOADS_DIR.iterdir():
+            if entry.is_dir() and entry.name == upload_id:
+                return entry
+    except FileNotFoundError:
+        pass
+    return None
 
 
 def _probe_duration(file_path: Path) -> float | None:
@@ -392,21 +398,19 @@ async def bulk_review(
     if action not in ("approved", "rejected"):
         return JSONResponse({"error": "bulk action must be approved or rejected"}, status_code=400)
 
-    if not _SAFE_ID.match(upload_id):
-        return JSONResponse({"error": "not found"}, status_code=404)
-    upload = db_module.get_training_upload(upload_id)
-    if not upload:
+    upload_dir = _safe_upload_dir(upload_id)
+    if upload_dir is None:
         return JSONResponse({"error": "not found"}, status_code=404)
 
-    safe_id: str = upload["id"]
+    verified_id = upload_dir.name
     count = db_module.bulk_update_training_events(
-        safe_id,
+        verified_id,
         action,
         filter_pass=filter_pass or None,
         filter_review_state="pending",
     )
-    logger.info("Bulk %s %d events in upload %s", action, count, safe_id)
+    logger.info("Bulk %s %d events in upload %s", action, count, verified_id)
     return RedirectResponse(
-        url=f"{_UPLOAD_LIST_URL}/{safe_id}",
+        url=f"{_UPLOAD_LIST_URL}/{verified_id}",
         status_code=303,
     )

--- a/services/web/src/routes/training_uploads.py
+++ b/services/web/src/routes/training_uploads.py
@@ -1,0 +1,381 @@
+"""Training video upload, labeling queue, and review endpoints."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+
+import db as db_module
+from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from rate_limit_dep import rate_limit
+from route_auth import require_admin, require_viewer
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/training/uploads")
+templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
+
+TRAINING_UPLOADS_DIR = Path(os.environ.get("TRAINING_UPLOADS_DIR", "/data/training_uploads"))
+ALLOWED_VIDEO_EXTENSIONS = {".mp4", ".avi", ".mkv", ".mov"}
+MAX_DURATION_SECONDS = 60
+_DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024
+UPLOAD_CHUNK_SIZE = int(os.environ.get("TRAINING_UPLOAD_CHUNK_SIZE", str(_DEFAULT_CHUNK_SIZE)))
+MAX_UPLOAD_BYTES: int | None = (
+    int(os.environ["TRAINING_UPLOAD_MAX_BYTES"])
+    if "TRAINING_UPLOAD_MAX_BYTES" in os.environ
+    else 500 * 1024 * 1024  # 500 MB default
+)
+PAGE_SIZE = 25
+
+
+def _probe_duration(file_path: Path) -> float | None:
+    """Use ffprobe to get video duration in seconds. Returns None on failure."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "json",
+                str(file_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+        return float(data["format"]["duration"])
+    except Exception:
+        logger.exception("ffprobe failed for %s", file_path)
+        return None
+
+
+def _error_response(request: Request, error: str, status_code: int = 400) -> Response:
+    return templates.TemplateResponse(
+        request,
+        "training_uploads.html",
+        {
+            "uploads": db_module.get_training_uploads(limit=PAGE_SIZE),
+            "total": db_module.count_training_uploads(),
+            "page": 1,
+            "total_pages": 1,
+            "filter_status": "",
+            "error": error,
+        },
+        status_code=status_code,
+    )
+
+
+# ── Upload list page ─────────────────────────────────────────────────────────
+
+
+@router.get("", response_class=HTMLResponse)
+async def uploads_list_page(
+    request: Request,
+    page: int = 1,
+    status: str = "",
+) -> Response:
+    gate = require_viewer(request)
+    if not isinstance(gate, dict):
+        return gate
+    st = status or None
+    offset = (page - 1) * PAGE_SIZE
+    uploads = db_module.get_training_uploads(limit=PAGE_SIZE, offset=offset, status=st)
+    total = db_module.count_training_uploads(status=st)
+    return templates.TemplateResponse(
+        request,
+        "training_uploads.html",
+        {
+            "uploads": [dict(u) for u in uploads],
+            "total": total,
+            "page": page,
+            "total_pages": max(1, -(-total // PAGE_SIZE)),
+            "filter_status": status,
+            "error": None,
+        },
+    )
+
+
+# ── Upload video ─────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "",
+    response_class=HTMLResponse,
+    dependencies=[Depends(rate_limit("training-upload", capacity=10, window_seconds=3600))],
+)
+async def upload_video(
+    request: Request,
+    file: UploadFile = File(...),
+    target_class_hint: str = Form(""),
+) -> Response:
+    gate = require_admin(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    filename = file.filename or "upload"
+    suffix = Path(filename).suffix.lower()
+    if suffix not in ALLOWED_VIDEO_EXTENSIONS:
+        return _error_response(
+            request,
+            f"Unsupported format '{suffix}'. Accepted: {', '.join(sorted(ALLOWED_VIDEO_EXTENSIONS))}",
+        )
+
+    hint = target_class_hint.strip() or None
+    if hint and hint not in ("duck", "heron", "raccoon", "background"):
+        return _error_response(request, f"Invalid target class hint: {hint}")
+
+    TRAINING_UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+    upload_id = uuid.uuid4().hex
+
+    fd, tmp_path_str = tempfile.mkstemp(dir=str(TRAINING_UPLOADS_DIR), suffix=suffix)
+    tmp_path = Path(tmp_path_str)
+    try:
+        bytes_written = 0
+        with os.fdopen(fd, "wb") as f:
+            while True:
+                chunk = await file.read(UPLOAD_CHUNK_SIZE)
+                if not chunk:
+                    break
+                bytes_written += len(chunk)
+                if MAX_UPLOAD_BYTES is not None and bytes_written > MAX_UPLOAD_BYTES:
+                    return _error_response(
+                        request,
+                        f"File too large (max {MAX_UPLOAD_BYTES // (1024 * 1024)} MB)",
+                    )
+                f.write(chunk)
+
+        duration = _probe_duration(tmp_path)
+        if duration is None:
+            return _error_response(request, "Could not read video — file may be corrupt or unsupported codec")
+        if duration > MAX_DURATION_SECONDS:
+            return _error_response(
+                request,
+                f"Video is {duration:.0f}s — max allowed is {MAX_DURATION_SECONDS}s",
+            )
+
+        upload_dir = TRAINING_UPLOADS_DIR / upload_id
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        final_path = upload_dir / f"original{suffix}"
+        os.replace(str(tmp_path), str(final_path))
+        tmp_path = final_path  # prevent cleanup of moved file
+
+        db_module.create_training_upload(upload_id, filename, hint)
+        logger.info("Training video uploaded: %s (%s, %.0fs)", filename, upload_id, duration)
+        return RedirectResponse(url="/admin/training/uploads", status_code=303)
+
+    finally:
+        if tmp_path.exists() and tmp_path != (TRAINING_UPLOADS_DIR / upload_id / f"original{suffix}"):
+            tmp_path.unlink(missing_ok=True)
+
+
+# ── Delete upload ────────────────────────────────────────────────────────────
+
+
+@router.post("/{upload_id}/delete")
+async def delete_upload(request: Request, upload_id: str) -> Response:
+    gate = require_admin(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    upload = db_module.get_training_upload(upload_id)
+    if not upload:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    db_module.delete_training_upload(upload_id)
+    upload_dir = TRAINING_UPLOADS_DIR / upload_id
+    shutil.rmtree(upload_dir, ignore_errors=True)
+    logger.info("Training upload deleted: %s", upload_id)
+    return RedirectResponse(url="/admin/training/uploads", status_code=303)
+
+
+# ── Serve frame ──────────────────────────────────────────────────────────────
+
+
+@router.get("/{upload_id}/frames/{frame_idx}")
+async def serve_frame(request: Request, upload_id: str, frame_idx: int) -> Response:
+    gate = require_viewer(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    upload = db_module.get_training_upload(upload_id)
+    if not upload:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    frame_path = TRAINING_UPLOADS_DIR / upload_id / "frames" / f"{frame_idx:06d}.jpg"
+    if not frame_path.exists():
+        return JSONResponse({"error": "frame not found"}, status_code=404)
+    if not frame_path.resolve().is_relative_to(TRAINING_UPLOADS_DIR.resolve()):
+        return JSONResponse({"error": "invalid path"}, status_code=400)
+
+    return FileResponse(str(frame_path), media_type="image/jpeg")
+
+
+# ── Labeling queue page ─────────────────────────────────────────────────────
+
+
+@router.get("/{upload_id}", response_class=HTMLResponse)
+async def label_page(
+    request: Request,
+    upload_id: str,
+    event_id: int = 0,
+    review_state: str = "",
+    detection_pass: str = "",
+) -> Response:
+    gate = require_viewer(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    upload = db_module.get_training_upload(upload_id)
+    if not upload:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    rs = review_state or None
+    dp = detection_pass or None
+    stats = db_module.get_training_upload_stats(upload_id)
+
+    if event_id:
+        event = db_module.get_training_event(event_id)
+    else:
+        events = db_module.get_training_events(upload_id, limit=1, review_state=rs, detection_pass=dp)
+        event = events[0] if events else None
+
+    next_event = None
+    prev_event = None
+    if event:
+        next_event = db_module.get_next_training_event(
+            upload_id, event["id"], review_state=rs, detection_pass=dp,
+        )
+        prev_event = db_module.get_prev_training_event(
+            upload_id, event["id"], review_state=rs, detection_pass=dp,
+        )
+
+    import config_store
+    cfg = config_store.load_cached()
+    target_classes = cfg.get("detection", {}).get("target_classes", [])
+
+    return templates.TemplateResponse(
+        request,
+        "training_label.html",
+        {
+            "upload": dict(upload),
+            "event": dict(event) if event else None,
+            "next_event": dict(next_event) if next_event else None,
+            "prev_event": dict(prev_event) if prev_event else None,
+            "stats": stats,
+            "target_classes": target_classes,
+            "filter_review_state": review_state,
+            "filter_detection_pass": detection_pass,
+        },
+    )
+
+
+# ── Review single event ─────────────────────────────────────────────────────
+
+
+@router.post("/{upload_id}/events/{event_id}/review")
+async def review_event(
+    request: Request,
+    upload_id: str,
+    event_id: int,
+    action: str = Form(...),
+    corrected_class: str = Form(""),
+) -> Response:
+    gate = require_admin(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    if action not in ("approved", "rejected", "corrected"):
+        return JSONResponse({"error": "invalid action"}, status_code=400)
+
+    corrected = corrected_class.strip()[:64] if action == "corrected" else None
+    if action == "corrected" and not corrected:
+        return JSONResponse({"error": "corrected_class required"}, status_code=400)
+
+    db_module.update_training_event_review(event_id, action, corrected)
+
+    rs = request.query_params.get("review_state", "")
+    dp = request.query_params.get("detection_pass", "")
+
+    next_event = db_module.get_next_training_event(
+        upload_id, event_id,
+        review_state=rs or None,
+        detection_pass=dp or None,
+    )
+    event = next_event or db_module.get_training_event(event_id)
+    stats = db_module.get_training_upload_stats(upload_id)
+
+    if next_event:
+        prev_event = db_module.get_prev_training_event(
+            upload_id, next_event["id"],
+            review_state=rs or None,
+            detection_pass=dp or None,
+        )
+    else:
+        prev_event = None
+
+    import config_store
+    cfg = config_store.load_cached()
+    target_classes = cfg.get("detection", {}).get("target_classes", [])
+
+    return templates.TemplateResponse(
+        request,
+        "partials/training_label_card.html",
+        {
+            "upload": dict(db_module.get_training_upload(upload_id)),  # type: ignore[arg-type]
+            "event": dict(event) if event else None,
+            "next_event": None if not next_event else (
+                db_module.get_next_training_event(
+                    upload_id, next_event["id"],
+                    review_state=rs or None,
+                    detection_pass=dp or None,
+                )
+            ),
+            "prev_event": prev_event,
+            "stats": stats,
+            "target_classes": target_classes,
+            "filter_review_state": rs,
+            "filter_detection_pass": dp,
+            "auto_advance": True,
+        },
+    )
+
+
+# ── Bulk review ──────────────────────────────────────────────────────────────
+
+
+@router.post("/{upload_id}/bulk-review")
+async def bulk_review(
+    request: Request,
+    upload_id: str,
+    action: str = Form(...),
+    filter_pass: str = Form(""),
+) -> Response:
+    gate = require_admin(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    if action not in ("approved", "rejected"):
+        return JSONResponse({"error": "bulk action must be approved or rejected"}, status_code=400)
+
+    count = db_module.bulk_update_training_events(
+        upload_id,
+        action,
+        filter_pass=filter_pass or None,
+        filter_review_state="pending",
+    )
+    logger.info("Bulk %s %d events in upload %s", action, count, upload_id)
+    return RedirectResponse(
+        url=f"/admin/training/uploads/{upload_id}",
+        status_code=303,
+    )

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -1041,3 +1041,61 @@ body.expert-mode details.expert-only { display: block !important; }
   background: rgba(255,255,255,0.15);
   opacity: 1;
 }
+
+/* ── Training labeling queue ─────────────────────────────────────────────── */
+
+.training-stats-row {
+  display: flex; gap: 0.75rem; margin-bottom: 1rem; flex-wrap: wrap;
+}
+.stat-card {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
+  padding: 0.6rem 1rem; text-align: center; min-width: 80px;
+}
+.stat-value { font-size: 1.4rem; font-weight: 700; }
+.stat-label { font-size: 0.75rem; color: var(--muted); }
+
+.label-viewer {
+  display: grid; grid-template-columns: 1fr 340px; gap: 1.25rem;
+  align-items: start; margin-bottom: 1rem;
+}
+@media (max-width: 900px) {
+  .label-viewer { grid-template-columns: 1fr; }
+}
+.label-frame-wrap {
+  position: relative; line-height: 0; background: #000; border-radius: 6px;
+  overflow: hidden;
+}
+.label-frame-wrap img {
+  width: 100%; height: auto; display: block;
+}
+.label-bbox {
+  position: absolute; border: 2px solid #ff3333; pointer-events: none;
+  display: none;
+}
+
+.label-detail { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 1rem; }
+.label-meta { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; margin-bottom: 0.75rem; }
+.label-class { font-weight: 700; font-size: 1.1rem; }
+.label-conf { font-size: 0.9rem; color: var(--muted); }
+.label-actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
+.label-correct-form { margin-bottom: 0.75rem; }
+.label-stats { font-size: 0.8rem; margin-top: 0.5rem; }
+
+.badge-pass-low { background: var(--warn); color: #000; }
+.badge-pass-normal { background: var(--accent); color: #fff; }
+.badge-review-approved { background: var(--ok); color: #0a1a12; }
+.badge-review-rejected { background: var(--danger); color: #fff; }
+.badge-review-corrected { background: var(--warn); color: #000; }
+
+.btn-small { font-size: 0.78rem; padding: 0.2em 0.6em; }
+.btn-danger { border-color: var(--danger); color: var(--danger); }
+.btn-danger:hover { background: rgba(229,62,62,0.15); }
+
+.kbd-legend {
+  font-size: 0.8rem; color: var(--muted); margin-top: 0.5rem;
+  padding: 0.5rem 0; border-top: 1px solid var(--border);
+}
+kbd {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 3px;
+  padding: 0.1em 0.4em; font-family: inherit; font-size: 0.85em;
+}

--- a/services/web/src/static/training_label.js
+++ b/services/web/src/static/training_label.js
@@ -1,0 +1,90 @@
+/* Labeling queue: bbox overlay, keyboard shortcuts, auto-advance. */
+(function () {
+  "use strict";
+
+  function renderBbox() {
+    var detail = document.getElementById("label-detail");
+    var box = document.getElementById("label-bbox");
+    if (!detail || !box) return;
+    var raw = detail.dataset.bbox;
+    if (!raw || raw === "[]") { box.style.display = "none"; return; }
+    try {
+      var bbox = JSON.parse(raw);
+      if (bbox.length < 4) { box.style.display = "none"; return; }
+      var xc = bbox[0], yc = bbox[1], w = bbox[2], h = bbox[3];
+      box.style.left = ((xc - w / 2) * 100) + "%";
+      box.style.top = ((yc - h / 2) * 100) + "%";
+      box.style.width = (w * 100) + "%";
+      box.style.height = (h * 100) + "%";
+      box.style.display = "block";
+    } catch (e) {
+      box.style.display = "none";
+    }
+  }
+
+  function updateFrame() {
+    var detail = document.getElementById("label-detail");
+    var img = document.getElementById("label-frame");
+    if (!detail || !img) return;
+    var frameIdx = detail.dataset.frameIdx;
+    if (frameIdx !== undefined && frameIdx !== "") {
+      img.src = "/admin/training/uploads/" + _labelData.uploadId + "/frames/" + frameIdx;
+    }
+  }
+
+  function navigateEvent(direction) {
+    var detail = document.getElementById("label-detail");
+    if (!detail) return;
+    var targetId = direction === "next" ? detail.dataset.nextId : detail.dataset.prevId;
+    if (!targetId) return;
+    var qs = "?event_id=" + targetId;
+    if (_labelData.filterReviewState) qs += "&review_state=" + encodeURIComponent(_labelData.filterReviewState);
+    if (_labelData.filterDetectionPass) qs += "&detection_pass=" + encodeURIComponent(_labelData.filterDetectionPass);
+    window.location.href = "/admin/training/uploads/" + _labelData.uploadId + qs;
+  }
+
+  document.addEventListener("keydown", function (e) {
+    var tag = (e.target.tagName || "").toUpperCase();
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+
+    switch (e.key) {
+      case "a":
+        var btn = document.getElementById("btn-approve");
+        if (btn) btn.click();
+        break;
+      case "x":
+        var btnR = document.getElementById("btn-reject");
+        if (btnR) btnR.click();
+        break;
+      case "c":
+        var btnC = document.getElementById("btn-show-correct");
+        if (btnC) btnC.click();
+        break;
+      case "j":
+      case "ArrowRight":
+        e.preventDefault();
+        navigateEvent("next");
+        break;
+      case "k":
+      case "ArrowLeft":
+        e.preventDefault();
+        navigateEvent("prev");
+        break;
+    }
+  });
+
+  /* After HTMX swaps the label card, re-render bbox and update frame. */
+  document.addEventListener("htmx:afterSettle", function (e) {
+    if (e.detail.target && e.detail.target.id === "label-card") {
+      renderBbox();
+      updateFrame();
+      var detail = document.getElementById("label-detail");
+      if (detail && detail.dataset.autoAdvance === "1" && detail.dataset.eventId) {
+        /* Auto-advanced: already showing the next event */
+      }
+    }
+  });
+
+  /* Initial render */
+  renderBbox();
+})();

--- a/services/web/src/templates/base.html
+++ b/services/web/src/templates/base.html
@@ -35,6 +35,7 @@
           {% if _is_admin %}<a href="/admin/audit-log">Audit Log</a>{% endif %}
           <a href="/admin/deterrent">Deterrent</a>
           <a href="/admin/training">Training Data</a>
+          <a href="/admin/training/uploads">Uploads</a>
           <a href="/admin/training/evaluate">Model Evaluation</a>
           <a href="/admin/backups">Config Backups</a>
         </div>

--- a/services/web/src/templates/partials/training_label_card.html
+++ b/services/web/src/templates/partials/training_label_card.html
@@ -1,0 +1,66 @@
+<div class="label-detail"
+     id="label-detail"
+     data-event-id="{{ event.id if event else '' }}"
+     data-frame-idx="{{ event.frame_idx if event else '' }}"
+     data-bbox="{{ event.bbox if event else '[]' }}"
+     data-next-id="{{ next_event.id if next_event else '' }}"
+     data-prev-id="{{ prev_event.id if prev_event else '' }}"
+     {% if auto_advance is defined and auto_advance %}data-auto-advance="1"{% endif %}>
+
+  {% if event %}
+  <div class="label-meta">
+    <span class="badge badge-pass-{{ event.detection_pass }}">{{ event.detection_pass }}</span>
+    <span class="label-class">{{ event.predicted_class }}</span>
+    <span class="label-conf">{{ "%.1f" | format(event.confidence * 100) }}%</span>
+    <span class="muted">Frame {{ event.frame_idx }}</span>
+    {% if event.review_state != 'pending' %}
+    <span class="badge badge-review-{{ event.review_state }}">{{ event.review_state }}{% if event.corrected_class %}: {{ event.corrected_class }}{% endif %}</span>
+    {% endif %}
+  </div>
+
+  {% if _is_admin %}
+  <div class="label-actions">
+    <button id="btn-approve" class="btn btn-correct"
+            hx-post="/admin/training/uploads/{{ upload.id }}/events/{{ event.id }}/review?review_state={{ filter_review_state }}&amp;detection_pass={{ filter_detection_pass }}"
+            hx-vals='{"action": "approved", "_csrf_token": "{{ request.state.csrf_token }}"}'
+            hx-target="#label-card"
+            hx-swap="innerHTML">Approve</button>
+    <button id="btn-reject" class="btn btn-fp"
+            hx-post="/admin/training/uploads/{{ upload.id }}/events/{{ event.id }}/review?review_state={{ filter_review_state }}&amp;detection_pass={{ filter_detection_pass }}"
+            hx-vals='{"action": "rejected", "_csrf_token": "{{ request.state.csrf_token }}"}'
+            hx-target="#label-card"
+            hx-swap="innerHTML">Reject</button>
+    <button id="btn-show-correct" class="btn btn-wrong" onclick="document.getElementById('correct-form').style.display='block';document.getElementById('corrected-class').focus();">Correct</button>
+  </div>
+
+  <div id="correct-form" class="label-correct-form" style="display:none;">
+    <form hx-post="/admin/training/uploads/{{ upload.id }}/events/{{ event.id }}/review?review_state={{ filter_review_state }}&amp;detection_pass={{ filter_detection_pass }}"
+          hx-target="#label-card"
+          hx-swap="innerHTML">
+      <input type="hidden" name="_csrf_token" value="{{ request.state.csrf_token }}">
+      <input type="hidden" name="action" value="corrected">
+      <div class="field-group">
+        <label>Corrected class</label>
+        <input id="corrected-class" type="text" name="corrected_class" list="class-options"
+               value="{{ upload.target_class_hint if upload.target_class_hint and upload.target_class_hint != 'background' else '' }}"
+               required autocomplete="off">
+        <datalist id="class-options">
+          {% for cls in target_classes %}<option value="{{ cls }}">{% endfor %}
+        </datalist>
+      </div>
+      <button type="submit" class="btn">Submit Correction</button>
+    </form>
+  </div>
+  {% endif %}
+
+  <div class="label-stats muted">
+    {{ stats.pending }} pending &middot;
+    {{ stats.approved }} approved &middot;
+    {{ stats.rejected }} rejected &middot;
+    {{ stats.corrected }} corrected
+  </div>
+
+  {% else %}
+  <div class="muted" style="padding:1rem;">No more detections to review.</div>
+  {% endif %}
+</div>

--- a/services/web/src/templates/partials/training_upload_rows.html
+++ b/services/web/src/templates/partials/training_upload_rows.html
@@ -1,0 +1,30 @@
+{% for u in uploads %}
+<tr>
+  <td>{{ u.filename }}</td>
+  <td>{% if u.target_class_hint %}<span class="badge">{{ u.target_class_hint }}</span>{% else %}<span class="muted">—</span>{% endif %}</td>
+  <td>{{ u.frame_count if u.frame_count is not none else '—' }}</td>
+  <td>{{ u.detection_count if u.detection_count is not none else '—' }}</td>
+  <td>
+    {% if u.status == 'processed' %}<span class="badge badge-armed">{{ u.status }}</span>
+    {% elif u.status == 'failed' %}<span class="badge badge-disarmed">{{ u.status }}</span>
+    {% elif u.status == 'processing' %}<span class="badge" style="background:var(--warn);color:#000;">{{ u.status }}</span>
+    {% else %}<span class="badge">{{ u.status }}</span>
+    {% endif %}
+  </td>
+  <td>{{ u.created_at[:16] }}</td>
+  <td>
+    {% if u.status == 'processed' %}
+    <a href="/admin/training/uploads/{{ u.id }}" class="btn btn-small">Label</a>
+    {% endif %}
+    {% if _is_admin %}
+    <form method="post" action="/admin/training/uploads/{{ u.id }}/delete" style="display:inline;">
+      <input type="hidden" name="_csrf_token" value="{{ request.state.csrf_token }}">
+      <button type="submit" class="btn btn-small btn-danger" onclick="return confirm('Delete this upload and all its annotations?')">Delete</button>
+    </form>
+    {% endif %}
+  </td>
+</tr>
+{% endfor %}
+{% if not uploads %}
+<tr><td colspan="7" class="muted" style="text-align:center;padding:2rem;">No uploads yet</td></tr>
+{% endif %}

--- a/services/web/src/templates/training_label.html
+++ b/services/web/src/templates/training_label.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Label: {{ upload.filename }}
+  {% if upload.target_class_hint %}<span class="badge">{{ upload.target_class_hint }}</span>{% endif %}
+</h1>
+
+<div class="training-stats-row">
+  <div class="stat-card"><div class="stat-value">{{ stats.pending }}</div><div class="stat-label">Pending</div></div>
+  <div class="stat-card"><div class="stat-value">{{ stats.approved }}</div><div class="stat-label">Approved</div></div>
+  <div class="stat-card"><div class="stat-value">{{ stats.rejected }}</div><div class="stat-label">Rejected</div></div>
+  <div class="stat-card"><div class="stat-value">{{ stats.corrected }}</div><div class="stat-label">Corrected</div></div>
+  <div class="stat-card"><div class="stat-value">{{ stats.total }}</div><div class="stat-label">Total</div></div>
+</div>
+
+{% if upload.target_class_hint == 'background' %}
+<div class="alert alert-warn">Background upload — sampled frames will be exported as negative samples. Review detections below to reject false alarms.</div>
+{% endif %}
+
+{% if _is_admin %}
+<div class="card" style="display:flex;gap:0.5rem;align-items:center;">
+  <form method="post" action="/admin/training/uploads/{{ upload.id }}/bulk-review" style="display:inline;">
+    <input type="hidden" name="_csrf_token" value="{{ request.state.csrf_token }}">
+    <input type="hidden" name="action" value="approved">
+    <input type="hidden" name="filter_pass" value="normal">
+    <button type="submit" class="btn" onclick="return confirm('Approve all normal-confidence pending detections?')">Approve All Normal</button>
+  </form>
+  <form method="post" action="/admin/training/uploads/{{ upload.id }}/bulk-review" style="display:inline;">
+    <input type="hidden" name="_csrf_token" value="{{ request.state.csrf_token }}">
+    <input type="hidden" name="action" value="rejected">
+    <button type="submit" class="btn btn-danger" onclick="return confirm('Reject all pending detections?')">Reject All Pending</button>
+  </form>
+  <span class="muted" style="margin-left:auto;">
+    <a href="/admin/training/uploads/{{ upload.id }}?review_state=pending">Pending only</a> |
+    <a href="/admin/training/uploads/{{ upload.id }}?detection_pass=low">Low-conf only</a> |
+    <a href="/admin/training/uploads/{{ upload.id }}">All</a>
+  </span>
+</div>
+{% endif %}
+
+{% if event %}
+<div class="label-viewer">
+  <div class="label-frame-wrap">
+    <img id="label-frame"
+         src="/admin/training/uploads/{{ upload.id }}/frames/{{ event.frame_idx }}"
+         alt="Frame {{ event.frame_idx }}">
+    <div id="label-bbox" class="label-bbox"></div>
+  </div>
+  <div id="label-card">
+    {% include "partials/training_label_card.html" %}
+  </div>
+</div>
+
+<div class="kbd-legend">
+  <kbd>a</kbd> Approve &nbsp;
+  <kbd>x</kbd> Reject &nbsp;
+  <kbd>c</kbd> Correct &nbsp;
+  <kbd>j</kbd> / <kbd>&rarr;</kbd> Next &nbsp;
+  <kbd>k</kbd> / <kbd>&larr;</kbd> Prev
+</div>
+{% else %}
+<div class="card" style="text-align:center;padding:3rem;">
+  <p class="muted">No detections to review{% if filter_review_state or filter_detection_pass %} with current filters{% endif %}.</p>
+  {% if filter_review_state or filter_detection_pass %}
+  <a href="/admin/training/uploads/{{ upload.id }}" class="btn">Clear filters</a>
+  {% endif %}
+</div>
+{% endif %}
+
+<script>
+  var _labelData = {
+    uploadId: {{ upload.id | tojson }},
+    csrfToken: {{ request.state.csrf_token | tojson }},
+    filterReviewState: {{ filter_review_state | tojson }},
+    filterDetectionPass: {{ filter_detection_pass | tojson }},
+    targetClasses: {{ target_classes | tojson }}
+  };
+</script>
+<script src="/static/training_label.js"></script>
+{% endblock %}

--- a/services/web/src/templates/training_uploads.html
+++ b/services/web/src/templates/training_uploads.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Training Uploads <span class="muted">({{ total }})</span></h1>
+
+{% if error %}
+<div class="alert alert-err">{{ error }}</div>
+{% endif %}
+
+{% if _is_admin %}
+<section class="card">
+  <h2>Upload Video</h2>
+  <form method="post" action="/admin/training/uploads" enctype="multipart/form-data">
+    <input type="hidden" name="_csrf_token" value="{{ request.state.csrf_token }}">
+    <div class="field-row">
+      <div class="field-group">
+        <label>Video file <span class="muted">(max 60s, mp4/avi/mkv/mov)</span></label>
+        <input type="file" name="file" accept=".mp4,.avi,.mkv,.mov" required>
+      </div>
+      <div class="field-group">
+        <label>Target class hint</label>
+        <select name="target_class_hint">
+          <option value="">None</option>
+          <option value="duck">Duck</option>
+          <option value="heron">Heron</option>
+          <option value="raccoon">Raccoon</option>
+          <option value="background">Background (empty/negative)</option>
+        </select>
+      </div>
+    </div>
+    <button type="submit" class="btn">Upload</button>
+  </form>
+</section>
+{% endif %}
+
+<form method="get" action="/admin/training/uploads" class="filter-form">
+  <div class="filter-row">
+    <label>
+      Status
+      <select name="status">
+        <option value="">All</option>
+        <option value="uploaded" {% if filter_status == 'uploaded' %}selected{% endif %}>Uploaded</option>
+        <option value="processing" {% if filter_status == 'processing' %}selected{% endif %}>Processing</option>
+        <option value="processed" {% if filter_status == 'processed' %}selected{% endif %}>Processed</option>
+        <option value="failed" {% if filter_status == 'failed' %}selected{% endif %}>Failed</option>
+      </select>
+    </label>
+    <button type="submit" class="btn">Filter</button>
+    {% if filter_status %}
+    <a href="/admin/training/uploads" class="btn-secondary">Clear</a>
+    {% endif %}
+  </div>
+</form>
+
+<table>
+  <thead>
+    <tr>
+      <th>Filename</th>
+      <th>Hint</th>
+      <th>Frames</th>
+      <th>Detections</th>
+      <th>Status</th>
+      <th>Created</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% include "partials/training_upload_rows.html" %}
+  </tbody>
+</table>
+
+{% if total_pages > 1 %}
+<nav class="pagination">
+  {% if page > 1 %}
+  <a href="/admin/training/uploads?page={{ page - 1 }}&amp;status={{ filter_status | urlencode }}">&laquo; Newer</a>
+  {% endif %}
+  <span>Page {{ page }} / {{ total_pages }}</span>
+  {% if page < total_pages %}
+  <a href="/admin/training/uploads?page={{ page + 1 }}&amp;status={{ filter_status | urlencode }}">Older &raquo;</a>
+  {% endif %}
+</nav>
+{% endif %}
+{% endblock %}

--- a/training/prepare_dataset.py
+++ b/training/prepare_dataset.py
@@ -1,0 +1,860 @@
+#!/usr/bin/env python3
+"""Prepare a merged YOLO dataset for ScarGuard model training.
+
+Pulls labeled data from the Orin via SSH + docker cp, downloads
+Roboflow Universe datasets and Open Images V6 annotations, remaps
+all class indices to a unified scheme, and writes a single
+YOLO-format dataset with a train/val split.
+
+Prerequisites:
+    pip install roboflow pyyaml requests
+
+Usage:
+    python prepare_dataset.py \
+        --orin-host scott@orin \
+        --roboflow-key YOUR_KEY \
+        --output ./merged_dataset
+
+    # Then train:
+    python train.py --data ./merged_dataset/data.yaml --output pond_v1.pt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import NamedTuple
+
+UNIFIED_CLASSES = ["duck", "heron", "raccoon"]
+
+CLASS_MAP: dict[str, str] = {
+    "great_blue_heron": "heron",
+    "green_heron": "heron",
+    "blue_heron": "heron",
+    "heron": "heron",
+    "duck": "duck",
+    "mallard": "duck",
+    "raccoon": "raccoon",
+    "raccon": "raccoon",
+}
+
+ROBOFLOW_DATASETS = [
+    ("louis-berndroth2-gmail-com", "heron-detection"),
+    ("harbin-institute-of-technology-hpsg8", "raccon-3osqx"),
+]
+
+OID_CLASSES: dict[str, str] = {
+    "/m/09ddx": "duck",
+    "/m/0dq75": "raccoon",
+}
+
+OID_ANNOTATIONS = {
+    "train": "https://storage.googleapis.com/openimages/v6/oidv6-train-annotations-bbox.csv",
+    "validation": "https://storage.googleapis.com/openimages/2018_04/validation/validation-annotations-bbox.csv",
+    "test": "https://storage.googleapis.com/openimages/2018_04/test/test-annotations-bbox.csv",
+}
+
+OID_IMAGE_BASE = "https://open-images-dataset.s3.amazonaws.com"
+
+
+class Sample(NamedTuple):
+    image: Path
+    label_lines: list[str]
+    source: str
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Prepare a merged YOLO dataset for ScarGuard training.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--orin-host", default="scott@orin",
+        help="SSH target for pulling ScarGuard data",
+    )
+    p.add_argument(
+        "--orin-container", default="",
+        help="Web container name on Orin (auto-detected if empty)",
+    )
+    p.add_argument(
+        "--scarguard-zip", default="",
+        help="Pre-downloaded ScarGuard export zip (skips SSH pull)",
+    )
+    p.add_argument(
+        "--roboflow-key", default="",
+        help="Roboflow API key for downloading Universe datasets",
+    )
+    p.add_argument(
+        "--output", default="./merged_dataset",
+        help="Output directory for the merged dataset",
+    )
+    p.add_argument(
+        "--val-split", type=float, default=0.15,
+        help="Fraction of images held out for validation",
+    )
+    p.add_argument("--seed", type=int, default=42, help="Random seed for split")
+    p.add_argument(
+        "--skip-orin", action="store_true",
+        help="Skip pulling from Orin",
+    )
+    p.add_argument(
+        "--skip-roboflow", action="store_true",
+        help="Skip Roboflow downloads",
+    )
+    p.add_argument(
+        "--skip-oid", action="store_true",
+        help="Skip Open Images downloads",
+    )
+    p.add_argument(
+        "--max-oid-per-class", type=int, default=1500,
+        help="Cap Open Images images per class to keep dataset balanced",
+    )
+    p.add_argument(
+        "--oid-workers", type=int, default=16,
+        help="Parallel download threads for Open Images",
+    )
+    p.add_argument(
+        "--local-db", default="",
+        help="Path to local scarguard.db (replaces SSH pull when running on Orin)",
+    )
+    p.add_argument(
+        "--local-snapshots", default="",
+        help="Snapshot directory for local DB mode",
+    )
+    p.add_argument(
+        "--training-uploads-db", default="",
+        help="Path to DB with training_events table (video upload annotations)",
+    )
+    p.add_argument(
+        "--training-uploads-frames", default="",
+        help="Root frames directory for training uploads",
+    )
+    p.add_argument(
+        "--skip-training-uploads", action="store_true",
+        help="Skip training uploads source",
+    )
+    p.add_argument(
+        "--background-sample-interval", type=int, default=10,
+        help="Export every Nth frame from background uploads as negative sample",
+    )
+    return p.parse_args()
+
+
+# ── Class mapping ──────────────────────────────────────────────────────────
+
+
+def _resolve_class(name: str) -> str | None:
+    """Map any source class name to a unified target class."""
+    if name in CLASS_MAP:
+        return CLASS_MAP[name]
+    lower = name.lower().strip().replace(" ", "_")
+    for src, dst in CLASS_MAP.items():
+        if src.lower() == lower:
+            return dst
+    for target in UNIFIED_CLASSES:
+        if target in lower:
+            return target
+    return None
+
+
+# ── SSH helpers ────────────────────────────────────────────────────────────
+
+
+def _ssh(host: str, cmd: str, *, timeout: int = 120) -> str:
+    r = subprocess.run(
+        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host, cmd],
+        capture_output=True, text=True, timeout=timeout,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"SSH failed: {cmd}\n  stderr: {r.stderr.strip()}")
+    return r.stdout.strip()
+
+
+def _scp(src: str, dst: str, *, timeout: int = 300) -> None:
+    subprocess.run(["scp", "-q", src, dst], check=True, timeout=timeout)
+
+
+# ── Orin pull ──────────────────────────────────────────────────────────────
+
+
+def _pull_orin_ssh(host: str, container: str, work_dir: Path) -> list[Sample]:
+    """Pull ScarGuard training data from the Orin via SSH + docker cp."""
+    print(f"\n{'='*60}")
+    print(f"Pulling ScarGuard data from {host}")
+    print("=" * 60)
+
+    if not container:
+        container = _ssh(
+            host, "docker ps --format '{{.Names}}' | grep -i web | head -1",
+        )
+    if not container:
+        print("  ERROR: Could not find web container on Orin", file=sys.stderr)
+        return []
+    print(f"  Container: {container}")
+
+    remote_tmp = "/tmp/_sg_train_export"
+    _ssh(host, f"rm -rf {remote_tmp} && mkdir -p {remote_tmp}")
+
+    _ssh(host, f"docker cp {container}:/data/scarguard.db {remote_tmp}/db.sqlite")
+    local_db = work_dir / "scarguard.db"
+    _scp(f"{host}:{remote_tmp}/db.sqlite", str(local_db))
+    print(f"  Database: {local_db.stat().st_size / 1_048_576:.1f} MB")
+
+    conn = sqlite3.connect(str(local_db))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute("""
+        SELECT id, class_name, snapshot_path, bbox, frame_size,
+               feedback, corrected_class
+        FROM detection_events
+        WHERE camera_name != '_system'
+          AND feedback IN ('correct', 'wrong_class', 'false_positive')
+          AND snapshot_path IS NOT NULL
+          AND (feedback = 'false_positive' OR bbox IS NOT NULL)
+        ORDER BY id
+    """).fetchall()
+    conn.close()
+
+    if not rows:
+        print("  No exportable events found")
+        _ssh(host, f"rm -rf {remote_tmp}")
+        return []
+    print(f"  {len(rows)} exportable events")
+
+    snap_names = sorted({Path(r["snapshot_path"]).name for r in rows})
+    print(f"  Transferring {len(snap_names)} snapshots...")
+
+    listing = "\n".join(snap_names)
+    _ssh(host, f"cat > {remote_tmp}/needed.txt << 'SNAPEOF'\n{listing}\nSNAPEOF")
+    _ssh(
+        host,
+        f"docker cp {container}:/data/snapshots {remote_tmp}/snapshots",
+        timeout=300,
+    )
+
+    snap_dir = work_dir / "snapshots"
+    snap_dir.mkdir()
+    result = subprocess.run(
+        [
+            "ssh", "-o", "BatchMode=yes", host,
+            f"cd {remote_tmp}/snapshots && tar cf - -T {remote_tmp}/needed.txt 2>/dev/null",
+        ],
+        capture_output=True, timeout=600,
+    )
+    if result.stdout:
+        tar_path = work_dir / "snapshots.tar"
+        tar_path.write_bytes(result.stdout)
+        subprocess.run(
+            ["tar", "xf", str(tar_path), "-C", str(snap_dir)],
+            check=True, capture_output=True,
+        )
+        print(f"  Snapshots: {tar_path.stat().st_size / 1_048_576:.1f} MB")
+    else:
+        print("  WARNING: tar produced no output — snapshot transfer may have failed")
+
+    _ssh(host, f"rm -rf {remote_tmp}")
+    return _rows_to_samples(rows, snap_dir)
+
+
+def _pull_orin_zip(zip_path: Path, work_dir: Path) -> list[Sample]:
+    """Build samples from a pre-downloaded ScarGuard export zip."""
+    import zipfile
+
+    import yaml
+
+    print(f"\n{'='*60}")
+    print(f"Loading ScarGuard export from {zip_path}")
+    print("=" * 60)
+
+    dest = work_dir / "sg_zip"
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(dest)
+
+    ds_dir = dest / "dataset" if (dest / "dataset").exists() else dest
+    data_yaml = ds_dir / "data.yaml"
+    if not data_yaml.exists():
+        print("  ERROR: No data.yaml in zip", file=sys.stderr)
+        return []
+
+    with open(data_yaml) as f:
+        dy = yaml.safe_load(f)
+    src_classes: list[str] = dy.get("names", [])
+    if isinstance(src_classes, dict):
+        src_classes = [src_classes[k] for k in sorted(src_classes.keys())]
+    print(f"  Source classes: {src_classes}")
+
+    remap = _build_remap(src_classes)
+    return _dir_to_samples(ds_dir, remap, source="scarguard")
+
+
+def _rows_to_samples(rows: list[sqlite3.Row], snap_dir: Path) -> list[Sample]:
+    """Convert database rows + snapshot files into Sample objects."""
+    samples: list[Sample] = []
+    skipped = 0
+
+    for r in rows:
+        row = dict(r)
+        snap_name = Path(row["snapshot_path"]).name
+        img = snap_dir / snap_name
+        if not img.exists():
+            skipped += 1
+            continue
+
+        if row["feedback"] == "false_positive":
+            samples.append(Sample(image=img, label_lines=[], source="scarguard"))
+            continue
+
+        eff_class = (
+            row["corrected_class"]
+            if row["feedback"] == "wrong_class" and row.get("corrected_class")
+            else row["class_name"]
+        )
+        target = _resolve_class(eff_class)
+        if target is None:
+            print(f"    WARNING: Unmapped class '{eff_class}' in event {row['id']}")
+            skipped += 1
+            continue
+
+        cls_idx = UNIFIED_CLASSES.index(target)
+        bbox = json.loads(row["bbox"]) if isinstance(row["bbox"], str) else row["bbox"]
+        fsize = (
+            json.loads(row["frame_size"])
+            if isinstance(row["frame_size"], str)
+            else row["frame_size"]
+        )
+        x1, y1, x2, y2 = bbox
+        fw, fh = fsize
+        line = (
+            f"{cls_idx} "
+            f"{((x1 + x2) / 2) / fw:.6f} "
+            f"{((y1 + y2) / 2) / fh:.6f} "
+            f"{(x2 - x1) / fw:.6f} "
+            f"{(y2 - y1) / fh:.6f}"
+        )
+        samples.append(Sample(image=img, label_lines=[line], source="scarguard"))
+
+    print(f"  {len(samples)} samples ({skipped} skipped)")
+    return samples
+
+
+# ── Local DB pull (replaces SSH when running on-Orin) ──────────────────────
+
+
+_ORIN_LABELED_QUERY = """
+    SELECT id, class_name, snapshot_path, bbox, frame_size,
+           feedback, corrected_class
+    FROM detection_events
+    WHERE camera_name != '_system'
+      AND feedback IN ('correct', 'wrong_class', 'false_positive')
+      AND snapshot_path IS NOT NULL
+      AND (feedback = 'false_positive' OR bbox IS NOT NULL)
+    ORDER BY id
+"""
+
+
+def _pull_orin_local(db_path: str, snapshots_dir: str) -> list[Sample]:
+    """Read detection_events directly from a local SQLite DB."""
+    print(f"\n── Local DB: {db_path} ──")
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(_ORIN_LABELED_QUERY).fetchall()
+    finally:
+        conn.close()
+    print(f"  {len(rows)} labeled events")
+    return _rows_to_samples(rows, Path(snapshots_dir))
+
+
+# ── Training uploads pull (video upload annotations) ──────────────────────
+
+
+def pull_training_uploads(
+    db_path: str,
+    frames_dir: str,
+    background_sample_interval: int = 10,
+) -> list[Sample]:
+    """Fourth source: approved annotations from video uploads."""
+    print(f"\n── Training uploads: {db_path} ──")
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        events = conn.execute("""
+            SELECT te.id, te.upload_id, te.frame_idx, te.bbox,
+                   te.predicted_class, te.confidence, te.review_state,
+                   te.corrected_class, tu.target_class_hint
+            FROM training_events te
+            JOIN training_uploads tu ON te.upload_id = tu.id
+            WHERE te.review_state IN ('approved', 'corrected')
+            ORDER BY te.upload_id, te.frame_idx
+        """).fetchall()
+        bg_uploads = conn.execute("""
+            SELECT id, frame_count FROM training_uploads
+            WHERE target_class_hint = 'background'
+              AND status = 'processed'
+        """).fetchall()
+    finally:
+        conn.close()
+
+    samples: list[Sample] = []
+    skipped = 0
+
+    # Positive samples: group by (upload_id, frame_idx) for multi-detection labels
+    from collections import defaultdict
+    frame_labels: dict[tuple[str, int], list[str]] = defaultdict(list)
+    frame_paths: dict[tuple[str, int], Path] = {}
+
+    for r in events:
+        row = dict(r)
+        cls = row["corrected_class"] if row["review_state"] == "corrected" and row.get("corrected_class") else row["predicted_class"]
+        target = _resolve_class(cls)
+        if target is None:
+            print(f"    WARNING: Unmapped class '{cls}' in training_event {row['id']}")
+            skipped += 1
+            continue
+
+        cls_idx = UNIFIED_CLASSES.index(target)
+        bbox = json.loads(row["bbox"]) if isinstance(row["bbox"], str) else row["bbox"]
+        line = f"{cls_idx} {bbox[0]:.6f} {bbox[1]:.6f} {bbox[2]:.6f} {bbox[3]:.6f}"
+        key = (row["upload_id"], row["frame_idx"])
+        frame_labels[key].append(line)
+        frame_paths[key] = Path(frames_dir) / row["upload_id"] / "frames" / f"{row['frame_idx']:06d}.jpg"
+
+    for key, lines in frame_labels.items():
+        img = frame_paths[key]
+        if img.exists():
+            samples.append(Sample(image=img, label_lines=lines, source="training_uploads"))
+        else:
+            skipped += 1
+
+    # Background samples: every Nth frame from background uploads
+    bg_count = 0
+    for upload in bg_uploads:
+        upload_frames = Path(frames_dir) / upload["id"] / "frames"
+        if not upload_frames.exists():
+            continue
+        fc = upload["frame_count"] or 0
+        for i in range(0, fc, max(1, background_sample_interval)):
+            fp = upload_frames / f"{i:06d}.jpg"
+            if fp.exists():
+                samples.append(Sample(image=fp, label_lines=[], source="training_uploads"))
+                bg_count += 1
+
+    print(f"  {len(samples)} samples ({skipped} skipped, {bg_count} background)")
+    return samples
+
+
+# ── Roboflow pull ──────────────────────────────────────────────────────────
+
+
+def pull_roboflow(api_key: str, work_dir: Path) -> list[Sample]:
+    """Download Roboflow Universe datasets and return remapped samples."""
+    try:
+        from roboflow import Roboflow
+    except ImportError:
+        print("ERROR: pip install roboflow", file=sys.stderr)
+        sys.exit(1)
+
+    import yaml
+
+    print(f"\n{'='*60}")
+    print("Downloading Roboflow datasets")
+    print("=" * 60)
+
+    rf = Roboflow(api_key=api_key)
+    all_samples: list[Sample] = []
+
+    for ws_name, proj_name in ROBOFLOW_DATASETS:
+        tag = f"{ws_name}/{proj_name}"
+        print(f"\n  [{tag}]")
+        try:
+            project = rf.project(tag)
+            version = _latest_version(project)
+            if version is None:
+                print("    No versions available, skipping")
+                continue
+
+            dl_dir = work_dir / "roboflow" / proj_name
+            version.download("yolov8", location=str(dl_dir))
+
+            data_yaml = dl_dir / "data.yaml"
+            if not data_yaml.exists():
+                print("    WARNING: No data.yaml, skipping")
+                continue
+
+            with open(data_yaml) as f:
+                dy = yaml.safe_load(f)
+            src_classes: list[str] = dy.get("names", [])
+            if isinstance(src_classes, dict):
+                src_classes = [src_classes[k] for k in sorted(src_classes.keys())]
+            print(f"    Classes: {src_classes}")
+
+            remap = _build_remap(src_classes)
+            samples = _dir_to_samples(dl_dir, remap, source=proj_name)
+            all_samples.extend(samples)
+            print(f"    {len(samples)} samples")
+
+        except Exception as e:
+            print(f"    ERROR: {e}")
+
+    return all_samples
+
+
+def _latest_version(project: object) -> object | None:
+    """Return the latest version of a Roboflow project."""
+    try:
+        versions = project.versions()  # type: ignore[union-attr]
+        return versions[0] if versions else None
+    except Exception:
+        pass
+    for n in range(10, 0, -1):
+        try:
+            return project.version(n)  # type: ignore[union-attr]
+        except Exception:
+            continue
+    return None
+
+
+# ── Open Images pull ──────────────────────────────────────────────────────
+
+
+def pull_open_images(
+    work_dir: Path,
+    max_per_class: int,
+    workers: int,
+) -> list[Sample]:
+    """Download duck + raccoon images from Open Images V6."""
+    import requests
+
+    print(f"\n{'='*60}")
+    print("Downloading Open Images (duck + raccoon)")
+    print("=" * 60)
+
+    # Collect annotations: {image_id: {split, class, bboxes[]}}
+    image_data: dict[str, dict] = {}
+    class_image_counts: dict[str, int] = {cls: 0 for cls in OID_CLASSES.values()}
+
+    for split, url in OID_ANNOTATIONS.items():
+        print(f"\n  Scanning {split} annotations...")
+        try:
+            resp = requests.get(url, stream=True, timeout=30)
+            resp.raise_for_status()
+        except Exception as e:
+            print(f"    ERROR downloading annotations: {e}")
+            continue
+
+        lines_iter = resp.iter_lines(decode_unicode=True)
+        header_line = next(lines_iter)
+        cols = header_line.split(",")
+        img_col = cols.index("ImageID")
+        label_col = cols.index("LabelName")
+        xmin_col = cols.index("XMin")
+        xmax_col = cols.index("XMax")
+        ymin_col = cols.index("YMin")
+        ymax_col = cols.index("YMax")
+
+        row_count = 0
+        for line in lines_iter:
+            parts = line.split(",")
+            label = parts[label_col]
+            if label not in OID_CLASSES:
+                row_count += 1
+                continue
+
+            target_cls = OID_CLASSES[label]
+            img_id = parts[img_col]
+
+            if img_id not in image_data:
+                if class_image_counts[target_cls] >= max_per_class:
+                    row_count += 1
+                    continue
+                class_image_counts[target_cls] += 1
+                image_data[img_id] = {
+                    "split": split,
+                    "bboxes": [],
+                }
+
+            image_data[img_id]["bboxes"].append({
+                "class": target_cls,
+                "xmin": float(parts[xmin_col]),
+                "xmax": float(parts[xmax_col]),
+                "ymin": float(parts[ymin_col]),
+                "ymax": float(parts[ymax_col]),
+            })
+            row_count += 1
+            if row_count % 5_000_000 == 0:
+                print(
+                    f"    ...{row_count / 1e6:.0f}M rows  "
+                    f"duck={class_image_counts['duck']}  "
+                    f"raccoon={class_image_counts['raccoon']}",
+                )
+
+            # Stop scanning if we have enough of everything
+            if all(c >= max_per_class for c in class_image_counts.values()):
+                break
+
+        for cls, cnt in sorted(class_image_counts.items()):
+            print(f"    {cls}: {cnt} images so far")
+
+    if not image_data:
+        print("  No images found")
+        return []
+
+    # Download images in parallel
+    img_dir = work_dir / "oid_images"
+    img_dir.mkdir(parents=True, exist_ok=True)
+
+    image_ids = list(image_data.keys())
+    print(f"\n  Downloading {len(image_ids)} images ({workers} threads)...")
+
+    def _download_one(img_id: str) -> bool:
+        split = image_data[img_id]["split"]
+        url = f"{OID_IMAGE_BASE}/{split}/{img_id}.jpg"
+        dest = img_dir / f"{img_id}.jpg"
+        try:
+            r = requests.get(url, timeout=30)
+            if r.status_code == 200 and len(r.content) > 1000:
+                dest.write_bytes(r.content)
+                return True
+        except Exception:
+            pass
+        return False
+
+    downloaded = 0
+    failed = 0
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(_download_one, iid): iid for iid in image_ids}
+        for i, future in enumerate(as_completed(futures), 1):
+            if future.result():
+                downloaded += 1
+            else:
+                failed += 1
+            if i % 200 == 0:
+                print(f"    ...{i}/{len(image_ids)} ({downloaded} ok, {failed} failed)")
+
+    print(f"  Downloaded {downloaded}/{len(image_ids)} images ({failed} failed)")
+
+    # Build samples with YOLO-format labels
+    samples: list[Sample] = []
+    for img_id, data in image_data.items():
+        img_path = img_dir / f"{img_id}.jpg"
+        if not img_path.exists():
+            continue
+
+        lines: list[str] = []
+        for bbox in data["bboxes"]:
+            cls_idx = UNIFIED_CLASSES.index(bbox["class"])
+            xmin, xmax = bbox["xmin"], bbox["xmax"]
+            ymin, ymax = bbox["ymin"], bbox["ymax"]
+            x_center = (xmin + xmax) / 2
+            y_center = (ymin + ymax) / 2
+            width = xmax - xmin
+            height = ymax - ymin
+            lines.append(
+                f"{cls_idx} {x_center:.6f} {y_center:.6f} {width:.6f} {height:.6f}"
+            )
+        samples.append(Sample(image=img_path, label_lines=lines, source="open-images"))
+
+    print(f"  {len(samples)} samples ready")
+    return samples
+
+
+# ── Dataset I/O helpers ───────────────────────────────────────────────────
+
+
+def _build_remap(src_classes: list[str]) -> dict[int, int]:
+    """Build source-index -> unified-index mapping."""
+    remap: dict[int, int] = {}
+    for src_idx, name in enumerate(src_classes):
+        target = _resolve_class(name)
+        if target is not None:
+            remap[src_idx] = UNIFIED_CLASSES.index(target)
+        else:
+            print(f"    WARNING: Unmapped class '{name}' (annotations dropped)")
+    return remap
+
+
+def _dir_to_samples(
+    ds_dir: Path,
+    remap: dict[int, int],
+    source: str,
+) -> list[Sample]:
+    """Read a YOLO dataset directory and return remapped samples.
+
+    Handles both layouts:
+      - Standard: images/train, labels/train
+      - Roboflow: train/images, train/labels
+    """
+    samples: list[Sample] = []
+
+    for split in ("train", "valid", "val", "test"):
+        for img_dir, lbl_dir in [
+            (ds_dir / split / "images", ds_dir / split / "labels"),
+            (ds_dir / "images" / split, ds_dir / "labels" / split),
+        ]:
+            if not img_dir.exists():
+                continue
+            for img in sorted(img_dir.iterdir()):
+                if img.suffix.lower() not in (".jpg", ".jpeg", ".png"):
+                    continue
+                lbl = lbl_dir / f"{img.stem}.txt"
+                lines: list[str] = []
+                if lbl.exists():
+                    for raw in lbl.read_text().strip().splitlines():
+                        parts = raw.strip().split()
+                        if not parts:
+                            continue
+                        src_idx = int(parts[0])
+                        if src_idx in remap:
+                            parts[0] = str(remap[src_idx])
+                            lines.append(" ".join(parts))
+                samples.append(Sample(image=img, label_lines=lines, source=source))
+            break
+
+    return samples
+
+
+# ── Merge + split ─────────────────────────────────────────────────────────
+
+
+def merge_and_split(
+    samples: list[Sample],
+    output_dir: Path,
+    val_split: float,
+    seed: int,
+) -> None:
+    """Write a unified YOLO dataset with a randomised train/val split."""
+    print(f"\n{'='*60}")
+    print(f"Merging {len(samples)} samples")
+    print("=" * 60)
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    for sub in ("images/train", "images/val", "labels/train", "labels/val"):
+        (output_dir / sub).mkdir(parents=True)
+
+    rng = random.Random(seed)
+    indices = list(range(len(samples)))
+    rng.shuffle(indices)
+    n_val = max(1, int(len(samples) * val_split))
+    val_set = set(indices[:n_val])
+
+    source_counts: dict[str, int] = {}
+    class_counts: dict[str, int] = {}
+    n_background = 0
+    seen_stems: set[str] = set()
+
+    for i, sample in enumerate(samples):
+        split = "val" if i in val_set else "train"
+
+        stem = f"{sample.source}_{sample.image.stem}"
+        if stem in seen_stems:
+            n = 2
+            while f"{stem}_{n}" in seen_stems:
+                n += 1
+            stem = f"{stem}_{n}"
+        seen_stems.add(stem)
+
+        ext = sample.image.suffix
+        shutil.copy2(
+            str(sample.image),
+            str(output_dir / "images" / split / f"{stem}{ext}"),
+        )
+
+        content = "\n".join(sample.label_lines) + "\n" if sample.label_lines else ""
+        (output_dir / "labels" / split / f"{stem}.txt").write_text(content)
+
+        source_counts[sample.source] = source_counts.get(sample.source, 0) + 1
+        if sample.label_lines:
+            for line in sample.label_lines:
+                cls_idx = int(line.split()[0])
+                cls_name = UNIFIED_CLASSES[cls_idx]
+                class_counts[cls_name] = class_counts.get(cls_name, 0) + 1
+        else:
+            n_background += 1
+
+    (output_dir / "data.yaml").write_text(
+        f"# ScarGuard merged training dataset\n"
+        f"path: .\n"
+        f"train: images/train\n"
+        f"val: images/val\n"
+        f"\n"
+        f"nc: {len(UNIFIED_CLASSES)}\n"
+        f"names: {UNIFIED_CLASSES}\n"
+    )
+
+    n_train = len(samples) - n_val
+    print(f"\n  Train: {n_train}   Val: {n_val}")
+    print("\n  By source:")
+    for src, cnt in sorted(source_counts.items()):
+        print(f"    {src}: {cnt}")
+    print("\n  By class (annotation count):")
+    for cls in UNIFIED_CLASSES:
+        cnt = class_counts.get(cls, 0)
+        status = "OK" if cnt >= 500 else "LOW"
+        print(f"    [{status}] {cls}: {cnt}")
+    if n_background:
+        print(f"    [bg]  background: {n_background}")
+    print(f"\n  Output: {output_dir / 'data.yaml'}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    args = _parse_args()
+    output_dir = Path(args.output).resolve()
+
+    if not args.skip_roboflow and not args.roboflow_key:
+        print("ERROR: --roboflow-key is required (or use --skip-roboflow)", file=sys.stderr)
+        sys.exit(1)
+
+    with tempfile.TemporaryDirectory(prefix="sg_train_") as tmp:
+        work_dir = Path(tmp)
+        samples: list[Sample] = []
+
+        if not args.skip_orin:
+            if args.local_db:
+                samples.extend(_pull_orin_local(args.local_db, args.local_snapshots or "/data/snapshots"))
+            elif args.scarguard_zip:
+                samples.extend(_pull_orin_zip(Path(args.scarguard_zip), work_dir))
+            else:
+                samples.extend(
+                    _pull_orin_ssh(args.orin_host, args.orin_container, work_dir),
+                )
+
+        if not args.skip_roboflow:
+            samples.extend(pull_roboflow(args.roboflow_key, work_dir))
+
+        if not args.skip_oid:
+            samples.extend(
+                pull_open_images(work_dir, args.max_oid_per_class, args.oid_workers),
+            )
+
+        if not args.skip_training_uploads and args.training_uploads_db:
+            samples.extend(
+                pull_training_uploads(
+                    args.training_uploads_db,
+                    args.training_uploads_frames or "/data/training_uploads",
+                    args.background_sample_interval,
+                ),
+            )
+
+        if not samples:
+            print("\nERROR: No samples collected from any source", file=sys.stderr)
+            sys.exit(1)
+
+        merge_and_split(samples, output_dir, args.val_split, args.seed)
+
+    print("\nDone! Next step:")
+    print(f"  python train.py --data {output_dir}/data.yaml --output pond_v1.pt")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/prepare_dataset.py
+++ b/training/prepare_dataset.py
@@ -433,7 +433,10 @@ def pull_training_uploads(
         else:
             skipped += 1
 
-    # Background samples: every Nth frame from background uploads
+    # Background samples: every Nth frame from background uploads.
+    # Skip frames that already have approved annotations to avoid
+    # emitting the same image as both labeled and empty.
+    labeled_frames: set[tuple[str, int]] = set(frame_labels.keys())
     bg_count = 0
     for upload in bg_uploads:
         upload_frames = Path(frames_dir) / upload["id"] / "frames"
@@ -441,6 +444,8 @@ def pull_training_uploads(
             continue
         fc = upload["frame_count"] or 0
         for i in range(0, fc, max(1, background_sample_interval)):
+            if (upload["id"], i) in labeled_frames:
+                continue
             fp = upload_frames / f"{i:06d}.jpg"
             if fp.exists():
                 samples.append(Sample(image=fp, label_lines=[], source="training_uploads"))


### PR DESCRIPTION
## Summary

- **DB CRUD**: Full data layer for training_uploads and training_events — create, list, filter, navigate (next/prev for keyboard flow), single + bulk review, stats, export queries
- **Upload endpoints**: Chunked video upload with ffprobe duration validation (max 60s), file serving, delete with cascade cleanup. Adds ffmpeg to web Dockerfile
- **Labeling queue UI**: Two-column layout (frame+bbox | details+actions), keyboard shortcuts (a/x/c/j/k), HTMX partial swaps, auto-advance, bulk approve/reject, filter by pass/state
- **Video processor**: Standalone module for frame extraction → YOLO inference at 0.05 conf → two-pass tagging → IoU deduplication. Returns data, no DB writes (testable in isolation)
- **prepare_dataset.py**: `--local-db` replaces SSH for Docker, `--training-uploads-db` adds video annotations as fourth source alongside Orin DB / Roboflow / Open Images
- **Config redaction**: Roboflow API key masked for viewers and encrypted at rest

## Depends on

PR #141 (merged) — training tables schema + detector pause/resume

## Test plan

- [ ] Upload a .mp4 — appears in list, frames dir created
- [ ] Upload a video >60s — rejected with duration error
- [ ] Open labeling page for a processed upload — bbox renders, keyboard shortcuts work
- [ ] Approve/reject via keyboard — auto-advances, stats update
- [ ] Bulk approve all normal — only pending normal-conf events updated
- [ ] Delete upload — frames dir removed, events cascade-deleted
- [ ] `prepare_dataset.py --help` shows new flags
- [ ] Ruff + mypy pass (verified locally)
- [ ] Existing web tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)