### PR TITLE
feat: trainer service + job queue + web UI training (PR 3/3)

### DIFF
--- a/config/scarguard.example.yml
+++ b/config/scarguard.example.yml
@@ -326,3 +326,37 @@ backup:
   retention_daily: 14            # keep last N backups (one per cycle)
   retention_weekly: 8            # plus N weekly samples beyond the daily window
   compress: true                 # gzip the backup (recommended)
+
+# ── Training pipeline (v1.16+) ───────────────────────────────────────────
+# Configuration for the video-upload training pipeline.  The trainer
+# service reads these values when running prepare_dataset + train jobs.
+#
+# training:
+#   sources:
+#     roboflow:
+#       api_key: ""                   # SENSITIVE — encrypted at rest
+#       datasets:
+#         - workspace: "your-workspace"
+#           project: "your-project"
+#     open_images:
+#       max_per_class: 1500
+#       workers: 16
+#     local:
+#       enabled: true                 # Include detection_events feedback
+#     training_uploads:
+#       enabled: true                 # Include video upload annotations
+#
+#   defaults:
+#     base_model: "yolov8n.pt"
+#     epochs: 100
+#     batch_size: 2                   # Orin 8GB safe
+#     image_size: 480                 # Orin 8GB safe
+#     patience: 20
+#     val_split: 0.15
+#
+#   video:
+#     low_confidence: 0.05
+#     dedupe_iou: 0.85
+#     dedupe_window: 5
+#     max_duration_seconds: 60
+#     background_sample_interval: 10

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -9,3 +9,12 @@ services:
     environment:
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DRIVER_CAPABILITIES: compute,utility,video
+  trainer:
+    runtime: nvidia
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility,video
+    deploy:
+      resources:
+        limits:
+          memory: 6g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -479,6 +479,41 @@ services:
       - SETUID
       - SETGID
 
