### PR TITLE
fix(web): add trainer/backup to log viewer + upload error tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ ScarGuard works with any RTSP-capable cameras and any Docker host with an NVIDIA
 | `notifier` | Redis subscriber, Discord + email + webhook + ntfy dispatch | `python:3.11-slim` |
 | `deterrent` | Tuya Cloud device control (sprinklers, lights, sirens) | `python:3.11-slim` |
 | `log-streamer` | Tails container logs, publishes to Redis for web UI | `python:3.11-slim` |
+| `trainer` | Video processing, dataset prep, YOLO training (ARM64/Jetson only, opt-in profile) | `dustynv/l4t-pytorch:r36.4.0` |
+| `backup` | SQLite online-backup sidecar (scarguard.db, auth.db, deterrent.db) | `python:3.11-slim` |
 | `caddy` | HTTPS reverse proxy | `caddy:2-alpine` |
 | `redis` | Internal message bus | `redis:alpine` |
 
@@ -728,8 +730,8 @@ system:
 
 **Logs page** — **Admin → Logs**
 
-Live tail of container logs from the detector, web, and notifier services. Filter by:
-- Service (detector / web / notifier)
+Live tail of container logs from all services (detector, notifier, deterrent, web, caddy, trainer, backup). Filter by:
+- Service
 - Log level (All / Debug+ / Info+ / Warning+ / Error only)
 - Tail depth (200–2000 lines)
 

--- a/services/web/src/routes/admin.py
+++ b/services/web/src/routes/admin.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 router = APIRouter(prefix="/admin")
 templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
 
-SERVICES = ["detector", "notifier", "deterrent", "web", "caddy"]
+SERVICES = ["detector", "notifier", "deterrent", "web", "caddy", "trainer", "backup"]
 
 # Redis key prefixes — must match log-streamer sidecar constants.
 _CHANNEL_PREFIX = "scarguard:logs:"

--- a/services/web/src/templates/partials/training_upload_rows.html
+++ b/services/web/src/templates/partials/training_upload_rows.html
@@ -6,7 +6,7 @@
   <td>{{ u.detection_count if u.detection_count is not none else '—' }}</td>
   <td>
     {% if u.status == 'processed' %}<span class="badge badge-armed">{{ u.status }}</span>
-    {% elif u.status == 'failed' %}<span class="badge badge-disarmed">{{ u.status }}</span>
+    {% elif u.status == 'failed' %}<span class="badge badge-disarmed" {% if u.error %}title="{{ u.error }}"{% endif %}>{{ u.status }}</span>
     {% elif u.status == 'processing' %}<span class="badge" style="background:var(--warn);color:#000;">{{ u.status }}</span>
     {% else %}<span class="badge">{{ u.status }}</span>
     {% endif %}


### PR DESCRIPTION
## Summary
- **Log viewer:** Added `trainer` and `backup` to the hardcoded service list in the admin log viewer. The log-streamer sidecar already tails all compose services, but the UI dropdown was missing these two.
- **Upload error tooltips:** Failed uploads on the training uploads page now show the stored error message as a hover tooltip on the status badge, so users can see why processing failed without digging into logs.

## Test plan
- [ ] Open Admin > Logs and verify "trainer" and "backup" appear in the service dropdown
- [ ] Trigger a failed training upload and confirm hovering over the red "failed" badge shows the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)