### PR TITLE
feat(web): frame browser for labeling missed-detection frames

### DIFF
--- a/services/trainer/src/job_runner.py
+++ b/services/trainer/src/job_runner.py
@@ -201,8 +201,14 @@ def _run_process_video(ctx: JobContext) -> dict:
             if clear_existing:
                 conn = _connect_db()
                 try:
+                    # Detector rows only — manual frame-browser annotations
+                    # (detection_pass='manual') are user work and must survive
+                    # a reprocess. Reprocessing only regenerates detector
+                    # output; manual rows are independent of model state.
                     deleted = conn.execute(
-                        "DELETE FROM training_events WHERE upload_id = ?", (uid,)
+                        "DELETE FROM training_events "
+                        "WHERE upload_id = ? AND detection_pass != 'manual'",
+                        (uid,),
                     ).rowcount
                     conn.commit()
                 finally:

--- a/services/web/src/db.py
+++ b/services/web/src/db.py
@@ -1052,6 +1052,62 @@ def update_training_event_review(
         return cur.rowcount > 0
 
 
+def insert_manual_training_event(
+    upload_id: str,
+    frame_idx: int,
+    corrected_bboxes_json: str,
+) -> int:
+    """Insert a human-annotated training event for a frame that had no detector
+    output. Stores sentinel values for the NOT NULL columns; the exporter
+    treats ``review_state='corrected'`` + ``corrected_bboxes`` as the
+    authoritative annotation regardless of the (empty) predicted class.
+
+    Returns the new event id.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    with _connect() as conn:
+        cur = conn.execute(
+            """
+            INSERT INTO training_events
+                (upload_id, frame_idx, timestamp_in_video, bbox, predicted_class,
+                 confidence, target_class_hint, detection_pass, review_state,
+                 corrected_bboxes, created_at, reviewed_at)
+            VALUES (?, ?, NULL, '[]', '', 0.0, NULL, 'manual', 'corrected',
+                    ?, ?, ?)
+            """,
+            (upload_id, frame_idx, corrected_bboxes_json, now, now),
+        )
+        conn.commit()
+        return int(cur.lastrowid or 0)
+
+
+def get_training_events_by_frames(
+    upload_id: str,
+    frame_idxs: list[int],
+) -> dict[int, list[sqlite3.Row]]:
+    """Fetch events for a specific set of frames, grouped by frame_idx.
+
+    Used by the frame-browser grid to badge thumbnails ("has detection",
+    "has annotation") without issuing one query per tile.
+    """
+    if not frame_idxs:
+        return {}
+    placeholders = ",".join("?" * len(frame_idxs))
+    out: dict[int, list[sqlite3.Row]] = {}
+    with _connect() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT * FROM training_events
+            WHERE upload_id = ?
+              AND frame_idx IN ({placeholders})
+            """,
+            [upload_id, *frame_idxs],
+        ).fetchall()
+    for r in rows:
+        out.setdefault(r["frame_idx"], []).append(r)
+    return out
+
+
 def bulk_update_training_events(
     upload_id: str,
     review_state: str,

--- a/services/web/src/routes/training_uploads.py
+++ b/services/web/src/routes/training_uploads.py
@@ -628,3 +628,243 @@ async def bulk_review(
         url=f"{_UPLOAD_LIST_URL}/{verified_id}",
         status_code=303,
     )
+
+
+# ── Frame browser ────────────────────────────────────────────────────────────
+
+
+_BROWSE_DEFAULT_STRIDE = 30
+_BROWSE_PAGE_SIZE = 60
+_BROWSE_MAX_STRIDE = 600
+
+
+def _list_frame_indices(upload_dir: Path) -> list[int]:
+    """Enumerate available frame indices on disk for an upload."""
+    frames_dir = upload_dir / "frames"
+    if not frames_dir.is_dir():
+        return []
+    out: list[int] = []
+    try:
+        for entry in frames_dir.iterdir():
+            if entry.suffix.lower() != ".jpg":
+                continue
+            stem = entry.stem
+            if stem.isdigit():
+                out.append(int(stem))
+    except OSError:
+        return []
+    out.sort()
+    return out
+
+
+@router.get("/{upload_id}/browse", response_class=HTMLResponse)
+async def browse_grid(
+    request: Request,
+    upload_id: str,
+    page: int = 1,
+    stride: str = "",
+) -> Response:
+    gate = require_viewer(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    upload_dir = _safe_upload_dir(upload_id)
+    if upload_dir is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    verified_id = upload_dir.name
+    upload = db_module.get_training_upload(verified_id)
+    if upload is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    all_frames = _list_frame_indices(upload_dir)
+    if stride == "all":
+        sampled = all_frames
+        stride_value = 1
+    else:
+        try:
+            stride_value = int(stride) if stride else _BROWSE_DEFAULT_STRIDE
+        except ValueError:
+            stride_value = _BROWSE_DEFAULT_STRIDE
+        stride_value = max(1, min(_BROWSE_MAX_STRIDE, stride_value))
+        sampled = [f for f in all_frames if f % stride_value == 0]
+
+    if page < 1:
+        page = 1
+    total = len(sampled)
+    total_pages = max(1, (total + _BROWSE_PAGE_SIZE - 1) // _BROWSE_PAGE_SIZE)
+    if page > total_pages:
+        page = total_pages
+    start = (page - 1) * _BROWSE_PAGE_SIZE
+    page_frames = sampled[start : start + _BROWSE_PAGE_SIZE]
+
+    events_by_frame = db_module.get_training_events_by_frames(verified_id, page_frames)
+
+    tiles = []
+    for frame_idx in page_frames:
+        events = events_by_frame.get(frame_idx, [])
+        has_detection = any(ev["detection_pass"] != "manual" for ev in events)
+        has_manual = any(ev["detection_pass"] == "manual" for ev in events)
+        has_annotation = any(
+            ev["corrected_bboxes"] for ev in events if ev["review_state"] == "corrected"
+        )
+        tiles.append({
+            "frame_idx": frame_idx,
+            "has_detection": has_detection,
+            "has_manual": has_manual,
+            "has_annotation": has_annotation,
+        })
+
+    return templates.TemplateResponse(
+        request,
+        "training_browse.html",
+        {
+            "upload": dict(upload),
+            "tiles": tiles,
+            "page": page,
+            "total_pages": total_pages,
+            "total": total,
+            "all_frames_total": len(all_frames),
+            "stride": stride_value,
+            "stride_param": "all" if stride == "all" else str(stride_value),
+            "showing_all": stride == "all",
+        },
+    )
+
+
+@router.get("/{upload_id}/browse/{frame_idx}", response_class=HTMLResponse)
+async def browse_frame(
+    request: Request,
+    upload_id: str,
+    frame_idx: int,
+) -> Response:
+    gate = require_viewer(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    upload_dir = _safe_upload_dir(upload_id)
+    if upload_dir is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    verified_id = upload_dir.name
+    upload = db_module.get_training_upload(verified_id)
+    if upload is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if frame_idx < 0:
+        return JSONResponse({"error": "invalid frame index"}, status_code=400)
+
+    frame_path = upload_dir / "frames" / f"{frame_idx:06d}.jpg"
+    if not frame_path.exists():
+        return JSONResponse({"error": "frame not found"}, status_code=404)
+
+    # If a detector event already exists for this frame, send the user to the
+    # existing labeling queue so re-label augments that event instead of
+    # creating a duplicate manual row.
+    existing = db_module.get_training_events_by_frames(verified_id, [frame_idx]).get(frame_idx, [])
+    detector_event = next(
+        (ev for ev in existing if ev["detection_pass"] != "manual"),
+        None,
+    )
+    if detector_event is not None:
+        return RedirectResponse(
+            url=f"{_UPLOAD_LIST_URL}/{verified_id}?event_id={detector_event['id']}",
+            status_code=303,
+        )
+
+    manual_event = next(
+        (ev for ev in existing if ev["detection_pass"] == "manual"),
+        None,
+    )
+
+    # Stride + page context so prev/next nav uses the same sampling the user
+    # entered with.
+    stride_q = request.query_params.get("stride", "")
+    all_frames = _list_frame_indices(upload_dir)
+    if stride_q == "all":
+        sampled = all_frames
+    else:
+        try:
+            stride_value = int(stride_q) if stride_q else _BROWSE_DEFAULT_STRIDE
+        except ValueError:
+            stride_value = _BROWSE_DEFAULT_STRIDE
+        stride_value = max(1, min(_BROWSE_MAX_STRIDE, stride_value))
+        sampled = [f for f in all_frames if f % stride_value == 0]
+
+    prev_frame = next_frame = None
+    if frame_idx in sampled:
+        i = sampled.index(frame_idx)
+        if i > 0:
+            prev_frame = sampled[i - 1]
+        if i < len(sampled) - 1:
+            next_frame = sampled[i + 1]
+
+    import config_store
+    cfg = config_store.load_cached()
+    target_classes = cfg.get("detection", {}).get("target_classes", [])
+
+    return templates.TemplateResponse(
+        request,
+        "training_browse_frame.html",
+        {
+            "upload": dict(upload),
+            "frame_idx": frame_idx,
+            "prev_frame": prev_frame,
+            "next_frame": next_frame,
+            "stride_param": stride_q or "",
+            "manual_event": dict(manual_event) if manual_event else None,
+            "target_classes": target_classes,
+        },
+    )
+
+
+@router.post("/{upload_id}/browse/{frame_idx}/annotate")
+async def annotate_frame(
+    request: Request,
+    upload_id: str,
+    frame_idx: int,
+    corrected_bboxes: str = Form(...),
+) -> Response:
+    gate = require_admin(request)
+    if not isinstance(gate, dict):
+        return gate
+
+    upload_dir = _safe_upload_dir(upload_id)
+    if upload_dir is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    verified_id = upload_dir.name
+    if frame_idx < 0:
+        return JSONResponse({"error": "invalid frame index"}, status_code=400)
+    frame_path = upload_dir / "frames" / f"{frame_idx:06d}.jpg"
+    if not frame_path.exists():
+        return JSONResponse({"error": "frame not found"}, status_code=404)
+
+    bboxes_json = _validate_corrected_bboxes(corrected_bboxes)
+    if bboxes_json is None:
+        return JSONResponse({"error": "invalid corrected_bboxes payload"}, status_code=400)
+
+    # Detector event already exists → redirect to label queue, do not duplicate.
+    existing = db_module.get_training_events_by_frames(verified_id, [frame_idx]).get(frame_idx, [])
+    detector_event = next(
+        (ev for ev in existing if ev["detection_pass"] != "manual"),
+        None,
+    )
+    if detector_event is not None:
+        return JSONResponse(
+            {"error": "frame already has a detector event — re-label it from the queue"},
+            status_code=409,
+        )
+
+    manual_event = next(
+        (ev for ev in existing if ev["detection_pass"] == "manual"),
+        None,
+    )
+    if manual_event is not None:
+        db_module.update_training_event_review(
+            int(manual_event["id"]), "corrected", None, bboxes_json,
+        )
+        logger.info("Updated manual training_event %s for upload %s frame %s",
+                    manual_event["id"], verified_id, frame_idx)
+    else:
+        new_id = db_module.insert_manual_training_event(verified_id, frame_idx, bboxes_json)
+        logger.info("Inserted manual training_event %s for upload %s frame %s",
+                    new_id, verified_id, frame_idx)
+
+    return JSONResponse({"ok": True})

--- a/services/web/src/static/style.css
+++ b/services/web/src/static/style.css
@@ -1136,6 +1136,49 @@ body.expert-mode details.expert-only { display: block !important; }
 .btn-danger { border-color: var(--danger); color: var(--danger); }
 .btn-danger:hover { background: rgba(229,62,62,0.15); }
 
+.browse-toolbar {
+  display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap;
+  padding: 0.5rem 0.75rem; margin-bottom: 1rem;
+}
+.browse-stride-toggle { display: inline-flex; gap: 0.25rem; }
+.btn-active {
+  background: var(--accent); color: #fff; border-color: var(--accent);
+}
+
+.browse-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.5rem; margin-bottom: 1rem;
+}
+.browse-tile {
+  position: relative; display: block; line-height: 0;
+  background: #000; border-radius: 4px; overflow: hidden;
+  border: 2px solid transparent; transition: border-color 0.1s;
+  text-decoration: none;
+}
+.browse-tile:hover { border-color: var(--accent); }
+.browse-tile img { width: 100%; height: auto; display: block; }
+.browse-tile-idx {
+  position: absolute; bottom: 2px; right: 4px;
+  background: rgba(0, 0, 0, 0.65); color: #fff;
+  font-family: monospace; font-size: 0.7rem;
+  padding: 1px 4px; border-radius: 2px;
+  line-height: 1;
+}
+.browse-tile-badge {
+  position: absolute; top: 2px; left: 4px;
+  font-family: monospace; font-size: 0.75rem; font-weight: 700;
+  padding: 1px 6px; border-radius: 2px; line-height: 1.1;
+}
+.badge-annotated { background: var(--ok); color: #0a1a12; }
+.badge-detected  { background: var(--accent); color: #fff; }
+.badge-manual    { background: var(--warn); color: #000; }
+
+.pagination {
+  display: flex; align-items: center; gap: 0.75rem; justify-content: center;
+  padding: 0.5rem 0 1rem;
+}
+
 .kbd-legend {
   font-size: 0.8rem; color: var(--muted); margin-top: 0.5rem;
   padding: 0.5rem 0; border-top: 1px solid var(--border);

--- a/services/web/src/static/training_browse_frame.js
+++ b/services/web/src/static/training_browse_frame.js
@@ -1,0 +1,251 @@
+/* Frame browser focus view: draw multi-box annotations on a frame that
+   had no detector output, then POST to /annotate. */
+(function () {
+  "use strict";
+
+  var _boxes = [];
+  var _drawing = null;
+
+  function _clamp01(v) { return Math.max(0, Math.min(1, v)); }
+
+  function _detail() { return document.getElementById("label-detail"); }
+
+  function _escape(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  function _sizeCanvasToImage() {
+    var img = document.getElementById("label-frame");
+    var canvas = document.getElementById("label-canvas");
+    if (!img || !canvas) return;
+    canvas.width = img.clientWidth;
+    canvas.height = img.clientHeight;
+  }
+
+  function _drawCanvas() {
+    var canvas = document.getElementById("label-canvas");
+    if (!canvas) return;
+    var ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    ctx.lineWidth = 2;
+    ctx.font = "10px monospace";
+    for (var i = 0; i < _boxes.length; i++) {
+      var b = _boxes[i].bbox;
+      var x = (b[0] - b[2] / 2) * canvas.width;
+      var y = (b[1] - b[3] / 2) * canvas.height;
+      var w = b[2] * canvas.width;
+      var h = b[3] * canvas.height;
+      ctx.strokeStyle = "#34d399";
+      ctx.strokeRect(x, y, w, h);
+      ctx.fillStyle = "rgba(52, 211, 153, 0.9)";
+      var label = _boxes[i].cls + " #" + (i + 1);
+      var tw = ctx.measureText(label).width + 4;
+      var ly = y >= 12 ? y - 12 : y;
+      ctx.fillRect(x, ly, tw, 12);
+      ctx.fillStyle = "#0a1a12";
+      ctx.fillText(label, x + 2, ly + 9);
+    }
+
+    if (_drawing) {
+      var dx = Math.min(_drawing.startX, _drawing.curX);
+      var dy = Math.min(_drawing.startY, _drawing.curY);
+      var dw = Math.abs(_drawing.curX - _drawing.startX);
+      var dh = Math.abs(_drawing.curY - _drawing.startY);
+      ctx.strokeStyle = "#fbbf24";
+      ctx.setLineDash([4, 3]);
+      ctx.strokeRect(dx, dy, dw, dh);
+      ctx.setLineDash([]);
+    }
+  }
+
+  function _renderList() {
+    var list = document.getElementById("relabel-box-list");
+    if (!list) return;
+    if (_boxes.length === 0) {
+      list.innerHTML = '<p class="muted relabel-empty">No boxes drawn yet.</p>';
+    } else {
+      var html = "";
+      for (var i = 0; i < _boxes.length; i++) {
+        var b = _boxes[i];
+        html += '<div class="relabel-box-row">';
+        html += '<span class="relabel-box-idx">#' + (i + 1) + '</span> ';
+        html += '<span class="relabel-box-cls">' + _escape(b.cls) + '</span> ';
+        html += '<button type="button" class="btn btn-small relabel-box-remove" data-idx="' + i + '">Remove</button>';
+        html += '</div>';
+      }
+      list.innerHTML = html;
+    }
+    var save = document.getElementById("btn-browse-save");
+    if (save) save.disabled = _boxes.length === 0;
+    _drawCanvas();
+  }
+
+  function _loadExisting() {
+    var detail = _detail();
+    if (!detail) return;
+    var raw = detail.dataset.existingBboxes || "";
+    if (!raw) return;
+    try {
+      var entries = JSON.parse(raw);
+      if (!Array.isArray(entries)) return;
+      for (var i = 0; i < entries.length; i++) {
+        var b = entries[i] && entries[i].bbox;
+        var cls = entries[i] && entries[i].cls;
+        if (!Array.isArray(b) || b.length < 4 || typeof cls !== "string") continue;
+        _boxes.push({ cls: cls, bbox: [+b[0], +b[1], +b[2], +b[3]] });
+      }
+      _renderList();
+    } catch (e) {
+      /* ignore malformed payload */
+    }
+  }
+
+  function _onCanvasDown(e) {
+    var canvas = document.getElementById("label-canvas");
+    if (!canvas || e.target !== canvas) return;
+    var rect = canvas.getBoundingClientRect();
+    _drawing = {
+      startX: e.clientX - rect.left,
+      startY: e.clientY - rect.top,
+      curX: e.clientX - rect.left,
+      curY: e.clientY - rect.top,
+    };
+    e.preventDefault();
+  }
+
+  function _onCanvasMove(e) {
+    if (!_drawing) return;
+    var canvas = document.getElementById("label-canvas");
+    if (!canvas) return;
+    var rect = canvas.getBoundingClientRect();
+    _drawing.curX = e.clientX - rect.left;
+    _drawing.curY = e.clientY - rect.top;
+    _drawCanvas();
+  }
+
+  function _onCanvasUp(e) {
+    if (!_drawing) return;
+    var canvas = document.getElementById("label-canvas");
+    if (!canvas) { _drawing = null; return; }
+    var rect = canvas.getBoundingClientRect();
+    var cw = canvas.width || 1;
+    var ch = canvas.height || 1;
+    var endX = Math.max(0, Math.min(cw, e.clientX - rect.left));
+    var endY = Math.max(0, Math.min(ch, e.clientY - rect.top));
+    var startX = Math.max(0, Math.min(cw, _drawing.startX));
+    var startY = Math.max(0, Math.min(ch, _drawing.startY));
+    var x1 = Math.min(startX, endX);
+    var y1 = Math.min(startY, endY);
+    var x2 = Math.max(startX, endX);
+    var y2 = Math.max(startY, endY);
+    _drawing = null;
+
+    var w = x2 - x1;
+    var h = y2 - y1;
+    if (w < 6 || h < 6) { _drawCanvas(); return; }
+
+    var input = document.getElementById("relabel-class-input");
+    var cls = (input && input.value || "").trim().toLowerCase();
+    if (!cls) {
+      alert("Pick a class before drawing a box.");
+      _drawCanvas();
+      return;
+    }
+
+    _boxes.push({
+      cls: cls,
+      bbox: [
+        _clamp01((x1 + w / 2) / cw),
+        _clamp01((y1 + h / 2) / ch),
+        _clamp01(w / cw),
+        _clamp01(h / ch),
+      ],
+    });
+    _renderList();
+  }
+
+  function _save(thenNext) {
+    var detail = _detail();
+    if (!detail || _boxes.length === 0) return;
+    var uploadId = detail.dataset.uploadId;
+    var frameIdx = detail.dataset.frameIdx;
+    if (!/^[a-f0-9]+$/.test(uploadId) || !/^\d+$/.test(frameIdx)) return;
+
+    var fd = new FormData();
+    fd.append("_csrf_token", detail.dataset.csrfToken || "");
+    fd.append("corrected_bboxes", JSON.stringify(_boxes));
+
+    var url = "/admin/training/uploads/" + uploadId + "/browse/" + frameIdx + "/annotate";
+    fetch(url, { method: "POST", body: fd, credentials: "same-origin" })
+      .then(function (r) {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.json();
+      })
+      .then(function () {
+        if (thenNext) {
+          var nextLink = document.getElementById("browse-next");
+          if (nextLink) { window.location.href = nextLink.href; return; }
+        }
+        window.location.reload();
+      })
+      .catch(function (err) { alert("Save failed: " + err.message); });
+  }
+
+  /* ── Events ─────────────────────────────────────────────────────────── */
+
+  document.addEventListener("click", function (e) {
+    var t = e.target;
+    if (!t) return;
+    if (t.id === "btn-browse-save") {
+      _save(true);
+    } else if (t.classList && t.classList.contains("relabel-box-remove")) {
+      var idx = parseInt(t.getAttribute("data-idx") || "-1", 10);
+      if (idx >= 0 && idx < _boxes.length) {
+        _boxes.splice(idx, 1);
+        _renderList();
+      }
+    }
+  });
+
+  document.addEventListener("mousedown", _onCanvasDown);
+  document.addEventListener("mousemove", _onCanvasMove);
+  document.addEventListener("mouseup", _onCanvasUp);
+  window.addEventListener("resize", function () { _sizeCanvasToImage(); _drawCanvas(); });
+
+  document.addEventListener("keydown", function (e) {
+    var tag = (e.target.tagName || "").toUpperCase();
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+    switch (e.key) {
+      case "j":
+      case "ArrowRight":
+        e.preventDefault();
+        var nxt = document.getElementById("browse-next");
+        if (nxt) window.location.href = nxt.href;
+        break;
+      case "k":
+      case "ArrowLeft":
+        e.preventDefault();
+        var prv = document.getElementById("browse-prev");
+        if (prv) window.location.href = prv.href;
+        break;
+      case "s":
+        e.preventDefault();
+        var save = document.getElementById("btn-browse-save");
+        if (save && !save.disabled) save.click();
+        break;
+    }
+  });
+
+  /* Resize canvas once the image lays out. */
+  var img = document.getElementById("label-frame");
+  if (img) {
+    if (img.complete) { _sizeCanvasToImage(); _drawCanvas(); }
+    img.addEventListener("load", function () { _sizeCanvasToImage(); _drawCanvas(); });
+  }
+
+  _loadExisting();
+})();

--- a/services/web/src/templates/partials/training_upload_rows.html
+++ b/services/web/src/templates/partials/training_upload_rows.html
@@ -51,6 +51,7 @@
     {% endif %}
     {% if u.status == 'processed' %}
     <a href="/admin/training/uploads/{{ u.id }}" class="btn btn-small">Label</a>
+    <a href="/admin/training/uploads/{{ u.id }}/browse" class="btn btn-small">Browse</a>
     {% endif %}
     {% if _is_admin %}
     <form method="post" action="/admin/training/uploads/{{ u.id }}/delete" style="display:inline;">

--- a/services/web/src/templates/training_browse.html
+++ b/services/web/src/templates/training_browse.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block main_class %}main-wide{% endblock %}
+{% block content %}
+<h1>Browse Frames: {{ upload.filename }}
+  {% if upload.target_class_hint %}<span class="badge">{{ upload.target_class_hint }}</span>{% endif %}
+</h1>
+
+<div class="card browse-toolbar">
+  <span class="muted">
+    {{ total }} frame{{ '' if total == 1 else 's' }}
+    {% if showing_all %}(all{% else %}(every {{ stride }}th of {{ all_frames_total }}{% endif %})
+  </span>
+  <span class="browse-stride-toggle">
+    <a href="?stride=30" class="btn btn-small {% if stride_param == '30' %}btn-active{% endif %}">1/sec</a>
+    <a href="?stride=60" class="btn btn-small {% if stride_param == '60' %}btn-active{% endif %}">1/2sec</a>
+    <a href="?stride=10" class="btn btn-small {% if stride_param == '10' %}btn-active{% endif %}">3/sec</a>
+    <a href="?stride=all" class="btn btn-small {% if showing_all %}btn-active{% endif %}">All frames</a>
+  </span>
+  <span class="muted" style="margin-left:auto;">
+    <a href="/admin/training/uploads/{{ upload.id }}">← back to labeling queue</a>
+  </span>
+</div>
+
+{% if tiles %}
+<div class="browse-grid">
+  {% for tile in tiles %}
+  <a class="browse-tile" href="/admin/training/uploads/{{ upload.id }}/browse/{{ tile.frame_idx }}?stride={{ stride_param }}">
+    <img loading="lazy" src="/admin/training/uploads/{{ upload.id }}/frames/{{ tile.frame_idx }}" alt="Frame {{ tile.frame_idx }}">
+    <span class="browse-tile-idx">{{ tile.frame_idx }}</span>
+    {% if tile.has_annotation %}
+    <span class="browse-tile-badge badge-annotated" title="You annotated this frame">✓</span>
+    {% elif tile.has_detection %}
+    <span class="browse-tile-badge badge-detected" title="Detector found something here">●</span>
+    {% elif tile.has_manual %}
+    <span class="browse-tile-badge badge-manual" title="Manual annotation row exists">·</span>
+    {% endif %}
+  </a>
+  {% endfor %}
+</div>
+{% else %}
+<div class="card" style="text-align:center;padding:3rem;">
+  <p class="muted">No frames available for this upload.</p>
+</div>
+{% endif %}
+
+{% if total_pages > 1 %}
+<div class="pagination">
+  {% if page > 1 %}
+  <a href="?page={{ page - 1 }}&stride={{ stride_param }}" class="btn btn-small">← prev</a>
+  {% endif %}
+  <span class="muted">Page {{ page }} of {{ total_pages }}</span>
+  {% if page < total_pages %}
+  <a href="?page={{ page + 1 }}&stride={{ stride_param }}" class="btn btn-small">next →</a>
+  {% endif %}
+</div>
+{% endif %}
+{% endblock %}

--- a/services/web/src/templates/training_browse_frame.html
+++ b/services/web/src/templates/training_browse_frame.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+{% block main_class %}main-wide{% endblock %}
+{% block content %}
+<h1>Frame {{ frame_idx }}: {{ upload.filename }}
+  {% if upload.target_class_hint %}<span class="badge">{{ upload.target_class_hint }}</span>{% endif %}
+</h1>
+
+<div class="card browse-toolbar">
+  <a href="/admin/training/uploads/{{ upload.id }}/browse?stride={{ stride_param }}" class="btn btn-small">← back to grid</a>
+  {% if prev_frame is not none %}
+  <a id="browse-prev" href="/admin/training/uploads/{{ upload.id }}/browse/{{ prev_frame }}?stride={{ stride_param }}" class="btn btn-small">← prev (k)</a>
+  {% endif %}
+  {% if next_frame is not none %}
+  <a id="browse-next" href="/admin/training/uploads/{{ upload.id }}/browse/{{ next_frame }}?stride={{ stride_param }}" class="btn btn-small">next (j) →</a>
+  {% endif %}
+  {% if manual_event %}
+  <span class="badge badge-review-corrected" style="margin-left:auto;">re-labeled</span>
+  {% endif %}
+</div>
+
+<div class="label-viewer">
+  <div class="label-frame-wrap">
+    <img id="label-frame"
+         src="/admin/training/uploads/{{ upload.id }}/frames/{{ frame_idx }}"
+         alt="Frame {{ frame_idx }}">
+    <canvas id="label-canvas" class="label-canvas"></canvas>
+    <div id="label-relabel-boxes" class="label-relabel-boxes"></div>
+  </div>
+
+  <div id="label-card">
+    <div class="label-detail"
+         id="label-detail"
+         data-upload-id="{{ upload.id }}"
+         data-frame-idx="{{ frame_idx }}"
+         data-csrf-token="{{ request.state.csrf_token }}"
+         data-existing-bboxes="{{ manual_event.corrected_bboxes if manual_event and manual_event.corrected_bboxes else '' }}"
+         data-target-hint="{{ upload.target_class_hint if upload.target_class_hint and upload.target_class_hint != 'background' else '' }}">
+
+      {% if _is_admin %}
+      <p class="muted relabel-help">
+        Click-drag on the frame to draw a box. Pick the class for each box,
+        then Save. Use this when the detector missed an object.
+      </p>
+      <div class="field-group">
+        <label>Class for the next box you draw</label>
+        <input id="relabel-class-input" type="text" list="class-options"
+               value="{{ upload.target_class_hint if upload.target_class_hint and upload.target_class_hint != 'background' else '' }}"
+               autocomplete="off">
+        <datalist id="class-options">
+          {% for cls in target_classes %}<option value="{{ cls }}">{% endfor %}
+        </datalist>
+      </div>
+      <div id="relabel-box-list" class="relabel-box-list">
+        <p class="muted relabel-empty">No boxes drawn yet.</p>
+      </div>
+      <div class="relabel-actions">
+        <button id="btn-browse-save" class="btn btn-primary" type="button" disabled>Save</button>
+        {% if next_frame is not none %}
+        <a href="/admin/training/uploads/{{ upload.id }}/browse/{{ next_frame }}?stride={{ stride_param }}" class="btn">Skip →</a>
+        {% endif %}
+      </div>
+      {% else %}
+      <p class="muted">Read-only view.</p>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+<div class="kbd-legend">
+  <kbd>j</kbd> / <kbd>&rarr;</kbd> next &nbsp;
+  <kbd>k</kbd> / <kbd>&larr;</kbd> prev &nbsp;
+  <kbd>s</kbd> save
+</div>
+
+<script src="/static/training_browse_frame.js"></script>
+{% endblock %}

--- a/services/web/src/templates/training_label.html
+++ b/services/web/src/templates/training_label.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h1>Label: {{ upload.filename }}
   {% if upload.target_class_hint %}<span class="badge">{{ upload.target_class_hint }}</span>{% endif %}
+  <a href="/admin/training/uploads/{{ upload.id }}/browse" class="btn btn-small" style="margin-left:0.75rem;font-size:0.7rem;font-weight:normal;">Browse frames →</a>
 </h1>
 
 <div class="training-stats-row">


### PR DESCRIPTION
## Summary

Adds a frame browser at \`/admin/training/uploads/{id}/browse\` so admins can label frames the detector missed (or never fired on at all). Closes the gap where a duck-on-camera clip would have nothing in the labeling queue because every detection was sub-threshold.

## How it works

- **Grid view** — thumbnails of every 30th frame by default (1/sec @ 30fps). Toggle to 1/2sec, 3/sec, or "All frames". Each tile carries a badge: detector hit, manual row exists, or you annotated this. Paginated 60/page.
- **Focus view** — click a tile, get the full-size frame with the same multi-box canvas tool the labeling queue uses. Pick a class, drag rectangles, save.
- **Saving** — creates a new \`training_event\` row with sentinel values (\`predicted_class=''\`, \`bbox='[]'\`, \`detection_pass='manual'\`, \`review_state='corrected'\`, \`corrected_bboxes=[…]\`). Skip creates nothing, so empty frames stay implicit.
- **Existing detector events** — if a frame already has a detector event, opening it from the browser redirects to the existing labeling queue (no duplicate manual rows).
- **Keyboard** — j/k between sampled frames, s saves.

No exporter changes needed — \`corrected_bboxes\` already overrides the original prediction at YOLO export time, regardless of how the row got into the DB.

## Test plan

- [ ] Upload a clip with known targets the detector missed (e.g. duck in low-light), open the upload's "Browse" tab.
- [ ] Verify grid loads, ~1/sec sampling, click stride toggles, pagination works.
- [ ] Click an empty frame, draw a box, save → returns to next sampled frame.
- [ ] Navigate back to that frame from the grid → tile shows the green ✓ "annotated" badge.
- [ ] Click a frame that has an existing detection → redirects to the labeling queue centered on that event.
- [ ] Skip button advances without writing a row.
- [ ] Reprocess and re-export the dataset (prepare_dataset.py) → the manual annotations show up as YOLO rows.
- [ ] Lint/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)