### PR TITLE
fix: trainer compose gating + auto-discover unprocessed uploads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -479,11 +479,17 @@ services:
       - SETUID
       - SETGID
 
-  # ── Trainer (idle until a training job is submitted) ──────────────────────
+  # ── Trainer (ARM64/Jetson only — opt-in via COMPOSE_PROFILES=training) ────
+  # Uses the L4T base image (ARM64 only, no x86 variant).  Gated behind a
+  # profile so `docker compose pull` on x86 hosts doesn't fail on the
+  # missing arch manifest.  Enable on the Orin:
+  #   echo "COMPOSE_PROFILES=training" >> .env
   trainer:
+    profiles: ["training"]
     build:
       context: .
       dockerfile: services/trainer/Dockerfile
+    image: ghcr.io/${GHCR_OWNER:-sentania-labs}/scarguard-trainer:${IMAGE_TAG:-latest}
     container_name: scarguard-trainer
     restart: unless-stopped
     user: "0:0"

--- a/services/trainer/src/job_runner.py
+++ b/services/trainer/src/job_runner.py
@@ -129,7 +129,16 @@ def _run_process_video(ctx: JobContext) -> dict:
 
     upload_ids: list[str] = ctx.params.get("upload_ids", [])
     if not upload_ids:
-        return {"error": "No upload_ids provided"}
+        conn = _connect_db()
+        try:
+            rows = conn.execute(
+                "SELECT id FROM training_uploads WHERE status = 'uploaded' ORDER BY created_at"
+            ).fetchall()
+            upload_ids = [r["id"] for r in rows]
+        finally:
+            conn.close()
+        if not upload_ids:
+            return {"error": "No unprocessed uploads found"}
 
     det_cfg = ctx.detection_config()
     train_cfg = ctx.training_config()

--- a/services/web/src/static/training_jobs.js
+++ b/services/web/src/static/training_jobs.js
@@ -58,9 +58,32 @@
     };
   };
 
+  /* Update hint text when job type changes. */
+  function _setupJobTypeHint() {
+    var sel = document.getElementById("job-type");
+    var hint = document.getElementById("params-hint");
+    var textarea = document.getElementById("params-json");
+    if (!sel || !hint) return;
+
+    var defaultHint = "Override defaults from config. Leave {} for defaults.";
+    var processHint = "Processes all uploaded videos that haven't been processed yet. No parameters needed.";
+
+    function update() {
+      if (sel.value === "process_video") {
+        hint.textContent = processHint;
+        if (textarea && textarea.value === "{}") textarea.value = "{}";
+      } else {
+        hint.textContent = defaultHint;
+      }
+    }
+    sel.addEventListener("change", update);
+    update();
+  }
+
   /* Auto-start stream on page load: either for a just-submitted job
      (via ?submitted= query param) or for any already-running job. */
   document.addEventListener("DOMContentLoaded", function () {
+    _setupJobTypeHint();
     var params = new URLSearchParams(window.location.search);
     var submitted = params.get("submitted");
     if (submitted) {

--- a/services/web/src/templates/training_jobs.html
+++ b/services/web/src/templates/training_jobs.html
@@ -26,7 +26,7 @@
       <div class="field-group">
         <label>Parameters (JSON)</label>
         <textarea name="params_json" id="params-json" rows="3" style="font-family:var(--mono);font-size:0.8rem;">{}</textarea>
-        <p class="hint">Override defaults from config. Leave {} for defaults.</p>
+        <p class="hint" id="params-hint">Override defaults from config. Leave {} for defaults.</p>
       </div>
     </div>
     <button type="submit" class="btn">Submit Job</button>


### PR DESCRIPTION
## Summary
- **Compose profile gate**: Trainer service uses ARM64-only L4T base image. Gated behind `profiles: ["training"]` so `docker compose pull` on x86 hosts doesn't fail on the missing arch manifest. On the Orin, `COMPOSE_PROFILES=training` in `.env` keeps it always-on.
- **GHCR image tag**: Added `image:` line so the trainer can be pulled from GHCR instead of requiring a local build.
- **Auto-discover uploads**: `process_video` jobs no longer require explicit `upload_ids`. When submitted with `{}` params, the trainer queries the DB for all uploads with `status='uploaded'` and processes them. Explicit IDs still work for re-processing specific uploads.
- **UI hint**: The params hint updates when "Process Videos" is selected to indicate no parameters are needed.

## Test plan
- [ ] On Orin: `echo "COMPOSE_PROFILES=training" >> .env` then `docker compose up -d` starts trainer
- [ ] On x86: `docker compose pull` succeeds (trainer skipped)
- [ ] Submit a `process_video` job with `{}` params — processes all `uploaded` videos
- [ ] Submit a `process_video` job with no `uploaded` videos — returns "No unprocessed uploads found"
- [ ] Submit a `process_video` job with explicit `upload_ids` — still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)