+  # ── Trainer (idle until a training job is submitted) ──────────────────────
+  trainer:
+    build:
+      context: .
+      dockerfile: services/trainer/Dockerfile
+    container_name: scarguard-trainer
+    restart: unless-stopped
+    user: "0:0"
+    volumes:
+      - scarguard-config:/config:ro
+      - scarguard-models:/models
+      - scarguard-data:/data
+    environment:
+      - CONFIG_PATH=/config/scarguard.yml
+      - DB_PATH=/data/scarguard.db
+      - MODELS_DIR=/models
+      - TRAINING_UPLOADS_DIR=/data/training_uploads
+      - TRAINING_WORKSPACE_DIR=/data/training_workspace
+    depends_on:
+      - redis
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - FOWNER
+      - DAC_OVERRIDE
+      - SETUID
+      - SETGID
+    healthcheck:
+      test: ["CMD", "test", "-f", "/tmp/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
 volumes:
   scarguard-caddy-data:
     name: scarguard-caddy-data

--- a/services/trainer/Dockerfile
+++ b/services/trainer/Dockerfile
@@ -1,0 +1,36 @@
+# Build context: repo root
+# docker build -f services/trainer/Dockerfile -t scarguard-trainer .
+FROM dustynv/l4t-pytorch:r36.4.0@sha256:a05c85def9139c21014546451d3baab44052d7cabe854d937f163390bfd5201b
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgstreamer1.0-0 \
+    libgstreamer-plugins-base1.0-0 \
+    libgl1 \
+    libglib2.0-0 \
+    gosu \
+    ffmpeg \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY services/trainer/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir --index-url https://pypi.org/simple/ -r requirements.txt
+
+COPY services/trainer/src/ ./src/
+COPY shared/ ./shared/
+COPY training/prepare_dataset.py ./scripts/prepare_dataset.py
+COPY training/train.py ./scripts/train.py
+
+ENV PYTHONPATH=/app/src:/app/shared
+ENV PYTHONUNBUFFERED=1
+ENV YOLO_CONFIG_DIR=/tmp/ultralytics
+
+RUN useradd -r -m -d /home/scarguard -s /usr/sbin/nologin -G video scarguard && \
+    mkdir -p /data /config /models /tmp/ultralytics /data/training_uploads /data/training_workspace && \
+    chown scarguard:scarguard /data /config /models /tmp/ultralytics
+
+COPY services/trainer/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["python3", "src/main.py"]

--- a/services/trainer/entrypoint.sh
+++ b/services/trainer/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+if [ "$(id -u)" = "0" ]; then
+    if [ ! -f /data/.ownership-fixed-trainer ]; then
+        chown -R scarguard:scarguard /data /models 2>/dev/null || echo "WARNING: chown failed on /data or /models" >&2
+        touch /data/.ownership-fixed-trainer 2>/dev/null || true
+    else
+        chown scarguard:scarguard /data /config /models 2>/dev/null || true
+    fi
+    mkdir -p /tmp/runs/predict /data/training_workspace /data/training_uploads
+    chown -R scarguard:scarguard /tmp/runs /data/training_workspace /data/training_uploads 2>/dev/null || true
+    exec gosu scarguard "$@"
+fi
+exec "$@"

--- a/services/trainer/requirements.txt
+++ b/services/trainer/requirements.txt
@@ -1,0 +1,6 @@
+ultralytics>=8.3.0
+opencv-python-headless>=4.8.0
+roboflow>=1.1.0
+redis>=5.0.0
+pyyaml>=6.0
+requests>=2.31.0

--- a/services/trainer/src/job_runner.py
+++ b/services/trainer/src/job_runner.py
@@ -1,0 +1,436 @@
+"""Job runner — dispatches training job types with pause/resume lifecycle.
+
+Each job type runs the appropriate pipeline step:
+- process_video: pause → YOLO inference on uploaded video → resume
+- prepare_dataset: CPU work (no pause needed)
+- train: pause → fine-tune YOLO model → resume
+- prepare_and_train: prepare_dataset then train
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import subprocess
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pause_protocol import PauseClient
+from redis_client import make_sync_client
+
+logger = logging.getLogger(__name__)
+
+DB_PATH = os.environ.get("DB_PATH", "/data/scarguard.db")
+MODELS_DIR = os.environ.get("MODELS_DIR", "/models")
+TRAINING_UPLOADS_DIR = os.environ.get("TRAINING_UPLOADS_DIR", "/data/training_uploads")
+WORKSPACE_DIR = Path(os.environ.get("TRAINING_WORKSPACE_DIR", "/data/training_workspace"))
+SCRIPTS_DIR = Path("/app/scripts")
+
+_PROGRESS_TTL = 300
+_LOG_TTL = 3600
+_LOG_CAP = 500
+
+
+def _progress_key(job_id: str) -> str:
+    return f"scarguard:training:job:{job_id}:progress"
+
+
+def _log_key(job_id: str) -> str:
+    return f"scarguard:training:job:{job_id}:log"
+
+
+def _cancel_key(job_id: str) -> str:
+    return f"scarguard:training:job:{job_id}:cancel"
+
+
+def _connect_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH, timeout=5)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+class JobContext:
+    """Shared state for a running job."""
+
+    def __init__(self, job: dict, cfg: dict, stop_event: threading.Event) -> None:
+        self.job = job
+        self.job_id: str = job["id"]
+        self.job_type: str = job["type"]
+        self.params: dict = json.loads(job["params"]) if isinstance(job["params"], str) else job["params"]
+        self.cfg = cfg
+        self.stop_event = stop_event
+        self.redis_cfg = cfg.get("redis", {})
+        self._redis = make_sync_client(self.redis_cfg)
+        self._pause_client = PauseClient(self.redis_cfg)
+
+    def close(self) -> None:
+        try:
+            self._redis.close()
+        except Exception:
+            pass
+
+    def publish_progress(self, phase: str, pct: float, detail: str = "", **extra: Any) -> None:
+        data = {"phase": phase, "pct": round(pct, 1), "detail": detail, **extra}
+        self._redis.set(_progress_key(self.job_id), json.dumps(data), ex=_PROGRESS_TTL)
+
+    def append_log(self, line: str) -> None:
+        key = _log_key(self.job_id)
+        self._redis.rpush(key, line)
+        self._redis.ltrim(key, -_LOG_CAP, -1)
+        self._redis.expire(key, _LOG_TTL)
+
+    def is_cancelled(self) -> bool:
+        return bool(self._redis.exists(_cancel_key(self.job_id))) or self.stop_event.is_set()
+
+    def pause_detector(self, timeout: int = 7200) -> bool:
+        ok = self._pause_client.pause(timeout=timeout)
+        if ok:
+            self._pause_client.start_heartbeat()
+        return ok
+
+    def resume_detector(self) -> None:
+        self._pause_client.stop_heartbeat()
+        self._pause_client.resume()
+
+    def training_config(self) -> dict:
+        return self.cfg.get("training", {})
+
+    def detection_config(self) -> dict:
+        return self.cfg.get("detection", {})
+
+
+def run_job(job: dict, cfg: dict, stop_event: threading.Event) -> dict:
+    """Dispatch a job by type. Returns result dict."""
+    ctx = JobContext(job, cfg, stop_event)
+    try:
+        if ctx.job_type == "process_video":
+            return _run_process_video(ctx)
+        elif ctx.job_type == "prepare_dataset":
+            return _run_prepare_dataset(ctx)
+        elif ctx.job_type == "train":
+            return _run_train(ctx)
+        elif ctx.job_type == "prepare_and_train":
+            return _run_prepare_and_train(ctx)
+        else:
+            return {"error": f"Unknown job type: {ctx.job_type}"}
+    finally:
+        ctx.close()
+
+
+# ── process_video ────────────────────────────────────────────────────────────
+
+
+def _run_process_video(ctx: JobContext) -> dict:
+    from video_processor import process_upload, result_to_db_rows
+
+    upload_ids: list[str] = ctx.params.get("upload_ids", [])
+    if not upload_ids:
+        return {"error": "No upload_ids provided"}
+
+    det_cfg = ctx.detection_config()
+    train_cfg = ctx.training_config()
+    video_cfg = train_cfg.get("video", {})
+    model_path = det_cfg.get("model_path", f"{MODELS_DIR}/yolov8n.pt")
+    conf_threshold = det_cfg.get("confidence_threshold", 0.25)
+    low_conf = ctx.params.get("low_confidence", video_cfg.get("low_confidence", 0.05))
+    dedupe_iou = ctx.params.get("dedupe_iou", video_cfg.get("dedupe_iou", 0.85))
+    dedupe_window = ctx.params.get("dedupe_window", video_cfg.get("dedupe_window", 5))
+
+    ctx.publish_progress("pausing", 0, "Pausing detector for GPU access")
+    if not ctx.pause_detector():
+        return {"error": "Failed to pause detector — timeout waiting for ack"}
+
+    try:
+        results = []
+        for i, uid in enumerate(upload_ids):
+            if ctx.is_cancelled():
+                return {"error": "Job cancelled", "processed": i}
+
+            conn = _connect_db()
+            try:
+                upload = conn.execute("SELECT * FROM training_uploads WHERE id = ?", (uid,)).fetchone()
+            finally:
+                conn.close()
+            if not upload:
+                logger.warning("Upload %s not found — skipping", uid)
+                continue
+
+            upload_dir = Path(TRAINING_UPLOADS_DIR) / uid
+            video_files = list(upload_dir.glob("original.*"))
+            if not video_files:
+                logger.warning("No video file for upload %s", uid)
+                continue
+
+            frames_dir = upload_dir / "frames"
+            ctx.publish_progress(
+                "processing",
+                (i / len(upload_ids)) * 100,
+                f"Processing {upload['filename']} ({i + 1}/{len(upload_ids)})",
+            )
+
+            def _progress(current: int, total: int) -> None:
+                if total > 0:
+                    pct = (i / len(upload_ids) + (current / total) / len(upload_ids)) * 100
+                    ctx.publish_progress("processing", pct, f"Frame {current}/{total}")
+
+            result = process_upload(
+                upload_id=uid,
+                video_path=video_files[0],
+                frames_dir=frames_dir,
+                model_path=model_path,
+                confidence_threshold=conf_threshold,
+                low_confidence=low_conf,
+                dedupe_iou=dedupe_iou,
+                dedupe_window=dedupe_window,
+                target_class_hint=upload["target_class_hint"],
+                progress_callback=_progress,
+            )
+
+            if result.error:
+                logger.error("Processing failed for %s: %s", uid, result.error)
+                _update_upload_status(uid, "failed", error=result.error)
+                continue
+
+            rows = result_to_db_rows(result, upload["target_class_hint"])
+            if rows:
+                _insert_training_events(uid, rows)
+            _update_upload_status(
+                uid, "processed",
+                frame_count=result.frame_count,
+                detection_count=result.deduped_detection_count,
+            )
+            results.append({
+                "upload_id": uid,
+                "frames": result.frame_count,
+                "detections": result.deduped_detection_count,
+            })
+
+        ctx.publish_progress("complete", 100, f"Processed {len(results)} upload(s)")
+        return {"uploads": results}
+    finally:
+        ctx.resume_detector()
+
+
+def _update_upload_status(
+    upload_id: str, status: str, *,
+    frame_count: int | None = None,
+    detection_count: int | None = None,
+    error: str | None = None,
+) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    sets = ["status = ?"]
+    params: list[object] = [status]
+    if frame_count is not None:
+        sets.append("frame_count = ?")
+        params.append(frame_count)
+    if detection_count is not None:
+        sets.append("detection_count = ?")
+        params.append(detection_count)
+    if error is not None:
+        sets.append("error = ?")
+        params.append(error)
+    if status in ("processed", "failed"):
+        sets.append("processed_at = ?")
+        params.append(now)
+    params.append(upload_id)
+    conn = _connect_db()
+    try:
+        conn.execute(f"UPDATE training_uploads SET {', '.join(sets)} WHERE id = ?", params)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_training_events(upload_id: str, events: list[dict]) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    conn = _connect_db()
+    try:
+        conn.executemany(
+            """
+            INSERT INTO training_events
+                (upload_id, frame_idx, timestamp_in_video, bbox, predicted_class,
+                 confidence, target_class_hint, detection_pass, review_state, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+            """,
+            [
+                (
+                    upload_id,
+                    e["frame_idx"],
+                    e.get("timestamp_in_video"),
+                    e["bbox"],
+                    e["predicted_class"],
+                    e["confidence"],
+                    e.get("target_class_hint"),
+                    e["detection_pass"],
+                    now,
+                )
+                for e in events
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ── prepare_dataset ──────────────────────────────────────────────────────────
+
+
+def _run_prepare_dataset(ctx: JobContext) -> dict:
+    train_cfg = ctx.training_config()
+    sources = train_cfg.get("sources", {})
+    defaults = train_cfg.get("defaults", {})
+    output_dir = WORKSPACE_DIR / "merged_dataset"
+
+    cmd = [
+        "python3", str(SCRIPTS_DIR / "prepare_dataset.py"),
+        "--local-db", DB_PATH,
+        "--local-snapshots", "/data/snapshots",
+        "--training-uploads-db", DB_PATH,
+        "--training-uploads-frames", TRAINING_UPLOADS_DIR,
+        "--output", str(output_dir),
+        "--val-split", str(ctx.params.get("val_split", defaults.get("val_split", 0.15))),
+        "--seed", str(ctx.params.get("seed", 42)),
+        "--background-sample-interval", str(
+            ctx.params.get("background_sample_interval",
+                           train_cfg.get("video", {}).get("background_sample_interval", 10))
+        ),
+    ]
+
+    rf_cfg = sources.get("roboflow", {})
+    rf_key = rf_cfg.get("api_key", "")
+    if rf_key and not ctx.params.get("skip_roboflow"):
+        cmd += ["--roboflow-key", rf_key]
+    else:
+        cmd.append("--skip-roboflow")
+
+    if ctx.params.get("skip_orin"):
+        cmd.append("--skip-orin")
+    if ctx.params.get("skip_oid"):
+        cmd.append("--skip-oid")
+    if ctx.params.get("skip_training_uploads"):
+        cmd.append("--skip-training-uploads")
+
+    oid_cfg = sources.get("open_images", {})
+    cmd += ["--max-oid-per-class", str(ctx.params.get("max_oid_per_class", oid_cfg.get("max_per_class", 1500)))]
+    cmd += ["--oid-workers", str(oid_cfg.get("workers", 16))]
+
+    return _run_subprocess(ctx, cmd, phase="prepare_dataset")
+
+
+def _run_subprocess(ctx: JobContext, cmd: list[str], phase: str) -> dict:
+    """Run a subprocess, streaming stdout/stderr to job log and Redis."""
+    ctx.publish_progress(phase, 0, f"Starting {phase}")
+    ctx.append_log(f"$ {' '.join(cmd)}")
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    lines: list[str] = []
+    try:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            line = line.rstrip("\n")
+            lines.append(line)
+            ctx.append_log(line)
+
+            epoch_info = _parse_epoch_progress(line)
+            if epoch_info:
+                ctx.publish_progress(phase, epoch_info["pct"], epoch_info["detail"], **epoch_info)
+
+            if ctx.is_cancelled():
+                proc.terminate()
+                proc.wait(timeout=10)
+                return {"error": "Job cancelled", "output_lines": len(lines)}
+
+        proc.wait()
+    except Exception:
+        proc.kill()
+        raise
+
+    if proc.returncode != 0:
+        last_lines = lines[-10:] if lines else ["(no output)"]
+        raise RuntimeError(f"{phase} failed (exit {proc.returncode}): {' | '.join(last_lines)}")
+
+    ctx.publish_progress(phase, 100, f"{phase} complete")
+    return {"phase": phase, "exit_code": 0, "output_lines": len(lines)}
+
+
+def _parse_epoch_progress(line: str) -> dict | None:
+    """Try to extract epoch/mAP from ultralytics training output."""
+    if "Epoch" not in line and "epoch" not in line.lower():
+        return None
+    try:
+        parts = line.split()
+        for i, p in enumerate(parts):
+            if "/" in p:
+                current, total = p.split("/")
+                if current.isdigit() and total.isdigit():
+                    pct = (int(current) / int(total)) * 100
+                    return {"pct": pct, "detail": line.strip(), "epoch": int(current), "total_epochs": int(total)}
+    except (ValueError, IndexError):
+        pass
+    return None
+
+
+# ── train ────────────────────────────────────────────────────────────────────
+
+
+def _run_train(ctx: JobContext) -> dict:
+    train_cfg = ctx.training_config()
+    defaults = train_cfg.get("defaults", {})
+    dataset_dir = WORKSPACE_DIR / "merged_dataset"
+    data_yaml = dataset_dir / "data.yaml"
+
+    if not data_yaml.exists():
+        return {"error": f"Dataset not found at {data_yaml} — run prepare_dataset first"}
+
+    output_name = ctx.params.get("output_name", "trained.pt")
+    output_path = Path(MODELS_DIR) / output_name
+
+    cmd = [
+        "python3", str(SCRIPTS_DIR / "train.py"),
+        "--data", str(data_yaml),
+        "--base-model", ctx.params.get("base_model", defaults.get("base_model", "yolov8n.pt")),
+        "--output", str(output_path),
+        "--epochs", str(ctx.params.get("epochs", defaults.get("epochs", 100))),
+        "--imgsz", str(ctx.params.get("image_size", defaults.get("image_size", 480))),
+        "--batch", str(ctx.params.get("batch_size", defaults.get("batch_size", 2))),
+        "--patience", str(ctx.params.get("patience", defaults.get("patience", 20))),
+        "--device", "0",
+    ]
+
+    if ctx.params.get("force"):
+        cmd.append("--force")
+
+    ctx.publish_progress("pausing", 0, "Pausing detector for GPU access")
+    if not ctx.pause_detector():
+        return {"error": "Failed to pause detector — timeout waiting for ack"}
+
+    try:
+        result = _run_subprocess(ctx, cmd, phase="train")
+        result["model_path"] = str(output_path)
+        return result
+    finally:
+        ctx.resume_detector()
+
+
+# ── prepare_and_train ────────────────────────────────────────────────────────
+
+
+def _run_prepare_and_train(ctx: JobContext) -> dict:
+    prep_result = _run_prepare_dataset(ctx)
+    if "error" in prep_result:
+        return prep_result
+    if ctx.is_cancelled():
+        return {"error": "Job cancelled after prepare_dataset"}
+    train_result = _run_train(ctx)
+    return {"prepare": prep_result, "train": train_result}

--- a/services/trainer/src/job_runner.py
+++ b/services/trainer/src/job_runner.py
@@ -321,10 +321,29 @@ def _run_prepare_dataset(ctx: JobContext) -> dict:
     return _run_subprocess(ctx, cmd, phase="prepare_dataset")
 
 
+_SECRET_ARGS = {"--roboflow-key"}
+
+
+def _redact_cmd(cmd: list[str]) -> str:
+    """Redact secret values from a command line for logging."""
+    parts: list[str] = []
+    skip_next = False
+    for arg in cmd:
+        if skip_next:
+            parts.append("***")
+            skip_next = False
+        elif arg in _SECRET_ARGS:
+            parts.append(arg)
+            skip_next = True
+        else:
+            parts.append(arg)
+    return " ".join(parts)
+
+
 def _run_subprocess(ctx: JobContext, cmd: list[str], phase: str) -> dict:
     """Run a subprocess, streaming stdout/stderr to job log and Redis."""
     ctx.publish_progress(phase, 0, f"Starting {phase}")
-    ctx.append_log(f"$ {' '.join(cmd)}")
+    ctx.append_log(f"$ {_redact_cmd(cmd)}")
 
     proc = subprocess.Popen(
         cmd,

--- a/services/trainer/src/main.py
+++ b/services/trainer/src/main.py
@@ -114,8 +114,12 @@ def _process_job(job: dict, cfg: dict, stop_event: threading.Event) -> None:
     _set_job_status(job_id, "running")
     try:
         result = run_job(job, cfg, stop_event)
-        _set_job_status(job_id, "completed", result=json.dumps(result))
-        logger.info("Job %s completed", job_id)
+        if "error" in result:
+            _set_job_status(job_id, "failed", result=json.dumps(result))
+            logger.warning("Job %s failed: %s", job_id, result["error"])
+        else:
+            _set_job_status(job_id, "completed", result=json.dumps(result))
+            logger.info("Job %s completed", job_id)
     except Exception as e:
         logger.exception("Job %s failed", job_id)
         _set_job_status(job_id, "failed", result=json.dumps({"error": str(e)}))
@@ -155,16 +159,15 @@ def main() -> None:
             pubsub.subscribe(JOB_NOTIFY_CHANNEL)
 
             last_poll = time.monotonic()
-            for message in pubsub.listen():
-                if stop_event.is_set():
-                    break
+            while not stop_event.is_set():
+                message = pubsub.get_message(timeout=POLL_INTERVAL)
 
                 Path("/tmp/healthy").touch(exist_ok=True)
 
                 should_check = False
-                if message["type"] == "message":
+                if message and message["type"] == "message":
                     should_check = True
-                elif time.monotonic() - last_poll >= POLL_INTERVAL:
+                if time.monotonic() - last_poll >= POLL_INTERVAL:
                     should_check = True
                     last_poll = time.monotonic()
 

--- a/services/trainer/src/main.py
+++ b/services/trainer/src/main.py
@@ -1,0 +1,192 @@
+"""ScarGuard trainer — job consumer loop.
+
+Listens for training job notifications via Redis pub/sub, with a
+fallback poll of the training_jobs table every 30 seconds.  Processes
+one job at a time.  On startup, marks any stale 'running' jobs as
+failed (crash recovery).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import sqlite3
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import redis
+import yaml
+
+logger = logging.getLogger(__name__)
+
+CONFIG_PATH = os.environ.get("CONFIG_PATH", "/config/scarguard.yml")
+DB_PATH = os.environ.get("DB_PATH", "/data/scarguard.db")
+MODELS_DIR = os.environ.get("MODELS_DIR", "/models")
+TRAINING_UPLOADS_DIR = os.environ.get("TRAINING_UPLOADS_DIR", "/data/training_uploads")
+
+JOB_NOTIFY_CHANNEL = "scarguard:training:job:notify"
+POLL_INTERVAL = 30
+
+
+def _load_config() -> dict:
+    with open(CONFIG_PATH) as f:
+        return yaml.safe_load(f) or {}
+
+
+def _connect_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH, timeout=5)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _get_redis(cfg: dict) -> redis.Redis:
+    redis_cfg = cfg.get("redis", {})
+    pw = os.environ.get("REDIS_PASSWORD", "") or None
+    return redis.Redis(
+        host=redis_cfg.get("host", "redis"),
+        port=int(redis_cfg.get("port", 6379)),
+        password=pw,
+        decode_responses=True,
+    )
+
+
+def _mark_stale_jobs() -> int:
+    """Mark any 'running' jobs as failed (crash recovery)."""
+    now = datetime.now(timezone.utc).isoformat()
+    result_json = json.dumps({"error": "Trainer restarted — job interrupted (possible OOM)"})
+    conn = _connect_db()
+    try:
+        cur = conn.execute(
+            "UPDATE training_jobs SET status = 'failed', completed_at = ?, result = ? WHERE status = 'running'",
+            (now, result_json),
+        )
+        conn.commit()
+        return cur.rowcount
+    finally:
+        conn.close()
+
+
+def _get_next_job() -> dict | None:
+    """Return the oldest queued job as a dict, or None."""
+    conn = _connect_db()
+    try:
+        row = conn.execute(
+            "SELECT * FROM training_jobs WHERE status = 'queued' ORDER BY created_at ASC LIMIT 1"
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def _set_job_status(job_id: str, status: str, result: str | None = None) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    sets = ["status = ?"]
+    params: list[object] = [status]
+    if status == "running":
+        sets.append("started_at = ?")
+        params.append(now)
+    if status in ("completed", "failed", "cancelled"):
+        sets.append("completed_at = ?")
+        params.append(now)
+    if result is not None:
+        sets.append("result = ?")
+        params.append(result)
+    params.append(job_id)
+    conn = _connect_db()
+    try:
+        conn.execute(f"UPDATE training_jobs SET {', '.join(sets)} WHERE id = ?", params)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _process_job(job: dict, cfg: dict, stop_event: threading.Event) -> None:
+    """Dispatch a single job to the job runner."""
+    from job_runner import run_job
+
+    job_id = job["id"]
+    logger.info("Processing job %s (type=%s)", job_id, job["type"])
+    _set_job_status(job_id, "running")
+    try:
+        result = run_job(job, cfg, stop_event)
+        _set_job_status(job_id, "completed", result=json.dumps(result))
+        logger.info("Job %s completed", job_id)
+    except Exception as e:
+        logger.exception("Job %s failed", job_id)
+        _set_job_status(job_id, "failed", result=json.dumps({"error": str(e)}))
+
+
+def main() -> None:
+    cfg = _load_config()
+    log_level = cfg.get("system", {}).get("log_level", "info")
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+        stream=sys.stdout,
+    )
+    logger.info("ScarGuard trainer starting")
+
+    Path("/tmp/healthy").touch(exist_ok=True)
+
+    stale = _mark_stale_jobs()
+    if stale:
+        logger.warning("Marked %d stale running job(s) as failed", stale)
+
+    stop_event = threading.Event()
+
+    def _shutdown(sig: int, _frame: object) -> None:
+        logger.info("Received signal %s — shutting down", sig)
+        stop_event.set()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    logger.info("Listening for jobs on %s (poll fallback every %ds)", JOB_NOTIFY_CHANNEL, POLL_INTERVAL)
+
+    while not stop_event.is_set():
+        try:
+            client = _get_redis(cfg)
+            pubsub = client.pubsub()
+            pubsub.subscribe(JOB_NOTIFY_CHANNEL)
+
+            last_poll = time.monotonic()
+            for message in pubsub.listen():
+                if stop_event.is_set():
+                    break
+
+                Path("/tmp/healthy").touch(exist_ok=True)
+
+                should_check = False
+                if message["type"] == "message":
+                    should_check = True
+                elif time.monotonic() - last_poll >= POLL_INTERVAL:
+                    should_check = True
+                    last_poll = time.monotonic()
+
+                if should_check:
+                    job = _get_next_job()
+                    if job:
+                        cfg = _load_config()
+                        _process_job(job, cfg, stop_event)
+                        last_poll = time.monotonic()
+
+            pubsub.unsubscribe()
+            client.close()
+        except redis.ConnectionError:
+            if not stop_event.is_set():
+                logger.warning("Redis connection lost — retrying in 5s")
+                stop_event.wait(5)
+        except Exception:
+            logger.exception("Unexpected error in trainer loop")
+            stop_event.wait(5)
+
+    logger.info("Trainer stopped cleanly")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -1038,3 +1038,118 @@ def get_exportable_training_events() -> list[sqlite3.Row]:
             ORDER BY te.upload_id, te.frame_idx
             """
         ).fetchall()
+
+
+# ── Training jobs ────────────────────────────────────────────────────────────
+
+
+def create_training_job(
+    job_id: str,
+    job_type: str,
+    params: str,
+) -> None:
+    """INSERT a new training_jobs row with status='queued'."""
+    now = datetime.now(timezone.utc).isoformat()
+    with _connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO training_jobs (id, type, params, status, created_at)
+            VALUES (?, ?, ?, 'queued', ?)
+            """,
+            (job_id, job_type, params, now),
+        )
+        conn.commit()
+
+
+def get_training_jobs(
+    limit: int = 50,
+    offset: int = 0,
+    status: str | None = None,
+) -> list[sqlite3.Row]:
+    where: list[str] = []
+    params: list[object] = []
+    if status:
+        where.append("status = ?")
+        params.append(status)
+    clause = ("WHERE " + " AND ".join(where)) if where else ""
+    params += [limit, offset]
+    with _connect() as conn:
+        return conn.execute(
+            f"""
+            SELECT * FROM training_jobs
+            {clause}
+            ORDER BY created_at DESC
+            LIMIT ? OFFSET ?
+            """,
+            params,
+        ).fetchall()
+
+
+def count_training_jobs(status: str | None = None) -> int:
+    where: list[str] = []
+    params: list[object] = []
+    if status:
+        where.append("status = ?")
+        params.append(status)
+    clause = ("WHERE " + " AND ".join(where)) if where else ""
+    with _connect() as conn:
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM training_jobs {clause}", params
+        ).fetchone()
+        return row[0] if row else 0
+
+
+def get_training_job(job_id: str) -> sqlite3.Row | None:
+    with _connect() as conn:
+        return conn.execute(
+            "SELECT * FROM training_jobs WHERE id = ?", (job_id,)
+        ).fetchone()
+
+
+def get_oldest_queued_job() -> sqlite3.Row | None:
+    """Return the oldest queued training job, or None."""
+    with _connect() as conn:
+        return conn.execute(
+            "SELECT * FROM training_jobs WHERE status = 'queued' ORDER BY created_at ASC LIMIT 1"
+        ).fetchone()
+
+
+def update_training_job_status(
+    job_id: str,
+    status: str,
+    *,
+    result: str | None = None,
+) -> bool:
+    now = datetime.now(timezone.utc).isoformat()
+    sets = ["status = ?"]
+    params: list[object] = [status]
+    if status == "running":
+        sets.append("started_at = ?")
+        params.append(now)
+    if status in ("completed", "failed", "cancelled"):
+        sets.append("completed_at = ?")
+        params.append(now)
+    if result is not None:
+        sets.append("result = ?")
+        params.append(result)
+    params.append(job_id)
+    with _connect() as conn:
+        cur = conn.execute(
+            f"UPDATE training_jobs SET {', '.join(sets)} WHERE id = ?",
+            params,
+        )
+        conn.commit()
+        return cur.rowcount > 0
+
+
+def mark_stale_running_jobs_failed() -> int:
+    """Mark any running jobs as failed (crash recovery on trainer restart)."""
+    now = datetime.now(timezone.utc).isoformat()
+    result_json = __import__("json").dumps({"error": "Trainer restarted — job interrupted (possible OOM)"})
+    with _connect() as conn:
+        cur = conn.execute(
+            "UPDATE training_jobs SET status = 'failed', completed_at = ?, result = ? WHERE status = 'running'",
+            (now, result_json),
+        )
+        conn.commit()
+        return cur.rowcount

