### PR TITLE
feat(web): multi-box Re-label canvas in labeling queue

### DIFF
--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -82,6 +82,11 @@ def ensure_training_tables() -> None:
         _add_column_if_missing(conn, "training_uploads", "detector_model", "detector_model TEXT")
         _add_column_if_missing(conn, "training_uploads", "confidence_threshold", "confidence_threshold REAL")
         _add_column_if_missing(conn, "training_uploads", "hints", "hints TEXT")
+        # Human-drawn replacement annotations for a frame. JSON list of
+        # {"cls": str, "bbox": [xc, yc, w, h]} where bbox is normalized.
+        # When set on a 'corrected' event, the exporter emits one YOLO row
+        # per entry instead of the detector's original bbox+predicted_class.
+        _add_column_if_missing(conn, "training_events", "corrected_bboxes", "corrected_bboxes TEXT")
         conn.commit()
 
 
@@ -1024,16 +1029,24 @@ def update_training_event_review(
     event_id: int,
     review_state: str,
     corrected_class: str | None = None,
+    corrected_bboxes: str | None = None,
 ) -> bool:
+    """Update review_state, optional corrected_class, optional corrected_bboxes.
+
+    ``corrected_bboxes`` is a JSON-encoded list of
+    ``{"cls": str, "bbox": [xc, yc, w, h]}`` (normalized 0-1) that overrides
+    the detector's prediction at export time.
+    """
     now = datetime.now(timezone.utc).isoformat()
     with _connect() as conn:
         cur = conn.execute(
             """
             UPDATE training_events
-            SET review_state = ?, corrected_class = ?, reviewed_at = ?
+            SET review_state = ?, corrected_class = ?, corrected_bboxes = ?,
+                reviewed_at = ?
             WHERE id = ?
             """,
-            (review_state, corrected_class, now, event_id),
+            (review_state, corrected_class, corrected_bboxes, now, event_id),
         )
         conn.commit()
         return cur.rowcount > 0

--- a/services/web/src/routes/training_uploads.py
+++ b/services/web/src/routes/training_uploads.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from rate_limit_dep import rate_limit
-from route_auth import require_admin, require_viewer
+from route_auth import current_role, require_admin, require_viewer
 from starlette.responses import Response
 
 logger = logging.getLogger(__name__)
@@ -43,6 +43,49 @@ _UPLOAD_LIST_URL = "/admin/training/uploads"
 _SAFE_ID = re.compile(r"^[0-9a-f]{32}$")
 _HINT_RE = re.compile(r"^[a-z0-9][a-z0-9 _-]{0,31}$")
 _MAX_HINTS = 8
+_RELABEL_CLASS_RE = re.compile(r"^[a-z0-9][a-z0-9 _-]{0,63}$")
+_MAX_RELABEL_BOXES = 32
+
+
+def _validate_corrected_bboxes(raw: str) -> str | None:
+    """Validate a JSON payload of human-drawn replacement boxes.
+
+    Expected shape: ``[{"cls": "duck", "bbox": [xc, yc, w, h]}, ...]`` with
+    bbox values normalized to 0-1. Returns the canonical JSON string to
+    store, or ``None`` if the payload is empty / invalid.
+    """
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, list) or not data or len(data) > _MAX_RELABEL_BOXES:
+        return None
+    out: list[dict] = []
+    for item in data:
+        if not isinstance(item, dict):
+            return None
+        cls = item.get("cls")
+        bbox = item.get("bbox")
+        if not isinstance(cls, str) or not _RELABEL_CLASS_RE.match(cls.lower().strip()):
+            return None
+        if not isinstance(bbox, list) or len(bbox) != 4:
+            return None
+        try:
+            xc, yc, w, h = (float(v) for v in bbox)
+        except (TypeError, ValueError):
+            return None
+        if not (0.0 <= xc <= 1.0 and 0.0 <= yc <= 1.0):
+            return None
+        if not (0.0 < w <= 1.0 and 0.0 < h <= 1.0):
+            return None
+        out.append({
+            "cls": cls.lower().strip(),
+            "bbox": [round(xc, 6), round(yc, 6), round(w, 6), round(h, 6)],
+        })
+    return json.dumps(out)
 
 
 def _list_model_filenames() -> list[str]:
@@ -473,6 +516,7 @@ async def review_event(
     event_id: int,
     action: str = Form(...),
     corrected_class: str = Form(""),
+    corrected_bboxes: str = Form(""),
 ) -> Response:
     gate = require_admin(request)
     if not isinstance(gate, dict):
@@ -486,10 +530,16 @@ async def review_event(
         return JSONResponse({"error": "event not found in this upload"}, status_code=404)
 
     corrected = corrected_class.strip()[:64] if action == "corrected" else None
-    if action == "corrected" and not corrected:
-        return JSONResponse({"error": "corrected_class required"}, status_code=400)
+    bboxes_json = _validate_corrected_bboxes(corrected_bboxes) if action == "corrected" else None
+    if action == "corrected" and not corrected and not bboxes_json:
+        return JSONResponse(
+            {"error": "corrected_class or corrected_bboxes required"},
+            status_code=400,
+        )
+    if action == "corrected" and corrected_bboxes and bboxes_json is None:
+        return JSONResponse({"error": "invalid corrected_bboxes payload"}, status_code=400)
 
-    db_module.update_training_event_review(event_id, action, corrected)
+    db_module.update_training_event_review(event_id, action, corrected, bboxes_json)
 
     rs = request.query_params.get("review_state", "")
     dp = request.query_params.get("detection_pass", "")
@@ -534,6 +584,9 @@ async def review_event(
             "filter_review_state": rs,
             "filter_detection_pass": dp,
             "auto_advance": True,
+            # Partial render bypasses base.html's _is_admin derivation, so
+            # pass it explicitly or the action buttons vanish after HTMX swap.
+            "_is_admin": current_role(request) == "admin",
         },
     )
 

