### PR TITLE
fix(trainer): pin numpy<2 for PyTorch 2.4 compatibility

### DIFF
--- a/services/trainer/requirements.txt
+++ b/services/trainer/requirements.txt
@@ -1,3 +1,4 @@
+numpy<2
 ultralytics>=8.3.0
 opencv-python-headless>=4.8.0
 roboflow>=1.1.0


### PR DESCRIPTION
## Summary
- Pin `numpy<2` in trainer requirements to prevent pip from installing numpy 2.x, which is ABI-incompatible with the PyTorch 2.4.0 wheels in the L4T base image
- Without this pin, every `process_video` job fails with `RuntimeError: Numpy is not available` at `torch.from_numpy()` during YOLO inference
- All uploads processed under v1.16.3 were marked "failed" due to this

## Root cause
The `dustynv/l4t-pytorch:r36.4.0` base image ships PyTorch 2.4.0 compiled against numpy 1.x. When `ultralytics>=8.3.0` is installed, pip resolves numpy 2.2.6 (the latest), which breaks the torch↔numpy C bridge at runtime.

## Test plan
- [ ] Rebuild trainer image on Orin self-hosted runner
- [ ] Verify `docker exec scarguard-trainer python3 -c "import torch, numpy as np; print(torch.from_numpy(np.array([1.0])))"` succeeds
- [ ] Reset failed uploads to `uploaded` status and re-run process_video job
- [ ] Confirm uploads process successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)