--- a/services/web/src/main.py
+++ b/services/web/src/main.py
@@ -29,6 +29,7 @@ from routes import (
     snapshot,
     stats,
     training,
+    training_jobs,
     training_uploads,
 )
 from routes import auth as auth_routes
@@ -477,6 +478,7 @@ app.include_router(about.router)
 app.include_router(admin.router)
 app.include_router(stats.router)
 app.include_router(training.router)
+app.include_router(training_jobs.router)
 app.include_router(training_uploads.router)
 app.include_router(audit_log.router)
 app.include_router(snapshot.router)

--- a/services/web/src/routes/training_jobs.py
+++ b/services/web/src/routes/training_jobs.py
@@ -1,0 +1,248 @@
+"""Training job submission, monitoring, and SSE progress endpoints."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+import db as db_module
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
+from redis_client import make_sync_client
+from route_auth import require_admin, require_viewer
+from starlette.responses import Response, StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/training/jobs")
+templates = Jinja2Templates(directory=str(__import__("pathlib").Path(__file__).parent.parent / "templates"))
+
+JOB_NOTIFY_CHANNEL = "scarguard:training:job:notify"
+STATE_KEY = "scarguard:detector:state"
+PAGE_SIZE = 25
+
+_VALID_JOB_TYPES = {"process_video", "prepare_dataset", "train", "prepare_and_train"}
+
+
+def _redis_cfg() -> dict:
+    import config_store
+    cfg = config_store.load_cached()
+    return cfg.get("redis", {})
+
+
+# ── Jobs list page ───────────────────────────────────────────────────────────
+
+
+@router.get("", response_class=HTMLResponse)
+async def jobs_page(
+    request: Request,
+    page: int = 1,
+    status: str = "",
+) -> Response:
+    gate = require_viewer(request)
+    if not isinstance(gate, dict):
+        return gate
+    st = status or None
+    offset = (page - 1) * PAGE_SIZE
+    jobs = db_module.get_training_jobs(limit=PAGE_SIZE, offset=offset, status=st)
+    total = db_module.count_training_jobs(status=st)
+
+    detector_state = _get_detector_state()
+
+    return templates.TemplateResponse(
+        request,
+        "training_jobs.html",
+        {
+            "jobs": [dict(j) for j in jobs],
+            "total": total,
+            "page": page,
+            "total_pages": max(1, -(-total // PAGE_SIZE)),
+            "filter_status": status,
+            "detector_state": detector_state,
+            "is_admin": require_admin(request) if not isinstance(require_admin(request), dict) else True,
+        },
+    )
+
+
+# ── Submit job ───────────────────────────────────────────────────────────────
+
+
+@router.post("")
+async def submit_job(
+    request: Request,
+    job_type: str = Form(...),
+    params_json: str = Form("{}"),
+) -> Response:
+    gate = require_admin(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    if job_type not in _VALID_JOB_TYPES:
+        return JSONResponse({"error": f"Invalid job type: {job_type}"}, status_code=400)
+
+    try:
+        params = json.loads(params_json)
+    except json.JSONDecodeError:
+        return JSONResponse({"error": "Invalid JSON in params"}, status_code=400)
+
+    running = db_module.count_training_jobs(status="running")
+    queued = db_module.count_training_jobs(status="queued")
+    if running > 0 or queued > 0:
+        return JSONResponse(
+            {"error": "A job is already running or queued. Wait for it to complete."},
+            status_code=409,
+        )
+
+    job_id = uuid.uuid4().hex
+    db_module.create_training_job(job_id, job_type, json.dumps(params))
+
+    try:
+        client = make_sync_client(_redis_cfg())
+        client.publish(JOB_NOTIFY_CHANNEL, json.dumps({"job_id": job_id}))
+        client.close()
+    except Exception:
+        logger.warning("Failed to notify trainer via Redis — trainer will pick up via poll")
+
+    logger.info("Training job submitted: %s (type=%s)", job_id, job_type)
+    from starlette.responses import RedirectResponse
+    return RedirectResponse(url=f"/admin/training/jobs?submitted={job_id}", status_code=303)
+
+
+# ── Job detail ───────────────────────────────────────────────────────────────
+
+
+@router.get("/{job_id}")
+async def job_detail(request: Request, job_id: str) -> Response:
+    gate = require_viewer(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    job = db_module.get_training_job(job_id)
+    if not job:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    progress = None
+    log_lines: list[str] = []
+    try:
+        client = make_sync_client(_redis_cfg())
+        raw_progress = client.get(f"scarguard:training:job:{job_id}:progress")
+        if raw_progress:
+            progress = json.loads(raw_progress)
+        raw_log = client.lrange(f"scarguard:training:job:{job_id}:log", -50, -1)
+        log_lines = list(raw_log) if raw_log else []
+        client.close()
+    except Exception:
+        pass
+
+    return JSONResponse({
+        "job": dict(job),
+        "progress": progress,
+        "log": log_lines,
+    })
+
+
+# ── SSE progress stream ─────────────────────────────────────────────────────
+
+
+@router.get("/{job_id}/stream")
+async def job_stream(request: Request, job_id: str) -> Response:
+    gate = require_viewer(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    import asyncio
+
+    async def _stream():
+        try:
+            client = make_sync_client(_redis_cfg())
+        except Exception:
+            yield "event: error\ndata: {\"error\": \"Redis unavailable\"}\n\n"
+            return
+
+        progress_key = f"scarguard:training:job:{job_id}:progress"
+        log_key = f"scarguard:training:job:{job_id}:log"
+        last_log_len = 0
+        timeout = 600
+
+        try:
+            for _ in range(timeout):
+                raw = client.get(progress_key)
+                if raw:
+                    yield f"event: progress\ndata: {raw}\n\n"
+
+                current_log_len = client.llen(log_key)
+                if current_log_len > last_log_len:
+                    new_lines = client.lrange(log_key, last_log_len, current_log_len - 1)
+                    if new_lines:
+                        for line in new_lines:
+                            yield f"event: log\ndata: {json.dumps(line)}\n\n"
+                    last_log_len = current_log_len
+
+                job = db_module.get_training_job(job_id)
+                if job and job["status"] in ("completed", "failed", "cancelled"):
+                    result_data = json.loads(job["result"]) if job["result"] else {}
+                    yield f"event: result\ndata: {json.dumps({'status': job['status'], **result_data})}\n\n"
+                    break
+
+                await asyncio.sleep(1)
+        finally:
+            try:
+                client.close()
+            except Exception:
+                pass
+
+    return StreamingResponse(_stream(), media_type="text/event-stream")
+
+
+# ── Cancel job ───────────────────────────────────────────────────────────────
+
+
+@router.post("/{job_id}/cancel")
+async def cancel_job(request: Request, job_id: str) -> Response:
+    gate = require_admin(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    job = db_module.get_training_job(job_id)
+    if not job:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    if job["status"] == "queued":
+        db_module.update_training_job_status(job_id, "cancelled")
+    elif job["status"] == "running":
+        try:
+            client = make_sync_client(_redis_cfg())
+            client.set(f"scarguard:training:job:{job_id}:cancel", "1", ex=3600)
+            client.close()
+        except Exception:
+            pass
+    else:
+        return JSONResponse({"error": "Job is not cancellable"}, status_code=400)
+
+    from starlette.responses import RedirectResponse
+    return RedirectResponse(url="/admin/training/jobs", status_code=303)
+
+
+# ── Detector state ───────────────────────────────────────────────────────────
+
+
+@router.get("/detector-state")
+async def detector_state(request: Request) -> Response:
+    gate = require_viewer(request)
+    if not isinstance(gate, dict):
+        return gate
+    return JSONResponse(_get_detector_state())
+
+
+def _get_detector_state() -> dict:
+    try:
+        client = make_sync_client(_redis_cfg())
+        raw = client.get(STATE_KEY)
+        client.close()
+        if raw:
+            return json.loads(raw)
+    except Exception:
+        pass
+    return {"state": "unknown"}

--- a/services/web/src/routes/training_jobs.py
+++ b/services/web/src/routes/training_jobs.py
@@ -127,11 +127,11 @@ async def job_detail(request: Request, job_id: str) -> Response:
     log_lines: list[str] = []
     try:
         client = make_sync_client(_redis_cfg())
-        raw_progress = client.get(f"scarguard:training:job:{job_id}:progress")
+        raw_progress: str | None = client.get(f"scarguard:training:job:{job_id}:progress")  # type: ignore[assignment,unused-ignore]
         if raw_progress:
             progress = json.loads(raw_progress)
-        raw_log = client.lrange(f"scarguard:training:job:{job_id}:log", -50, -1)
-        log_lines = list(raw_log) if raw_log else []
+        raw_log: list[str] = client.lrange(f"scarguard:training:job:{job_id}:log", -50, -1)  # type: ignore[assignment,unused-ignore]
+        log_lines = raw_log if raw_log else []
         client.close()
     except Exception:
         pass
@@ -239,7 +239,7 @@ async def detector_state(request: Request) -> Response:
 def _get_detector_state() -> dict:
     try:
         client = make_sync_client(_redis_cfg())
-        raw = client.get(STATE_KEY)
+        raw: str | None = client.get(STATE_KEY)  # type: ignore[assignment,unused-ignore]
         client.close()
         if raw:
             return json.loads(raw)

--- a/services/web/src/routes/training_jobs.py
+++ b/services/web/src/routes/training_jobs.py
@@ -164,10 +164,10 @@ async def job_stream(request: Request, job_id: str) -> Response:
         progress_key = f"scarguard:training:job:{job_id}:progress"
         log_key = f"scarguard:training:job:{job_id}:log"
         last_log_len = 0
-        timeout = 600
+        max_iterations = 43200  # 12 hours at 1s intervals
 
         try:
-            for _ in range(timeout):
+            for _ in range(max_iterations):
                 raw = client.get(progress_key)
                 if raw:
                     yield f"event: progress\ndata: {raw}\n\n"

--- a/services/web/src/static/training_jobs.js
+++ b/services/web/src/static/training_jobs.js
@@ -1,0 +1,72 @@
+/* Training jobs: SSE progress streaming + log tailing. */
+(function () {
+  "use strict";
+
+  var evtSource = null;
+
+  window.startJobStream = function (jobId) {
+    if (evtSource) { evtSource.close(); }
+
+    var progressEl = document.getElementById("job-progress");
+    var barEl = document.getElementById("progress-bar");
+    var labelEl = document.getElementById("progress-label");
+    var detailEl = document.getElementById("progress-detail");
+    var logEl = document.getElementById("job-log");
+
+    if (progressEl) progressEl.style.display = "block";
+    if (logEl) logEl.textContent = "";
+
+    evtSource = new EventSource("/admin/training/jobs/" + jobId + "/stream");
+
+    evtSource.addEventListener("progress", function (e) {
+      var data = JSON.parse(e.data);
+      if (barEl) barEl.style.width = data.pct + "%";
+      if (labelEl) labelEl.textContent = data.phase || "Working...";
+      if (detailEl) detailEl.textContent = data.detail || "";
+    });
+
+    evtSource.addEventListener("log", function (e) {
+      var line = JSON.parse(e.data);
+      if (logEl) {
+        logEl.textContent += line + "\n";
+        logEl.scrollTop = logEl.scrollHeight;
+      }
+    });
+
+    evtSource.addEventListener("result", function (e) {
+      evtSource.close();
+      evtSource = null;
+      var data = JSON.parse(e.data);
+      if (labelEl) labelEl.textContent = data.status === "completed" ? "Complete" : "Failed";
+      if (barEl) barEl.style.width = "100%";
+      if (detailEl) {
+        if (data.error) {
+          detailEl.textContent = "Error: " + data.error;
+        } else if (data.model_path) {
+          detailEl.textContent = "Model saved to " + data.model_path;
+        } else {
+          detailEl.textContent = "Done";
+        }
+      }
+      setTimeout(function () { window.location.reload(); }, 2000);
+    });
+
+    evtSource.onerror = function () {
+      evtSource.close();
+      evtSource = null;
+      if (labelEl) labelEl.textContent = "Connection lost";
+    };
+  };
+
+  /* Auto-start stream for running jobs on page load */
+  document.addEventListener("DOMContentLoaded", function () {
+    var rows = document.querySelectorAll("tr");
+    rows.forEach(function (tr) {
+      var statusBadge = tr.querySelector(".badge");
+      if (statusBadge && statusBadge.textContent.trim() === "running") {
+        var watchBtn = tr.querySelector("button[onclick^='startJobStream']");
+        if (watchBtn) watchBtn.click();
+      }
+    });
+  });
+})();

--- a/services/web/src/templates/base.html
+++ b/services/web/src/templates/base.html
@@ -36,6 +36,7 @@
           <a href="/admin/deterrent">Deterrent</a>
           <a href="/admin/training">Training Data</a>
           <a href="/admin/training/uploads">Uploads</a>
+          <a href="/admin/training/jobs">Jobs</a>
           <a href="/admin/training/evaluate">Model Evaluation</a>
           <a href="/admin/backups">Config Backups</a>
         </div>

--- a/services/web/src/templates/partials/training_job_rows.html
+++ b/services/web/src/templates/partials/training_job_rows.html
@@ -1,0 +1,52 @@
+{% for j in jobs %}
+<tr>
+  <td>{{ j.type }}</td>
+  <td>
+    {% if j.status == 'completed' %}<span class="badge badge-armed">{{ j.status }}</span>
+    {% elif j.status == 'failed' %}<span class="badge badge-disarmed">{{ j.status }}</span>
+    {% elif j.status == 'running' %}<span class="badge" style="background:var(--warn);color:#000;">{{ j.status }}</span>
+    {% elif j.status == 'cancelled' %}<span class="badge">{{ j.status }}</span>
+    {% else %}<span class="badge">{{ j.status }}</span>
+    {% endif %}
+  </td>
+  <td>{{ j.created_at[:16] }}</td>
+  <td>
+    {% if j.started_at and j.completed_at %}
+      {{ j.completed_at[:16] }}
+    {% elif j.started_at %}
+      running...
+    {% else %}
+      —
+    {% endif %}
+  </td>
+  <td>
+    {% if j.result %}
+      {% set r = j.result %}
+      {% if r is string %}
+        <span class="muted" title="{{ r }}">{{ r[:60] }}{% if r|length > 60 %}...{% endif %}</span>
+      {% endif %}
+    {% else %}
+      <span class="muted">—</span>
+    {% endif %}
+  </td>
+  <td>
+    {% if j.status == 'running' and _is_admin %}
+    <form method="post" action="/admin/training/jobs/{{ j.id }}/cancel" style="display:inline;">
+      <input type="hidden" name="_csrf_token" value="{{ request.state.csrf_token }}">
+      <button type="submit" class="btn btn-small btn-danger" onclick="return confirm('Cancel this job?')">Cancel</button>
+    </form>
+    {% elif j.status == 'queued' and _is_admin %}
+    <form method="post" action="/admin/training/jobs/{{ j.id }}/cancel" style="display:inline;">
+      <input type="hidden" name="_csrf_token" value="{{ request.state.csrf_token }}">
+      <button type="submit" class="btn btn-small btn-danger">Cancel</button>
+    </form>
+    {% endif %}
+    {% if j.status == 'running' %}
+    <button class="btn btn-small" onclick="startJobStream('{{ j.id }}')">Watch</button>
+    {% endif %}
+  </td>
+</tr>
+{% endfor %}
+{% if not jobs %}
+<tr><td colspan="6" class="muted" style="text-align:center;padding:2rem;">No jobs yet</td></tr>
+{% endif %}

--- a/services/web/src/templates/training_jobs.html
+++ b/services/web/src/templates/training_jobs.html
@@ -1,0 +1,93 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Training Jobs
+  {% if detector_state.state == 'paused' %}
+  <span class="badge" style="background:var(--warn);color:#000;">Detector Paused</span>
+  {% elif detector_state.state == 'running' %}
+  <span class="badge badge-armed">Detector Running</span>
+  {% endif %}
+</h1>
+
+{% if _is_admin %}
+<section class="card">
+  <h2>Submit Job</h2>
+  <form method="post" action="/admin/training/jobs" id="job-form">
+    <input type="hidden" name="_csrf_token" value="{{ request.state.csrf_token }}">
+    <div class="field-row">
+      <div class="field-group">
+        <label>Job Type</label>
+        <select name="job_type" id="job-type">
+          <option value="prepare_and_train">Prepare &amp; Train</option>
+          <option value="prepare_dataset">Prepare Dataset Only</option>
+          <option value="train">Train Only</option>
+          <option value="process_video">Process Videos</option>
+        </select>
+      </div>
+      <div class="field-group">
+        <label>Parameters (JSON)</label>
+        <textarea name="params_json" id="params-json" rows="3" style="font-family:var(--mono);font-size:0.8rem;">{}</textarea>
+        <p class="hint">Override defaults from config. Leave {} for defaults.</p>
+      </div>
+    </div>
+    <button type="submit" class="btn">Submit Job</button>
+  </form>
+</section>
+{% endif %}
+
+<div id="job-progress" style="display:none;" class="card">
+  <div class="eval-progress-label" id="progress-label">Starting...</div>
+  <div class="eval-progress-bar-outer">
+    <div class="eval-progress-bar-inner" id="progress-bar" style="width:0%"></div>
+  </div>
+  <div class="muted" id="progress-detail"></div>
+  <pre id="job-log" style="max-height:300px;overflow-y:auto;font-size:0.75rem;margin-top:0.5rem;padding:0.5rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;"></pre>
+</div>
+
+<form method="get" action="/admin/training/jobs" class="filter-form">
+  <div class="filter-row">
+    <label>
+      Status
+      <select name="status">
+        <option value="">All</option>
+        <option value="queued" {% if filter_status == 'queued' %}selected{% endif %}>Queued</option>
+        <option value="running" {% if filter_status == 'running' %}selected{% endif %}>Running</option>
+        <option value="completed" {% if filter_status == 'completed' %}selected{% endif %}>Completed</option>
+        <option value="failed" {% if filter_status == 'failed' %}selected{% endif %}>Failed</option>
+        <option value="cancelled" {% if filter_status == 'cancelled' %}selected{% endif %}>Cancelled</option>
+      </select>
+    </label>
+    <button type="submit" class="btn">Filter</button>
+    {% if filter_status %}<a href="/admin/training/jobs" class="btn-secondary">Clear</a>{% endif %}
+  </div>
+</form>
+
+<table>
+  <thead>
+    <tr>
+      <th>Type</th>
+      <th>Status</th>
+      <th>Created</th>
+      <th>Duration</th>
+      <th>Result</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% include "partials/training_job_rows.html" %}
+  </tbody>
+</table>
+
+{% if total_pages > 1 %}
+<nav class="pagination">
+  {% if page > 1 %}
+  <a href="/admin/training/jobs?page={{ page - 1 }}&amp;status={{ filter_status | urlencode }}">&laquo; Newer</a>
+  {% endif %}
+  <span>Page {{ page }} / {{ total_pages }}</span>
+  {% if page < total_pages %}
+  <a href="/admin/training/jobs?page={{ page + 1 }}&amp;status={{ filter_status | urlencode }}">Older &raquo;</a>
+  {% endif %}
+</nav>
+{% endif %}
+
+<script src="/static/training_jobs.js"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary

Final PR in the video-upload training pipeline. Wires everything together:

- **Trainer service**: Dockerfile (L4T base), entrypoint (gosu pattern), job consumer loop with Redis pub/sub + DB poll fallback, crash recovery on startup
- **Job runner**: Dispatches 4 job types (process_video, prepare_dataset, train, prepare_and_train) with pause/resume lifecycle, subprocess streaming, epoch progress parsing, cancellation support
- **Training jobs web UI**: Submit form, SSE progress streaming with log tail, detector state badge, cancel support, auto-stream for running jobs
- **Docker Compose**: Trainer service definition + GPU overlay (6GB memory limit, nvidia runtime)
- **Example config**: Commented training section documenting all fields

## Depends on

- PR #141 (merged) — training tables + detector pause/resume
- PR #142 (merged) — video upload, labeling queue, video processor, prepare_dataset

## Architecture

```
Web UI → POST /admin/training/jobs → DB insert + Redis notify
Trainer → Redis subscribe + DB poll → pick job → dispatch:
  process_video: pause → YOLO inference → insert events → resume
  prepare_dataset: subprocess (CPU, no pause)
  train: pause → subprocess train.py → resume
  prepare_and_train: prepare then train
Progress → Redis keys → SSE → web UI progress bar + log tail
```

## Test plan

- [ ] Ruff + mypy pass (verified locally)
- [ ] Existing web tests pass (233 tests)
- [ ] `docker compose config --quiet` validates
- [ ] Submit a prepare_dataset job — appears in jobs list, status transitions
- [ ] SSE progress stream shows phase + detail updates
- [ ] Cancel a queued job — status changes to cancelled
- [ ] Detector state badge shows running/paused correctly
- [ ] Example config documents all training fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)