--- a/services/web/src/routes/training_uploads.py
+++ b/services/web/src/routes/training_uploads.py
@@ -77,9 +77,13 @@ def _validate_corrected_bboxes(raw: str) -> str | None:
             xc, yc, w, h = (float(v) for v in bbox)
         except (TypeError, ValueError):
             return None
-        if not (0.0 <= xc <= 1.0 and 0.0 <= yc <= 1.0):
-            return None
         if not (0.0 < w <= 1.0 and 0.0 < h <= 1.0):
+            return None
+        # Reject boxes whose extents fall outside the image — clamping the
+        # center alone allows e.g. xc=1.0, w=0.6 (right edge at 1.3).
+        if not (0.0 <= xc - w / 2 and xc + w / 2 <= 1.0):
+            return None
+        if not (0.0 <= yc - h / 2 and yc + h / 2 <= 1.0):
             return None
         out.append({
             "cls": cls.lower().strip(),

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -1076,6 +1076,24 @@ body.expert-mode details.expert-only { display: block !important; }
 .label-bbox.state-approved { border-color: var(--ok); }
 .label-bbox.state-rejected { border-color: var(--danger); }
 .label-bbox.state-corrected { border-color: var(--warn); }
+/* Original detector box is no longer authoritative once human-drawn
+   boxes are saved — keep it visible but dimmed for reference. */
+.label-bbox.state-superseded {
+  border-style: dashed; border-color: #888; opacity: 0.5;
+}
+
+.label-relabel-boxes {
+  position: absolute; inset: 0; pointer-events: none;
+}
+.relabel-saved-box {
+  position: absolute; border: 2px solid #34d399; box-sizing: border-box;
+}
+.relabel-saved-label {
+  position: absolute; top: 0; left: 0;
+  background: #34d399; color: #0a1a12;
+  font-family: monospace; font-size: 0.75rem;
+  padding: 0 0.3rem; line-height: 1.1rem;
+}
 
 .label-canvas {
   position: absolute; left: 0; top: 0; width: 100%; height: 100%;

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -1064,10 +1064,9 @@ body.expert-mode details.expert-only { display: block !important; }
 }
 .label-frame-wrap {
   position: relative; line-height: 0; background: #000; border-radius: 6px;
-  overflow: hidden;
 }
 .label-frame-wrap img {
-  width: 100%; height: auto; display: block;
+  width: 100%; height: auto; display: block; border-radius: 6px;
 }
 .label-bbox {
   position: absolute; border: 2px solid #ff3333; pointer-events: none;
@@ -1089,12 +1088,11 @@ body.expert-mode details.expert-only { display: block !important; }
   position: absolute; border: 2px solid #34d399; box-sizing: border-box;
 }
 .relabel-saved-label {
-  position: absolute; top: 0; left: 0;
-  background: rgba(52, 211, 153, 0.85); color: #0a1a12;
-  font-family: monospace; font-size: 0.65rem;
-  padding: 0 0.2rem; line-height: 0.95rem;
-  max-width: 100%; white-space: nowrap;
-  overflow: hidden; text-overflow: ellipsis;
+  position: absolute; bottom: 100%; left: -2px;
+  background: rgba(52, 211, 153, 0.9); color: #0a1a12;
+  font-family: monospace; font-size: 0.7rem;
+  padding: 0 0.25rem; line-height: 1rem;
+  white-space: nowrap;
 }
 
 .label-canvas {

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -1090,9 +1090,11 @@ body.expert-mode details.expert-only { display: block !important; }
 }
 .relabel-saved-label {
   position: absolute; top: 0; left: 0;
-  background: #34d399; color: #0a1a12;
-  font-family: monospace; font-size: 0.75rem;
-  padding: 0 0.3rem; line-height: 1.1rem;
+  background: rgba(52, 211, 153, 0.85); color: #0a1a12;
+  font-family: monospace; font-size: 0.65rem;
+  padding: 0 0.2rem; line-height: 0.95rem;
+  max-width: 100%; white-space: nowrap;
+  overflow: hidden; text-overflow: ellipsis;
 }
 
 .label-canvas {

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -117,6 +117,7 @@ main {
   margin: 0 auto;
   padding: 2rem 1.5rem;
 }
+main.main-wide { max-width: 1400px; }
 
 h1 { font-size: 1.4rem; font-weight: 600; margin-bottom: 1.25rem; }
 h2 { font-size: 1.05rem; font-weight: 600; margin-bottom: 0.75rem; }
@@ -1055,10 +1056,10 @@ body.expert-mode details.expert-only { display: block !important; }
 .stat-label { font-size: 0.75rem; color: var(--muted); }
 
 .label-viewer {
-  display: grid; grid-template-columns: 1fr 340px; gap: 1.25rem;
+  display: grid; grid-template-columns: 1fr 360px; gap: 1.25rem;
   align-items: start; margin-bottom: 1rem;
 }
-@media (max-width: 900px) {
+@media (max-width: 1100px) {
   .label-viewer { grid-template-columns: 1fr; }
 }
 .label-frame-wrap {
@@ -1075,6 +1076,29 @@ body.expert-mode details.expert-only { display: block !important; }
 .label-bbox.state-approved { border-color: var(--ok); }
 .label-bbox.state-rejected { border-color: var(--danger); }
 .label-bbox.state-corrected { border-color: var(--warn); }
+
+.label-canvas {
+  position: absolute; left: 0; top: 0; width: 100%; height: 100%;
+  cursor: crosshair; touch-action: none;
+}
+.label-canvas[hidden] { display: none; }
+
+.label-relabel-panel { margin-top: 0.75rem; }
+.label-relabel-panel[hidden] { display: none; }
+.relabel-help { font-size: 0.85rem; margin-bottom: 0.5rem; }
+.relabel-box-list {
+  border: 1px solid var(--border); border-radius: 4px; padding: 0.4rem 0.6rem;
+  margin: 0.5rem 0; min-height: 2.2rem;
+}
+.relabel-empty { font-size: 0.85rem; margin: 0; }
+.relabel-box-row {
+  display: flex; align-items: center; gap: 0.5rem; padding: 0.15rem 0;
+  font-size: 0.9rem;
+}
+.relabel-box-idx { color: var(--muted); font-family: monospace; }
+.relabel-box-cls { font-weight: 600; }
+.relabel-box-remove { margin-left: auto; }
+.relabel-actions { display: flex; gap: 0.5rem; }
 
 .label-detail { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 1rem; }
 .label-meta { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; margin-bottom: 0.75rem; }

--- a/services/web/src/static/training_label.js
+++ b/services/web/src/static/training_label.js
@@ -154,12 +154,14 @@
       var h = b[3] * canvas.height;
       ctx.strokeStyle = "#34d399";
       ctx.strokeRect(x, y, w, h);
-      ctx.fillStyle = "rgba(52, 211, 153, 0.85)";
+      ctx.fillStyle = "rgba(52, 211, 153, 0.9)";
       var label = _relabelBoxes[i].cls + " #" + (i + 1);
       var tw = ctx.measureText(label).width + 4;
-      ctx.fillRect(x, y, tw, 12);
+      /* Label above the box when there's room; flip inside when at top edge. */
+      var ly = y >= 12 ? y - 12 : y;
+      ctx.fillRect(x, ly, tw, 12);
       ctx.fillStyle = "#0a1a12";
-      ctx.fillText(label, x + 2, y + 9);
+      ctx.fillText(label, x + 2, ly + 9);
     }
 
     /* Active drag */

--- a/services/web/src/static/training_label.js
+++ b/services/web/src/static/training_label.js
@@ -1,4 +1,4 @@
-/* Labeling queue: bbox overlay, keyboard shortcuts, auto-advance. */
+/* Labeling queue: bbox overlay, keyboard shortcuts, multi-box re-label canvas. */
 (function () {
   "use strict";
 
@@ -11,8 +11,19 @@
   function _isHexId(s) { return typeof s === "string" && /^[a-f0-9]+$/.test(s); }
   function _isUInt(s)  { return /^\d+$/.test(String(s || "")); }
 
+  /* Per-card relabel state. Reset on every card swap. */
+  var _relabelBoxes = [];   /* [{cls, bbox: [xc,yc,w,h]}] */
+  var _drawing = null;      /* {startX, startY, curX, curY} during a drag */
+  var _relabelActive = false;
+
+  function _clamp01(v) { return Math.max(0, Math.min(1, v)); }
+
+  function _detail() { return document.getElementById("label-detail"); }
+
+  /* ── Original-detector bbox overlay ────────────────────────────────── */
+
   function renderBbox() {
-    var detail = document.getElementById("label-detail");
+    var detail = _detail();
     var box = document.getElementById("label-bbox");
     if (!detail || !box) return;
     box.classList.remove("state-approved", "state-rejected", "state-corrected");
@@ -35,7 +46,7 @@
   }
 
   function updateFrame() {
-    var detail = document.getElementById("label-detail");
+    var detail = _detail();
     var img = document.getElementById("label-frame");
     if (!detail || !img) return;
     var frameIdx = detail.dataset.frameIdx;
@@ -44,7 +55,7 @@
   }
 
   function navigateEvent(direction) {
-    var detail = document.getElementById("label-detail");
+    var detail = _detail();
     if (!detail) return;
     var targetId = direction === "next" ? detail.dataset.nextId : detail.dataset.prevId;
     if (!_isHexId(_labelData.uploadId) || !_isUInt(targetId)) return;
@@ -54,16 +65,247 @@
     window.location.href = "/admin/training/uploads/" + _labelData.uploadId + qs;
   }
 
-  /* Delegated click for the Correct button (CSP forbids inline onclick).
-     Delegation survives HTMX swaps that replace the card. */
+  /* ── Re-label canvas ─────────────────────────────────────────────── */
+
+  function _resetRelabelState() {
+    _relabelBoxes = [];
+    _drawing = null;
+    _relabelActive = false;
+    var canvas = document.getElementById("label-canvas");
+    if (canvas) canvas.hidden = true;
+    var panel = document.getElementById("relabel-panel");
+    if (panel) panel.hidden = true;
+    var list = document.getElementById("relabel-box-list");
+    if (list) list.innerHTML = '<p class="muted relabel-empty">No boxes drawn yet.</p>';
+    var submit = document.getElementById("btn-relabel-submit");
+    if (submit) submit.disabled = true;
+    _renderRelabelOverlay();
+  }
+
+  function _sizeCanvasToImage() {
+    var img = document.getElementById("label-frame");
+    var canvas = document.getElementById("label-canvas");
+    if (!img || !canvas) return;
+    canvas.width = img.clientWidth;
+    canvas.height = img.clientHeight;
+  }
+
+  function _activateRelabel() {
+    if (_relabelActive) return;
+    _relabelActive = true;
+    var panel = document.getElementById("relabel-panel");
+    if (panel) panel.hidden = false;
+    var canvas = document.getElementById("label-canvas");
+    if (canvas) {
+      canvas.hidden = false;
+      _sizeCanvasToImage();
+      _drawCanvas();
+    }
+    var input = document.getElementById("relabel-class-input");
+    if (input) input.focus();
+  }
+
+  function _drawCanvas() {
+    var canvas = document.getElementById("label-canvas");
+    if (!canvas) return;
+    var ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    /* Existing drawn boxes */
+    ctx.lineWidth = 2;
+    ctx.font = "14px monospace";
+    for (var i = 0; i < _relabelBoxes.length; i++) {
+      var b = _relabelBoxes[i].bbox;
+      var x = (b[0] - b[2] / 2) * canvas.width;
+      var y = (b[1] - b[3] / 2) * canvas.height;
+      var w = b[2] * canvas.width;
+      var h = b[3] * canvas.height;
+      ctx.strokeStyle = "#34d399";
+      ctx.strokeRect(x, y, w, h);
+      ctx.fillStyle = "rgba(52, 211, 153, 0.85)";
+      var label = _relabelBoxes[i].cls + " #" + (i + 1);
+      var tw = ctx.measureText(label).width + 8;
+      ctx.fillRect(x, Math.max(0, y - 18), tw, 18);
+      ctx.fillStyle = "#0a1a12";
+      ctx.fillText(label, x + 4, Math.max(12, y - 4));
+    }
+
+    /* Active drag */
+    if (_drawing) {
+      var dx = Math.min(_drawing.startX, _drawing.curX);
+      var dy = Math.min(_drawing.startY, _drawing.curY);
+      var dw = Math.abs(_drawing.curX - _drawing.startX);
+      var dh = Math.abs(_drawing.curY - _drawing.startY);
+      ctx.strokeStyle = "#fbbf24";
+      ctx.setLineDash([4, 3]);
+      ctx.strokeRect(dx, dy, dw, dh);
+      ctx.setLineDash([]);
+    }
+  }
+
+  function _renderRelabelOverlay() {
+    if (_relabelActive) {
+      _drawCanvas();
+    }
+    var list = document.getElementById("relabel-box-list");
+    if (!list) return;
+    if (_relabelBoxes.length === 0) {
+      list.innerHTML = '<p class="muted relabel-empty">No boxes drawn yet.</p>';
+    } else {
+      var html = "";
+      for (var i = 0; i < _relabelBoxes.length; i++) {
+        var b = _relabelBoxes[i];
+        html += '<div class="relabel-box-row">';
+        html += '<span class="relabel-box-idx">#' + (i + 1) + '</span> ';
+        html += '<span class="relabel-box-cls">' + _escape(b.cls) + '</span> ';
+        html += '<button type="button" class="btn btn-small relabel-box-remove" data-idx="' + i + '">Remove</button>';
+        html += '</div>';
+      }
+      list.innerHTML = html;
+    }
+    var submit = document.getElementById("btn-relabel-submit");
+    if (submit) submit.disabled = _relabelBoxes.length === 0;
+  }
+
+  function _escape(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  /* Canvas mouse handlers (delegated; canvas may re-mount on swap). */
+
+  function _onCanvasDown(e) {
+    if (!_relabelActive) return;
+    var canvas = document.getElementById("label-canvas");
+    if (!canvas || e.target !== canvas) return;
+    var rect = canvas.getBoundingClientRect();
+    _drawing = {
+      startX: e.clientX - rect.left,
+      startY: e.clientY - rect.top,
+      curX: e.clientX - rect.left,
+      curY: e.clientY - rect.top,
+    };
+    e.preventDefault();
+  }
+
+  function _onCanvasMove(e) {
+    if (!_drawing) return;
+    var canvas = document.getElementById("label-canvas");
+    if (!canvas) return;
+    var rect = canvas.getBoundingClientRect();
+    _drawing.curX = e.clientX - rect.left;
+    _drawing.curY = e.clientY - rect.top;
+    _drawCanvas();
+  }
+
+  function _onCanvasUp(e) {
+    if (!_drawing) return;
+    var canvas = document.getElementById("label-canvas");
+    if (!canvas) { _drawing = null; return; }
+    var rect = canvas.getBoundingClientRect();
+    var endX = e.clientX - rect.left;
+    var endY = e.clientY - rect.top;
+    var x1 = Math.min(_drawing.startX, endX);
+    var y1 = Math.min(_drawing.startY, endY);
+    var x2 = Math.max(_drawing.startX, endX);
+    var y2 = Math.max(_drawing.startY, endY);
+    _drawing = null;
+
+    var w = x2 - x1;
+    var h = y2 - y1;
+    if (w < 6 || h < 6) { _drawCanvas(); return; }
+
+    var cw = canvas.width || 1;
+    var ch = canvas.height || 1;
+    var input = document.getElementById("relabel-class-input");
+    var cls = (input && input.value || "").trim().toLowerCase();
+    if (!cls) {
+      alert("Pick a class before drawing a box.");
+      _drawCanvas();
+      return;
+    }
+
+    _relabelBoxes.push({
+      cls: cls,
+      bbox: [
+        _clamp01((x1 + w / 2) / cw),
+        _clamp01((y1 + h / 2) / ch),
+        _clamp01(w / cw),
+        _clamp01(h / ch),
+      ],
+    });
+    _renderRelabelOverlay();
+  }
+
+  /* ── Submit re-label ─────────────────────────────────────────────── */
+
+  function _submitRelabel() {
+    var detail = _detail();
+    if (!detail) return;
+    var eventId = detail.dataset.eventId;
+    var uploadId = detail.dataset.uploadId;
+    if (!_isHexId(uploadId) || !_isUInt(eventId)) return;
+    if (_relabelBoxes.length === 0) return;
+
+    var csrf = detail.dataset.csrfToken || "";
+    var fd = new FormData();
+    fd.append("_csrf_token", csrf);
+    fd.append("action", "corrected");
+    fd.append("corrected_bboxes", JSON.stringify(_relabelBoxes));
+
+    var qs = "?review_state=" + encodeURIComponent(detail.dataset.filterReviewState || "")
+           + "&detection_pass=" + encodeURIComponent(detail.dataset.filterDetectionPass || "");
+    var url = "/admin/training/uploads/" + uploadId + "/events/" + eventId + "/review" + qs;
+
+    fetch(url, { method: "POST", body: fd, credentials: "same-origin" })
+      .then(function (r) {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.text();
+      })
+      .then(function (html) {
+        var card = document.getElementById("label-card");
+        if (card) card.innerHTML = html;
+        /* Manual init: fetch() doesn't fire htmx:afterSettle. */
+        _afterCardSwap();
+      })
+      .catch(function (err) {
+        alert("Submit failed: " + err.message);
+      });
+  }
+
+  function _afterCardSwap() {
+    _resetRelabelState();
+    renderBbox();
+    updateFrame();
+  }
+
+  /* ── Event delegation (survives partial swaps) ──────────────────── */
+
   document.addEventListener("click", function (e) {
     var t = e.target;
-    if (t && t.id === "btn-show-correct") {
-      var form = document.getElementById("correct-form");
-      if (form) form.style.display = "block";
-      var input = document.getElementById("corrected-class");
-      if (input) input.focus();
+    if (!t) return;
+    if (t.id === "btn-relabel") {
+      _activateRelabel();
+    } else if (t.id === "btn-relabel-cancel") {
+      _resetRelabelState();
+    } else if (t.id === "btn-relabel-submit") {
+      _submitRelabel();
+    } else if (t.classList && t.classList.contains("relabel-box-remove")) {
+      var idx = parseInt(t.getAttribute("data-idx") || "-1", 10);
+      if (idx >= 0 && idx < _relabelBoxes.length) {
+        _relabelBoxes.splice(idx, 1);
+        _renderRelabelOverlay();
+      }
     }
+  });
+
+  document.addEventListener("mousedown", _onCanvasDown);
+  document.addEventListener("mousemove", _onCanvasMove);
+  document.addEventListener("mouseup", _onCanvasUp);
+  window.addEventListener("resize", function () {
+    if (_relabelActive) { _sizeCanvasToImage(); _drawCanvas(); }
   });
 
   document.addEventListener("keydown", function (e) {
@@ -79,9 +321,9 @@
         var btnR = document.getElementById("btn-reject");
         if (btnR) btnR.click();
         break;
-      case "c":
-        var btnC = document.getElementById("btn-show-correct");
-        if (btnC) btnC.click();
+      case "r":
+        var btnRl = document.getElementById("btn-relabel");
+        if (btnRl) btnRl.click();
         break;
       case "j":
       case "ArrowRight":
@@ -93,18 +335,16 @@
         e.preventDefault();
         navigateEvent("prev");
         break;
+      case "Escape":
+        if (_relabelActive) { _resetRelabelState(); }
+        break;
     }
   });
 
-  /* After HTMX swaps the label card, re-render bbox and update frame. */
+  /* After HTMX swaps the label card (approve/reject), re-init. */
   document.addEventListener("htmx:afterSettle", function (e) {
     if (e.detail.target && e.detail.target.id === "label-card") {
-      renderBbox();
-      updateFrame();
-      var detail = document.getElementById("label-detail");
-      if (detail && detail.dataset.autoAdvance === "1" && detail.dataset.eventId) {
-        /* Auto-advanced: already showing the next event */
-      }
+      _afterCardSwap();
     }
   });
 

--- a/services/web/src/static/training_label.js
+++ b/services/web/src/static/training_label.js
@@ -145,7 +145,7 @@
 
     /* Existing drawn boxes */
     ctx.lineWidth = 2;
-    ctx.font = "14px monospace";
+    ctx.font = "10px monospace";
     for (var i = 0; i < _relabelBoxes.length; i++) {
       var b = _relabelBoxes[i].bbox;
       var x = (b[0] - b[2] / 2) * canvas.width;
@@ -156,10 +156,10 @@
       ctx.strokeRect(x, y, w, h);
       ctx.fillStyle = "rgba(52, 211, 153, 0.85)";
       var label = _relabelBoxes[i].cls + " #" + (i + 1);
-      var tw = ctx.measureText(label).width + 8;
-      ctx.fillRect(x, Math.max(0, y - 18), tw, 18);
+      var tw = ctx.measureText(label).width + 4;
+      ctx.fillRect(x, y, tw, 12);
       ctx.fillStyle = "#0a1a12";
-      ctx.fillText(label, x + 4, Math.max(12, y - 4));
+      ctx.fillText(label, x + 2, y + 9);
     }
 
     /* Active drag */
@@ -354,6 +354,9 @@
         if (btnR) btnR.click();
         break;
       case "r":
+        /* Prevent the keystroke from leaking into the class input
+           that gets focused inside _activateRelabel(). */
+        e.preventDefault();
         var btnRl = document.getElementById("btn-relabel");
         if (btnRl) btnRl.click();
         break;

--- a/services/web/src/static/training_label.js
+++ b/services/web/src/static/training_label.js
@@ -238,20 +238,25 @@
     var canvas = document.getElementById("label-canvas");
     if (!canvas) { _drawing = null; return; }
     var rect = canvas.getBoundingClientRect();
-    var endX = e.clientX - rect.left;
-    var endY = e.clientY - rect.top;
-    var x1 = Math.min(_drawing.startX, endX);
-    var y1 = Math.min(_drawing.startY, endY);
-    var x2 = Math.max(_drawing.startX, endX);
-    var y2 = Math.max(_drawing.startY, endY);
+    var cw = canvas.width || 1;
+    var ch = canvas.height || 1;
+    /* Clamp endpoints to canvas bounds — mouseup is document-wide, so
+       releases outside the frame would otherwise produce boxes whose
+       extents fall outside [0, 1] after normalization. */
+    var endX = Math.max(0, Math.min(cw, e.clientX - rect.left));
+    var endY = Math.max(0, Math.min(ch, e.clientY - rect.top));
+    var startX = Math.max(0, Math.min(cw, _drawing.startX));
+    var startY = Math.max(0, Math.min(ch, _drawing.startY));
+    var x1 = Math.min(startX, endX);
+    var y1 = Math.min(startY, endY);
+    var x2 = Math.max(startX, endX);
+    var y2 = Math.max(startY, endY);
     _drawing = null;
 
     var w = x2 - x1;
     var h = y2 - y1;
     if (w < 6 || h < 6) { _drawCanvas(); return; }
 
-    var cw = canvas.width || 1;
-    var ch = canvas.height || 1;
     var input = document.getElementById("relabel-class-input");
     var cls = (input && input.value || "").trim().toLowerCase();
     if (!cls) {
@@ -263,10 +268,10 @@
     _relabelBoxes.push({
       cls: cls,
       bbox: [
-        _clamp01((x1 + w / 2) / cw),
-        _clamp01((y1 + h / 2) / ch),
-        _clamp01(w / cw),
-        _clamp01(h / ch),
+        (x1 + w / 2) / cw,
+        (y1 + h / 2) / ch,
+        w / cw,
+        h / ch,
       ],
     });
     _renderRelabelOverlay();
@@ -299,7 +304,16 @@
       })
       .then(function (html) {
         var card = document.getElementById("label-card");
-        if (card) card.innerHTML = html;
+        if (card) {
+          card.innerHTML = html;
+          /* HTMX 1.x does not auto-initialize hx-* attributes on raw
+             innerHTML insertions. Without this, the next card's
+             Approve/Reject buttons render but their hx-post wiring is
+             dead until a full page reload. */
+          if (window.htmx && typeof window.htmx.process === "function") {
+            window.htmx.process(card);
+          }
+        }
         /* Manual init: fetch() doesn't fire htmx:afterSettle. */
         _afterCardSwap();
       })

--- a/services/web/src/static/training_label.js
+++ b/services/web/src/static/training_label.js
@@ -26,9 +26,11 @@
     var detail = _detail();
     var box = document.getElementById("label-bbox");
     if (!detail || !box) return;
-    box.classList.remove("state-approved", "state-rejected", "state-corrected");
+    box.classList.remove("state-approved", "state-rejected", "state-corrected", "state-superseded");
     var state = detail.dataset.reviewState || "";
     if (state && state !== "pending") box.classList.add("state-" + state);
+    var hasCorrected = !!(detail.dataset.correctedBboxes || "");
+    if (hasCorrected) box.classList.add("state-superseded");
     var raw = detail.dataset.bbox;
     if (!raw || raw === "[]") { box.style.display = "none"; return; }
     try {
@@ -42,6 +44,35 @@
       box.style.display = "block";
     } catch (e) {
       box.style.display = "none";
+    }
+  }
+
+  function renderCorrectedBboxes() {
+    var detail = _detail();
+    var container = document.getElementById("label-relabel-boxes");
+    if (!detail || !container) return;
+    container.innerHTML = "";
+    var raw = detail.dataset.correctedBboxes || "";
+    if (!raw) return;
+    var entries;
+    try { entries = JSON.parse(raw); } catch (e) { return; }
+    if (!Array.isArray(entries)) return;
+    for (var i = 0; i < entries.length; i++) {
+      var b = entries[i] && entries[i].bbox;
+      var cls = entries[i] && entries[i].cls;
+      if (!Array.isArray(b) || b.length < 4) continue;
+      var xc = +b[0], yc = +b[1], w = +b[2], h = +b[3];
+      var div = document.createElement("div");
+      div.className = "relabel-saved-box";
+      div.style.left = ((xc - w / 2) * 100) + "%";
+      div.style.top = ((yc - h / 2) * 100) + "%";
+      div.style.width = (w * 100) + "%";
+      div.style.height = (h * 100) + "%";
+      var label = document.createElement("span");
+      label.className = "relabel-saved-label";
+      label.textContent = (cls || "?") + " #" + (i + 1);
+      div.appendChild(label);
+      container.appendChild(div);
     }
   }
 
@@ -278,6 +309,7 @@
   function _afterCardSwap() {
     _resetRelabelState();
     renderBbox();
+    renderCorrectedBboxes();
     updateFrame();
   }
 
@@ -350,4 +382,5 @@
 
   /* Initial render */
   renderBbox();
+  renderCorrectedBboxes();
 })();

--- a/services/web/src/templates/base.html
+++ b/services/web/src/templates/base.html
@@ -52,7 +52,7 @@
     </form>
     {% endif %}
   </nav>
-  <main>
+  <main class="{% block main_class %}{% endblock %}">
     <div id="stuck-banner" class="stuck-banner" style="display:none"></div>
     {% block content %}{% endblock %}
   </main>

--- a/services/web/src/templates/partials/training_label_card.html
+++ b/services/web/src/templates/partials/training_label_card.html
@@ -6,6 +6,11 @@
      data-review-state="{{ event.review_state if event else '' }}"
      data-next-id="{{ next_event.id if next_event else '' }}"
      data-prev-id="{{ prev_event.id if prev_event else '' }}"
+     data-upload-id="{{ upload.id if upload else '' }}"
+     data-csrf-token="{{ request.state.csrf_token }}"
+     data-target-hint="{{ upload.target_class_hint if upload and upload.target_class_hint and upload.target_class_hint != 'background' else '' }}"
+     data-filter-review-state="{{ filter_review_state }}"
+     data-filter-detection-pass="{{ filter_detection_pass }}"
      {% if auto_advance is defined and auto_advance %}data-auto-advance="1"{% endif %}>
 
   {% if event %}
@@ -16,6 +21,9 @@
     <span class="muted">Frame {{ event.frame_idx }}</span>
     {% if event.review_state != 'pending' %}
     <span class="badge badge-review-{{ event.review_state }}">{{ event.review_state }}{% if event.corrected_class %}: {{ event.corrected_class }}{% endif %}</span>
+    {% endif %}
+    {% if event.corrected_bboxes %}
+    <span class="badge badge-review-corrected" title="Human-drawn replacement boxes">re-labeled</span>
     {% endif %}
   </div>
 
@@ -31,26 +39,31 @@
             hx-vals='{"action": "rejected", "_csrf_token": "{{ request.state.csrf_token }}"}'
             hx-target="#label-card"
             hx-swap="innerHTML">Reject</button>
-    <button id="btn-show-correct" class="btn btn-wrong" type="button">Correct</button>
+    <button id="btn-relabel" class="btn btn-wrong" type="button">Re-label</button>
   </div>
 
-  <div id="correct-form" class="label-correct-form" style="display:none;">
-    <form hx-post="/admin/training/uploads/{{ upload.id }}/events/{{ event.id }}/review?review_state={{ filter_review_state }}&amp;detection_pass={{ filter_detection_pass }}"
-          hx-target="#label-card"
-          hx-swap="innerHTML">
-      <input type="hidden" name="_csrf_token" value="{{ request.state.csrf_token }}">
-      <input type="hidden" name="action" value="corrected">
-      <div class="field-group">
-        <label>Corrected class</label>
-        <input id="corrected-class" type="text" name="corrected_class" list="class-options"
-               value="{{ upload.target_class_hint if upload.target_class_hint and upload.target_class_hint != 'background' else '' }}"
-               required autocomplete="off">
-        <datalist id="class-options">
-          {% for cls in target_classes %}<option value="{{ cls }}">{% endfor %}
-        </datalist>
-      </div>
-      <button type="submit" class="btn">Submit Correction</button>
-    </form>
+  <div id="relabel-panel" class="label-relabel-panel" hidden>
+    <p class="muted relabel-help">
+      Click-drag on the frame to draw a box. Pick the class for each box,
+      then submit. Use this when the detector boxed the wrong thing or
+      missed an object in the frame.
+    </p>
+    <div class="field-group">
+      <label>Class for the next box you draw</label>
+      <input id="relabel-class-input" type="text" list="class-options"
+             value="{{ upload.target_class_hint if upload.target_class_hint and upload.target_class_hint != 'background' else '' }}"
+             autocomplete="off">
+      <datalist id="class-options">
+        {% for cls in target_classes %}<option value="{{ cls }}">{% endfor %}
+      </datalist>
+    </div>
+    <div id="relabel-box-list" class="relabel-box-list">
+      <p class="muted relabel-empty">No boxes drawn yet.</p>
+    </div>
+    <div class="relabel-actions">
+      <button id="btn-relabel-submit" class="btn btn-primary" type="button" disabled>Submit Re-label</button>
+      <button id="btn-relabel-cancel" class="btn" type="button">Cancel</button>
+    </div>
   </div>
   {% endif %}
 

--- a/services/web/src/templates/partials/training_label_card.html
+++ b/services/web/src/templates/partials/training_label_card.html
@@ -3,6 +3,7 @@
      data-event-id="{{ event.id if event else '' }}"
      data-frame-idx="{{ event.frame_idx if event else '' }}"
      data-bbox="{{ event.bbox if event else '[]' }}"
+     data-corrected-bboxes="{{ event.corrected_bboxes if event and event.corrected_bboxes else '' }}"
      data-review-state="{{ event.review_state if event else '' }}"
      data-next-id="{{ next_event.id if next_event else '' }}"
      data-prev-id="{{ prev_event.id if prev_event else '' }}"

--- a/services/web/src/templates/training_label.html
+++ b/services/web/src/templates/training_label.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block main_class %}main-wide{% endblock %}
 {% block content %}
 <h1>Label: {{ upload.filename }}
   {% if upload.target_class_hint %}<span class="badge">{{ upload.target_class_hint }}</span>{% endif %}
@@ -44,6 +45,8 @@
          src="/admin/training/uploads/{{ upload.id }}/frames/{{ event.frame_idx }}"
          alt="Frame {{ event.frame_idx }}">
     <div id="label-bbox" class="label-bbox"></div>
+    <canvas id="label-canvas" class="label-canvas" hidden></canvas>
+    <div id="label-relabel-boxes" class="label-relabel-boxes"></div>
   </div>
   <div id="label-card">
     {% include "partials/training_label_card.html" %}
@@ -53,7 +56,7 @@
 <div class="kbd-legend">
   <kbd>a</kbd> Approve &nbsp;
   <kbd>x</kbd> Reject &nbsp;
-  <kbd>c</kbd> Correct &nbsp;
+  <kbd>r</kbd> Re-label &nbsp;
   <kbd>j</kbd> / <kbd>&rarr;</kbd> Next &nbsp;
   <kbd>k</kbd> / <kbd>&larr;</kbd> Prev
 </div>

--- a/training/prepare_dataset.py
+++ b/training/prepare_dataset.py
@@ -385,10 +385,14 @@ def pull_training_uploads(
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
-        events = conn.execute("""
+        # corrected_bboxes is additive (added in v1.16+); SELECT it via a
+        # tolerant query that falls back if the column is missing.
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(training_events)").fetchall()}
+        bboxes_col = "te.corrected_bboxes" if "corrected_bboxes" in cols else "NULL AS corrected_bboxes"
+        events = conn.execute(f"""
             SELECT te.id, te.upload_id, te.frame_idx, te.bbox,
                    te.predicted_class, te.confidence, te.review_state,
-                   te.corrected_class, tu.target_class_hint
+                   te.corrected_class, {bboxes_col}, tu.target_class_hint
             FROM training_events te
             JOIN training_uploads tu ON te.upload_id = tu.id
             WHERE te.review_state IN ('approved', 'corrected')
@@ -412,6 +416,37 @@ def pull_training_uploads(
 
     for r in events:
         row = dict(r)
+        key = (row["upload_id"], row["frame_idx"])
+        frame_paths[key] = Path(frames_dir) / row["upload_id"] / "frames" / f"{row['frame_idx']:06d}.jpg"
+
+        # Human-drawn replacement boxes override the detector entirely:
+        # one or more {cls, bbox} entries replace the original prediction.
+        relabeled = None
+        if row["review_state"] == "corrected" and row.get("corrected_bboxes"):
+            try:
+                relabeled = json.loads(row["corrected_bboxes"])
+                if not isinstance(relabeled, list) or not relabeled:
+                    relabeled = None
+            except (TypeError, ValueError):
+                relabeled = None
+
+        if relabeled is not None:
+            for entry in relabeled:
+                cls_name = entry.get("cls")
+                bbox = entry.get("bbox")
+                if not isinstance(cls_name, str) or not isinstance(bbox, list) or len(bbox) != 4:
+                    skipped += 1
+                    continue
+                target = _resolve_class(cls_name)
+                if target is None:
+                    print(f"    WARNING: Unmapped re-label class '{cls_name}' in training_event {row['id']}")
+                    skipped += 1
+                    continue
+                cls_idx = UNIFIED_CLASSES.index(target)
+                line = f"{cls_idx} {bbox[0]:.6f} {bbox[1]:.6f} {bbox[2]:.6f} {bbox[3]:.6f}"
+                frame_labels[key].append(line)
+            continue
+
         cls = row["corrected_class"] if row["review_state"] == "corrected" and row.get("corrected_class") else row["predicted_class"]
         target = _resolve_class(cls)
         if target is None:
@@ -422,9 +457,7 @@ def pull_training_uploads(
         cls_idx = UNIFIED_CLASSES.index(target)
         bbox = json.loads(row["bbox"]) if isinstance(row["bbox"], str) else row["bbox"]
         line = f"{cls_idx} {bbox[0]:.6f} {bbox[1]:.6f} {bbox[2]:.6f} {bbox[3]:.6f}"
-        key = (row["upload_id"], row["frame_idx"])
         frame_labels[key].append(line)
-        frame_paths[key] = Path(frames_dir) / row["upload_id"] / "frames" / f"{row['frame_idx']:06d}.jpg"
 
     for key, lines in frame_labels.items():
         img = frame_paths[key]


### PR DESCRIPTION
## Summary

- Replace "Correct" (class-only) with "Re-label": admin draws N replacement boxes on the frame with a canvas overlay, each with its own class. Handles the duck-and-raccoon case where the detector boxed the wrong thing or missed an object.
- Widen the labeling page to 1400px so the frame is large enough to annotate without zooming.
- Fix disappearing-buttons bug: partial render after HTMX approve/reject was missing `_is_admin` in the template context, so Approve/Reject/Re-label gated off until a full page reload. Now `_is_admin` is passed explicitly to the partial.

## How re-label data flows

1. UI: click **Re-label** (or press `r`) → canvas overlay appears on the frame. Pick a class, drag a rectangle, repeat for each object. Boxes appear in a side list with Remove buttons.
2. Submit → `POST /admin/training/uploads/{id}/events/{eid}/review` with `action=corrected` and `corrected_bboxes=[{"cls":"duck","bbox":[xc,yc,w,h]},...]`. Validator enforces 0-1 normalized xywh, max 32 boxes.
3. DB: new nullable `training_events.corrected_bboxes` TEXT column (additive migration; runs at web startup).
4. Exporter (`training/prepare_dataset.py`): when a corrected event has `corrected_bboxes` set, emit one YOLO row per entry instead of the detector's original bbox + predicted_class. Otherwise legacy behavior (class-only correction still works).

## Test plan

- [ ] Open an upload with pending detections in the labeling queue.
- [ ] Verify Approve → next event swaps in, buttons remain visible (regression test for the disappearing-buttons bug).
- [ ] Verify Reject → same.
- [ ] Press `r` → canvas overlay appears, original detector box stays visible underneath.
- [ ] Pick "duck", drag a rectangle → green box appears with "duck #1" label and a row in the side list.
- [ ] Pick "raccoon", drag a second rectangle → "raccoon #2" appears.
- [ ] Click Remove on box #1 → list collapses to one entry.
- [ ] Submit Re-label → card refreshes to next pending event, "re-labeled" badge shows on the prior event when navigating back.
- [ ] Cancel via `Esc` or Cancel button → canvas closes, no submission.
- [ ] Lint clean (ruff + mypy on all services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)