### PR TITLE
feat(training): configurable training classes with distractors (v0.16.6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -573,7 +573,7 @@ jobs:
 
       - name: Start stack (CPU mode)
         env:
-          COMPOSE_FILE: docker-compose.yml
+          COMPOSE_FILE: docker-compose.yml:tests/ci/compose.smoke-overrides.yml
           DETECTOR_IMAGE: scarguard-detector-x86
           IMAGE_TAG: smoke
           GHCR_OWNER: ""
@@ -588,7 +588,7 @@ jobs:
 
       - name: Health checks
         env:
-          COMPOSE_FILE: docker-compose.yml
+          COMPOSE_FILE: docker-compose.yml:tests/ci/compose.smoke-overrides.yml
           DETECTOR_IMAGE: scarguard-detector-x86
           IMAGE_TAG: smoke
           GHCR_OWNER: ""
@@ -635,7 +635,7 @@ jobs:
       - name: Tear down
         if: always()
         env:
-          COMPOSE_FILE: docker-compose.yml
+          COMPOSE_FILE: docker-compose.yml:tests/ci/compose.smoke-overrides.yml
           DETECTOR_IMAGE: scarguard-detector-x86
           IMAGE_TAG: smoke
           GHCR_OWNER: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
             services/notifier/src \
             services/deterrent/src \
             services/log-streamer/src \
-            shared
+            services/trainer/src \
+            shared \
+            training
 
   # ── Type check ──────────────────────────────────────────────────────────────
   # Detector is excluded — it requires torch/opencv/ultralytics which are
@@ -148,3 +150,24 @@ jobs:
         env:
           PYTHONPATH: services/deterrent/src:shared
         run: pytest services/deterrent/tests/ -v
+
+  # ── Tests — training ────────────────────────────────────────────────────────
+  # prepare_dataset.py keeps its heavy imports (roboflow, requests, yaml)
+  # function-local, so the class-handling unit tests run on stdlib + pytest.
+  test-training:
+    name: Tests — training
+    runs-on: [self-hosted, linux, generic]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install deps
+        run: pip install pytest
+
+      - name: pytest
+        run: pytest training/tests/ -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Run these before considering any code change done (mirrors CI exactly):
 
 ```bash
 # Ruff — all services (detector included; no GPU deps needed)
-ruff check services/detector/src services/web/src services/notifier/src services/deterrent/src services/backup/src shared
+ruff check services/detector/src services/web/src services/notifier/src services/deterrent/src services/backup/src services/trainer/src shared training
 
 # mypy — web (detector is excluded from CI: torch/opencv not available outside L4T)
 MYPYPATH=services/web/src:shared \

--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -169,6 +169,56 @@ Labeled events power the training pipeline:
 - **Model Evaluation** page compares two models side-by-side against labeled snapshots
 - **Model Promotion** updates config and triggers hot-reload
 
+### Training Configuration (`training:` section)
+
+The `training:` YAML section configures the trainer service (dataset
+preparation and on-device fine-tuning jobs). It is a passthrough section:
+not part of the structured config UI's schema, but preserved by UI saves.
+`training.sources.roboflow.api_key` is sensitive (encrypted at rest,
+redacted for viewers).
+
+| Key | Default | Description |
+|---|---|---|
+| `training.defaults.classes` | `[duck, heron, raccoon, person, dog, cat, plant]` | Ordered training class list — order defines model class indices. Overridable per job via the Classes field on the Training Jobs page. |
+| `training.defaults.base_model` | `yolov8n.pt` | Base model for fine-tuning |
+| `training.defaults.epochs` | `100` | Training epochs |
+| `training.defaults.batch_size` | `2` | Batch size (Orin 8GB safe) |
+| `training.defaults.image_size` | `480` | Training image size (Orin 8GB safe) |
+| `training.defaults.patience` | `20` | Early-stopping patience |
+| `training.defaults.val_split` | `0.15` | Validation holdout fraction |
+| `training.sources.roboflow.api_key` | `""` | Roboflow API key (SENSITIVE) |
+| `training.sources.open_images.max_per_class` | `1500` | Open Images cap per class |
+| `training.sources.open_images.workers` | `16` | Parallel download threads |
+| `training.video.low_confidence` | `0.05` | Low-confidence pass threshold for video processing |
+| `training.video.dedupe_iou` | `0.85` | IoU threshold for near-duplicate frame dedup |
+| `training.video.dedupe_window` | `5` | Frame window for dedup |
+| `training.video.background_sample_interval` | `10` | Every Nth frame of background uploads becomes a negative sample |
+
+### Distractor Classes & Runtime Behavior
+
+`person`, `dog`, `cat`, and `plant` are **distractor classes**: they are
+trained into the model so it learns what *not* to call a heron (humans at
+the pond were previously misclassified as herons), but they are not meant
+to alert or deter. All runtime behavior is driven by existing class
+config — no special handling:
+
+- `detection.target_classes` is an explicit allowlist. Distractor classes
+  not listed there are dropped at inference: no events, no snapshots.
+  Deploying a 7-class model with an unchanged config needs no edits.
+- **Never add `plant` to `target_classes`** — pond vegetation would fire
+  constantly.
+- To **log** a distractor (e.g. person) without notifications: add it to
+  `target_classes`, then give the camera explicit `notification_rules`
+  for the classes you *do* want notifications for, **without a wildcard
+  rule**. A class matching no rule is suppressed. Note: a *matched* rule
+  with `channels: []` means "notify all channels" — that is not the
+  suppression recipe.
+- Deterrents are opt-in per class via `deterrent_rules`, so distractors
+  can never trigger them unless explicitly configured.
+- The Models page will show all 7 classes for a distractor-trained model
+  while `target_classes` lists fewer — that is expected, not a
+  misconfiguration.
+
 ### Database Columns (detection_events)
 
 | Column | Type | Description |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -483,6 +483,37 @@ the v1.14 migration window.
 
 ---
 
+## v0.16.6 — distractor training classes (in progress)
+
+Fixes the "humans look like herons" failure mode of pond_v1: a model
+trained on only 3 classes loses the pretrained features that
+distinguish people, so out-of-distribution objects collapse into the
+nearest target silhouette. Adds distractor classes (person, dog, cat,
+plant) to the default training set; the model learns a correct bucket
+for them while runtime behavior stays config-driven via
+`detection.target_classes`.
+
+1. **Configurable class list in `prepare_dataset.py`.** `--classes`
+   CLI arg (ordered, defines model class indices), default
+   `duck,heron,raccoon,person,dog,cat,plant`. Open Images label IDs
+   added for person/dog/cat/plant (Houseplant + Plant fold into
+   `plant`). Labels not in the active list are dropped with warnings,
+   so a 3-class run reproduces the old behavior exactly. Token-based
+   alias matching (no more `cattle`→cat substring traps).
+2. **Trainer + jobs UI.** `prepare_dataset`/`prepare_and_train` jobs
+   accept a `classes` param; visible Classes field on the Training
+   Jobs page prefilled from `training.defaults.classes` or the
+   built-in default. Labeling-queue and frame-browser datalists now
+   suggest training classes, not just detection targets.
+3. **Docs.** `training:` config section documented in
+   CONFIG_REFERENCE.md for the first time, plus distractor runtime
+   guidance (target_classes allowlist, log-without-notify recipe,
+   never add plant).
+4. **Tests + CI.** `training/tests/` unit tests for class parsing and
+   resolution; `training/` added to ruff scope.
+
+---
+
 ## Future Ideas (Unprioritized)
 
 - Twilio SMS notifications — paid per-message, but works on any phone without an app

--- a/STATUS.md
+++ b/STATUS.md
@@ -66,6 +66,8 @@
 - **Model class introspection (v0.13.4):** `/models` admin page grew a Classes column — expand any model to see its full embedded class list as chips, copy-to-clipboard. Backed by `/models/{filename}/classes`. TensorRT `.engine` files without embedded names return a warning pointing at the source `.pt`.
 - **Orphan-reference soft-warn (v0.13.4):** Save succeeds, response includes a `warnings` list for any rule or summary-report reference that doesn't resolve to a defined channel or group. Applies to both structured-form saves and raw-YAML edits.
 
+- **Configurable training classes with distractors (v0.16.6):** Training class list is tweakable at training time (`--classes` on `prepare_dataset.py`, Classes field on the Training Jobs page, `training.defaults.classes` in config). Default expanded to `duck, heron, raccoon, person, dog, cat, plant` — the last four are distractor classes pulled from Open Images so the model stops misclassifying humans/pets/vegetation as herons. Runtime untouched: distractors are filtered by `detection.target_classes`.
+
 ## Known Issues / Buggy
 
 - **Tuya battery-device first-shot latency.** Battery-powered Tuya devices

--- a/config/scarguard.example.yml
+++ b/config/scarguard.example.yml
@@ -347,6 +347,11 @@ backup:
 #       enabled: true                 # Include video upload annotations
 #
 #   defaults:
+#     # Ordered class list — order defines model class indices.
+#     # person/dog/cat/plant are distractors: trained so the model stops
+#     # calling humans/pets/vegetation "heron"; filtered at runtime via
+#     # detection.target_classes (never add plant there).
+#     classes: [duck, heron, raccoon, person, dog, cat, plant]
 #     base_model: "yolov8n.pt"
 #     epochs: 100
 #     batch_size: 2                   # Orin 8GB safe

--- a/services/backup/Dockerfile
+++ b/services/backup/Dockerfile
@@ -6,7 +6,7 @@
 # /data/backups/{db_name}/{YYYY-MM-DD}.db.gz on a configurable schedule.
 # Subscribes to scarguard:backup:trigger for manual web-UI triggers and
 # publishes scarguard:backup:status so the UI can surface backup state.
-FROM docker.io/library/python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM docker.io/library/python:3.11-slim@sha256:f9fa7f851e38bfb19c9de3afbc4b86ae7176ea7aaf94535c31df5458d5849457
 
 WORKDIR /app
 

--- a/services/config-api/Dockerfile
+++ b/services/config-api/Dockerfile
@@ -5,7 +5,7 @@
 # Handles the 8 config-write POST endpoints when split from the web
 # monolith.  When the "config-api" compose profile is not active this
 # image is never built or started — the web service handles everything.
-FROM docker.io/library/python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM docker.io/library/python:3.11-slim@sha256:f9fa7f851e38bfb19c9de3afbc4b86ae7176ea7aaf94535c31df5458d5849457
 
 WORKDIR /app
 

--- a/services/deterrent/Dockerfile
+++ b/services/deterrent/Dockerfile
@@ -3,7 +3,7 @@
 # v0.13.4: authenticated Docker Hub pull via DOCKER_HUB_USERNAME/_API_KEY
 # org secrets (docker/login-action step in build.yml) — per-user quota
 # (5000/day) instead of the anonymous-IP quota (~100/6h).
-FROM docker.io/library/python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM docker.io/library/python:3.11-slim@sha256:f9fa7f851e38bfb19c9de3afbc4b86ae7176ea7aaf94535c31df5458d5849457
 
 WORKDIR /app
 

--- a/services/log-streamer/Dockerfile
+++ b/services/log-streamer/Dockerfile
@@ -7,7 +7,7 @@
 # v0.13.4: authenticated Docker Hub pull via DOCKER_HUB_USERNAME/_API_KEY
 # org secrets (docker/login-action step in build.yml) — per-user quota
 # (5000/day) instead of the anonymous-IP quota (~100/6h).
-FROM docker.io/library/python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM docker.io/library/python:3.11-slim@sha256:f9fa7f851e38bfb19c9de3afbc4b86ae7176ea7aaf94535c31df5458d5849457
 
 WORKDIR /app
 

--- a/services/notifier/Dockerfile
+++ b/services/notifier/Dockerfile
@@ -3,7 +3,7 @@
 # v0.13.4: authenticated Docker Hub pull via DOCKER_HUB_USERNAME/_API_KEY
 # org secrets (docker/login-action step in build.yml) — per-user quota
 # (5000/day) instead of the anonymous-IP quota (~100/6h).
-FROM docker.io/library/python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM docker.io/library/python:3.11-slim@sha256:f9fa7f851e38bfb19c9de3afbc4b86ae7176ea7aaf94535c31df5458d5849457
 
 WORKDIR /app
 

--- a/services/trainer/src/job_runner.py
+++ b/services/trainer/src/job_runner.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sqlite3
 import subprocess
 import threading
@@ -33,6 +34,9 @@ SCRIPTS_DIR = Path("/app/scripts")
 _PROGRESS_TTL = 300
 _LOG_TTL = 3600
 _LOG_CAP = 500
+
+# Mirrors the web form's class-name validation (routes/training_jobs.py).
+_CLASS_TOKEN_RE = re.compile(r"^[a-z0-9_-]+$")
 
 
 def _progress_key(job_id: str) -> str:
@@ -350,6 +354,29 @@ def _run_prepare_dataset(ctx: JobContext) -> dict:
                            train_cfg.get("video", {}).get("background_sample_interval", 10))
         ),
     ]
+
+    # Class list: job param wins, then training.defaults.classes, then the
+    # script's built-in default. YAML gives a list, the jobs form a
+    # comma-string — accept both, and fail fast on malformed values
+    # rather than preparing a near-empty dataset from unmatched labels.
+    classes = ctx.params.get("classes") or defaults.get("classes")
+    if classes:
+        raw = (
+            [str(c) for c in classes]
+            if isinstance(classes, (list, tuple))
+            else re.split(r"[,\s]+", str(classes))
+        )
+        tokens: list[str] = []
+        for part in raw:
+            token = part.strip().lower()
+            if not token:
+                continue
+            if not _CLASS_TOKEN_RE.match(token):
+                return {"error": f"Invalid class name in training classes: {token!r}"}
+            if token not in tokens:
+                tokens.append(token)
+        if tokens:
+            cmd += ["--classes", ",".join(tokens)]
 
     rf_cfg = sources.get("roboflow", {})
     rf_key = rf_cfg.get("api_key", "")

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -3,7 +3,7 @@
 # DOCKER_HUB_API_KEY org secrets) so we have the per-user quota (5000/day)
 # instead of the anonymous-IP quota (~100/6h) that kept hitting us on GHA
 # shared runners.
-FROM docker.io/library/python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM docker.io/library/python:3.11-slim@sha256:f9fa7f851e38bfb19c9de3afbc4b86ae7176ea7aaf94535c31df5458d5849457
 
 WORKDIR /app
 

--- a/services/web/src/routes/training_jobs.py
+++ b/services/web/src/routes/training_jobs.py
@@ -29,6 +29,29 @@ PAGE_SIZE = 25
 
 _VALID_JOB_TYPES = {"process_video", "prepare_dataset", "train", "prepare_and_train"}
 
+# Default training class list. Keep in sync with DEFAULT_CLASSES in
+# training/prepare_dataset.py (standalone by design — copied into the
+# trainer image, so it can't be imported here). person/dog/cat/plant are
+# distractor classes: trained so the model stops calling them herons,
+# filtered at runtime via detection.target_classes.
+DEFAULT_TRAINING_CLASSES = "duck,heron,raccoon,person,dog,cat,plant"
+
+_CLASS_TOKEN_RE = __import__("re").compile(r"^[a-z0-9_-]+$")
+
+_CLASSES_JOB_TYPES = {"prepare_dataset", "prepare_and_train"}
+
+
+def training_classes_default() -> str:
+    """Resolve the Classes prefill: training.defaults.classes or built-in."""
+    import config_store
+    cfg = config_store.load_cached()
+    classes = cfg.get("training", {}).get("defaults", {}).get("classes")
+    if isinstance(classes, (list, tuple)) and classes:
+        return ",".join(str(c).strip() for c in classes)
+    if isinstance(classes, str) and classes.strip():
+        return classes.strip()
+    return DEFAULT_TRAINING_CLASSES
+
 
 def _redis_cfg() -> dict:
     import config_store
@@ -86,6 +109,7 @@ async def jobs_page(
             "detector_state": detector_state,
             "is_admin": require_admin(request) if not isinstance(require_admin(request), dict) else True,
             "upload_options": upload_options,
+            "training_classes_default": training_classes_default(),
         },
     )
 
@@ -123,6 +147,24 @@ async def submit_job(request: Request) -> Response:
             params = json.loads(str(form.get("params_json") or "{}"))
         except json.JSONDecodeError:
             return JSONResponse({"error": "Invalid JSON in params"}, status_code=400)
+
+        # Visible Classes field (prepare jobs only); wins over a "classes"
+        # key in the JSON textarea when filled.
+        classes_raw = str(form.get("classes") or "").strip()
+        if classes_raw and job_type in _CLASSES_JOB_TYPES:
+            tokens: list[str] = []
+            for part in classes_raw.lower().split(","):
+                token = part.strip()
+                if not token:
+                    continue
+                if not _CLASS_TOKEN_RE.match(token):
+                    return JSONResponse(
+                        {"error": f"Invalid class name: {token!r}"}, status_code=400
+                    )
+                if token not in tokens:
+                    tokens.append(token)
+            if tokens:
+                params["classes"] = ",".join(tokens)
 
     running = db_module.count_training_jobs(status="running")
     queued = db_module.count_training_jobs(status="queued")

--- a/services/web/src/routes/training_uploads.py
+++ b/services/web/src/routes/training_uploads.py
@@ -38,6 +38,25 @@ MAX_UPLOAD_BYTES: int | None = (
     else 500 * 1024 * 1024  # 500 MB default
 )
 PAGE_SIZE = 25
+
+
+def _label_class_options() -> list[str]:
+    """Class suggestions for the labeling datalists: the training class
+    list (training.defaults.classes or built-in default) merged with
+    detection.target_classes. Free-text entry remains allowed — the
+    datalist is suggestion-only."""
+    import config_store
+
+    from routes.training_jobs import training_classes_default
+
+    cfg = config_store.load_cached()
+    training_classes = [
+        c.strip() for c in training_classes_default().split(",") if c.strip()
+    ]
+    detect = cfg.get("detection", {}).get("target_classes", []) or []
+    return list(dict.fromkeys(training_classes + list(detect)))
+
+
 _UPLOAD_LIST_URL = "/admin/training/uploads"
 
 _SAFE_ID = re.compile(r"^[0-9a-f]{32}$")
@@ -490,9 +509,7 @@ async def label_page(
             upload_id, event["id"], review_state=rs, detection_pass=dp,
         )
 
-    import config_store
-    cfg = config_store.load_cached()
-    target_classes = cfg.get("detection", {}).get("target_classes", [])
+    target_classes = _label_class_options()
 
     return templates.TemplateResponse(
         request,
@@ -565,9 +582,7 @@ async def review_event(
     else:
         prev_event = None
 
-    import config_store
-    cfg = config_store.load_cached()
-    target_classes = cfg.get("detection", {}).get("target_classes", [])
+    target_classes = _label_class_options()
 
     return templates.TemplateResponse(
         request,
@@ -796,9 +811,7 @@ async def browse_frame(
         if i < len(sampled) - 1:
             next_frame = sampled[i + 1]
 
-    import config_store
-    cfg = config_store.load_cached()
-    target_classes = cfg.get("detection", {}).get("target_classes", [])
+    target_classes = _label_class_options()
 
     return templates.TemplateResponse(
         request,

--- a/services/web/src/static/training_jobs.js
+++ b/services/web/src/static/training_jobs.js
@@ -65,11 +65,14 @@
     if (!sel) return;
     var processFields = document.getElementById("process-video-fields");
     var jsonFields = document.getElementById("json-params-fields");
+    var classesField = document.getElementById("classes-field");
 
     function update() {
       var isProcess = sel.value === "process_video";
+      var hasClasses = sel.value === "prepare_dataset" || sel.value === "prepare_and_train";
       if (processFields) processFields.style.display = isProcess ? "" : "none";
       if (jsonFields) jsonFields.style.display = isProcess ? "none" : "";
+      if (classesField) classesField.style.display = hasClasses ? "" : "none";
     }
     sel.addEventListener("change", update);
     update();

--- a/services/web/src/templates/training_jobs.html
+++ b/services/web/src/templates/training_jobs.html
@@ -49,6 +49,12 @@
       <p class="hint">Each upload's own settings (model, confidence threshold, hints) are used. Edit them on the <a href="/admin/training/uploads">Uploads</a> page.</p>
     </div>
 
+    <div class="field-group" id="classes-field">
+      <label>Classes <span class="muted">(comma-separated; order defines model class indices)</span></label>
+      <input type="text" name="classes" id="classes-input" value="{{ training_classes_default }}">
+      <p class="hint">Classes beyond detection targets are distractors — trained so the model learns what <em>not</em> to call a heron, but never alerted on. Overrides a "classes" key in the JSON parameters.</p>
+    </div>
+
     <div class="field-group" id="json-params-fields">
       <label>Parameters (JSON)</label>
       <textarea name="params_json" id="params-json" rows="3" style="font-family:var(--mono);font-size:0.8rem;">{}</textarea>

--- a/tests/ci/compose.smoke-overrides.yml
+++ b/tests/ci/compose.smoke-overrides.yml
@@ -1,0 +1,10 @@
+# Compose overrides for the CI smoke test (build.yml compose-smoke-test job).
+# Layered on top of docker-compose.yml via COMPOSE_FILE.
+#
+# The production detector limit (cpus: 4.0) is sized for the Orin's 6
+# cores; the x86 runner host has fewer, and Docker rejects a cpus limit
+# above the host count. The smoke test only verifies the stack starts,
+# so cap it to what any runner host can satisfy.
+services:
+  detector:
+    cpus: 1.0

--- a/training/README.md
+++ b/training/README.md
@@ -110,6 +110,43 @@ the snapshot with a zero-byte label file, which YOLO interprets as
 "no targets in this image." These act as negative / background
 samples during training.
 
+## prepare_dataset.py — merged dataset builder
+
+`prepare_dataset.py` automates the dataset merge: ScarGuard feedback
+events (via SSH or local DB), training-upload annotations, Roboflow
+Universe datasets, and Open Images downloads, remapped to one unified
+class scheme with a train/val split. The trainer service runs this same
+script for on-device `prepare_dataset` / `prepare_and_train` jobs.
+
+```bash
+python prepare_dataset.py \
+    --orin-host scott@orin \
+    --roboflow-key YOUR_KEY \
+    --output ./merged_dataset
+
+# Custom class list (order defines model class indices):
+python prepare_dataset.py --classes duck,heron,raccoon ...
+```
+
+### Classes and distractors
+
+The default class list is
+`duck, heron, raccoon, person, dog, cat, plant`. The last four are
+**distractor classes**: trained so the model has a correct bucket for
+humans, pets, and vegetation instead of forcing them into the nearest
+target silhouette (humans at the pond used to come back as "heron").
+Distractor training data is pulled automatically from Open Images;
+person/dog/cat/plant boxes you draw in the labeling UI count too.
+
+- `--classes` takes a comma-separated **ordered** list — order defines
+  the model's class indices, so keep it stable between runs you intend
+  to compare.
+- Labels that don't map to an active class are dropped with a warning:
+  `--classes duck,heron,raccoon` reproduces the original 3-class
+  behavior exactly.
+- At runtime, distractors are filtered by `detection.target_classes` —
+  see CONFIG_REFERENCE.md ("Distractor Classes & Runtime Behavior").
+
 ## Mixing third-party datasets
 
 The exported zip is a standard YOLO dataset, so you can extend it

--- a/training/prepare_dataset.py
+++ b/training/prepare_dataset.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import json
 import random
+import re
 import shutil
 import sqlite3
 import subprocess
@@ -33,8 +34,21 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import NamedTuple
 
-UNIFIED_CLASSES = ["duck", "heron", "raccoon"]
+# Default class set: the three target species plus distractor classes
+# (person, dog, cat, plant) that teach the model what NOT to call a heron.
+# Distractors are filtered at runtime via detection.target_classes.
+# Keep in sync with DEFAULT_TRAINING_CLASSES in
+# services/web/src/routes/training_jobs.py (this script is standalone by
+# design — copied into the trainer image — so it can't be imported there).
+DEFAULT_CLASSES = ["duck", "heron", "raccoon", "person", "dog", "cat", "plant"]
 
+# Active class list for this run; order defines model class indices.
+# Overridden from --classes via set_active_classes().
+UNIFIED_CLASSES = list(DEFAULT_CLASSES)
+
+# Master alias map: source label → unified class, for every class this
+# script knows about. _resolve_class() only returns targets present in
+# the active UNIFIED_CLASSES list.
 CLASS_MAP: dict[str, str] = {
     "great_blue_heron": "heron",
     "green_heron": "heron",
@@ -44,6 +58,18 @@ CLASS_MAP: dict[str, str] = {
     "mallard": "duck",
     "raccoon": "raccoon",
     "raccon": "raccoon",
+    "person": "person",
+    "pedestrian": "person",
+    "man": "person",
+    "woman": "person",
+    "dog": "dog",
+    "puppy": "dog",
+    "cat": "cat",
+    "kitten": "cat",
+    "plant": "plant",
+    "houseplant": "plant",
+    "potted_plant": "plant",
+    "flower": "plant",
 }
 
 ROBOFLOW_DATASETS = [
@@ -51,10 +77,49 @@ ROBOFLOW_DATASETS = [
     ("harbin-institute-of-technology-hpsg8", "raccon-3osqx"),
 ]
 
-OID_CLASSES: dict[str, str] = {
+# Master Open Images label map (IDs verified against
+# oidv6-class-descriptions.csv). Houseplant and Plant both fold into
+# "plant"; the per-class image cap is keyed by unified class, so it
+# covers them combined.
+OID_ALL_CLASSES: dict[str, str] = {
     "/m/09ddx": "duck",
     "/m/0dq75": "raccoon",
+    "/m/01g317": "person",
+    "/m/0bt9lr": "dog",
+    "/m/01yrx": "cat",
+    "/m/03fp41": "plant",
+    "/m/05s2s": "plant",
 }
+
+# Active OID label map — entries whose unified class is active.
+OID_CLASSES: dict[str, str] = dict(OID_ALL_CLASSES)
+
+
+def _parse_classes(raw: str) -> list[str]:
+    """Parse a comma-separated class list: strip, lowercase, dedupe in order."""
+    seen: dict[str, None] = {}
+    for part in raw.split(","):
+        name = part.strip().lower()
+        if name:
+            seen.setdefault(name)
+    return list(seen)
+
+
+def set_active_classes(classes: list[str]) -> None:
+    """Set the active class list (model index order) and filter OID labels."""
+    UNIFIED_CLASSES[:] = classes
+    OID_CLASSES.clear()
+    OID_CLASSES.update(
+        {mid: cls for mid, cls in OID_ALL_CLASSES.items() if cls in classes}
+    )
+    print(f"Active classes ({len(classes)}): {classes}")
+    known = set(CLASS_MAP.values()) | set(OID_ALL_CLASSES.values())
+    for cls in classes:
+        if cls not in known:
+            print(
+                f"  WARNING: class '{cls}' has no CLASS_MAP aliases and no "
+                f"Open Images coverage — only exact-name labels will match"
+            )
 
 OID_ANNOTATIONS = {
     "train": "https://storage.googleapis.com/openimages/v6/oidv6-train-annotations-bbox.csv",
@@ -145,6 +210,10 @@ def _parse_args() -> argparse.Namespace:
         "--background-sample-interval", type=int, default=10,
         help="Export every Nth frame from background uploads as negative sample",
     )
+    p.add_argument(
+        "--classes", default=",".join(DEFAULT_CLASSES),
+        help="Comma-separated ordered class list; order defines model class indices",
+    )
     return p.parse_args()
 
 
@@ -152,17 +221,26 @@ def _parse_args() -> argparse.Namespace:
 
 
 def _resolve_class(name: str) -> str | None:
-    """Map any source class name to a unified target class."""
-    if name in CLASS_MAP:
-        return CLASS_MAP[name]
+    """Map a source class name to an *active* unified class, else None."""
     lower = name.lower().strip().replace(" ", "_")
-    for src, dst in CLASS_MAP.items():
-        if src.lower() == lower:
-            return dst
-    for target in UNIFIED_CLASSES:
-        if target in lower:
-            return target
-    return None
+    # An exact active-class name always wins, even when an alias would
+    # fold it into something else (e.g. --classes ...,flower keeps
+    # "flower" labels instead of mapping them to an inactive "plant").
+    if lower in UNIFIED_CLASSES:
+        return lower
+    target = CLASS_MAP.get(name) or CLASS_MAP.get(lower)
+    if target is None:
+        # Token fallback: "great_blue_heron"/"blue-heron"/"herons" →
+        # heron. Whole-token match only, so "cattle"/"bobcat"/"eggplant"
+        # don't false-match cat/plant.
+        tokens = re.split(r"[^a-z0-9]+", lower)
+        for cls in UNIFIED_CLASSES:
+            if cls in tokens or f"{cls}s" in tokens:
+                target = cls
+                break
+    if target is not None and target not in UNIFIED_CLASSES:
+        return None
+    return target
 
 
 # ── SSH helpers ────────────────────────────────────────────────────────────
@@ -567,11 +645,16 @@ def pull_open_images(
     max_per_class: int,
     workers: int,
 ) -> list[Sample]:
-    """Download duck + raccoon images from Open Images V6."""
+    """Download images for the active OID-covered classes from Open Images V6."""
     import requests
 
+    active = sorted(set(OID_CLASSES.values()))
+    if not active:
+        print("\nOpen Images: no active classes have OID coverage — skipping")
+        return []
+
     print(f"\n{'='*60}")
-    print("Downloading Open Images (duck + raccoon)")
+    print(f"Downloading Open Images ({', '.join(active)})")
     print("=" * 60)
 
     # Collect annotations: {image_id: {split, class, bboxes[]}}
@@ -627,11 +710,10 @@ def pull_open_images(
             })
             row_count += 1
             if row_count % 5_000_000 == 0:
-                print(
-                    f"    ...{row_count / 1e6:.0f}M rows  "
-                    f"duck={class_image_counts['duck']}  "
-                    f"raccoon={class_image_counts['raccoon']}",
+                counts = "  ".join(
+                    f"{cls}={cnt}" for cls, cnt in sorted(class_image_counts.items())
                 )
+                print(f"    ...{row_count / 1e6:.0f}M rows  {counts}")
 
             # Stop scanning if we have enough of everything
             if all(c >= max_per_class for c in class_image_counts.values()):
@@ -848,6 +930,12 @@ def merge_and_split(
 def main() -> None:
     args = _parse_args()
     output_dir = Path(args.output).resolve()
+
+    classes = _parse_classes(args.classes)
+    if not classes:
+        print("ERROR: --classes must name at least one class", file=sys.stderr)
+        sys.exit(1)
+    set_active_classes(classes)
 
     if not args.skip_roboflow and not args.roboflow_key:
         print("ERROR: --roboflow-key is required (or use --skip-roboflow)", file=sys.stderr)

--- a/training/tests/conftest.py
+++ b/training/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/training/tests/test_prepare_dataset.py
+++ b/training/tests/test_prepare_dataset.py
@@ -1,0 +1,95 @@
+"""Unit tests for class-list handling in prepare_dataset.py."""
+
+import prepare_dataset as pd
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_active_classes():
+    yield
+    pd.set_active_classes(list(pd.DEFAULT_CLASSES))
+
+
+def test_parse_classes_strips_lowercases_dedupes():
+    assert pd._parse_classes(" Duck, heron ,DUCK,plant ") == ["duck", "heron", "plant"]
+
+
+def test_parse_classes_empty_input():
+    assert pd._parse_classes("") == []
+    assert pd._parse_classes(" , ,") == []
+
+
+def test_default_classes_include_distractors():
+    assert pd.DEFAULT_CLASSES == [
+        "duck", "heron", "raccoon", "person", "dog", "cat", "plant",
+    ]
+
+
+def test_resolve_class_defaults():
+    assert pd._resolve_class("person") == "person"
+    assert pd._resolve_class("Potted Plant") == "plant"
+    assert pd._resolve_class("houseplant") == "plant"
+    assert pd._resolve_class("great_blue_heron") == "heron"
+    assert pd._resolve_class("herons") == "heron"
+    assert pd._resolve_class("kitten") == "cat"
+
+
+def test_resolve_class_token_matching_blocks_substrings():
+    assert pd._resolve_class("cattle") is None
+    assert pd._resolve_class("bobcat") is None
+    assert pd._resolve_class("eggplant") is None
+
+
+def test_resolve_class_hyphenated_labels():
+    # Roboflow Universe class names frequently use hyphens.
+    assert pd._resolve_class("blue-heron") == "heron"
+    assert pd._resolve_class("duck-male") == "duck"
+    assert pd._resolve_class("great blue heron") == "heron"
+
+
+def test_resolve_class_exact_active_name_beats_alias():
+    # "flower" normally aliases to plant; as an active class it wins.
+    pd.set_active_classes(["duck", "heron", "flower"])
+    assert pd._resolve_class("flower") == "flower"
+    assert pd._resolve_class("houseplant") is None
+
+
+def test_resolve_class_restricted_to_active_classes():
+    pd.set_active_classes(["duck", "heron", "raccoon"])
+    assert pd._resolve_class("person") is None
+    assert pd._resolve_class("plant") is None
+    assert pd._resolve_class("great_blue_heron") == "heron"
+    assert pd._resolve_class("mallard") == "duck"
+
+
+def test_set_active_classes_filters_oid_labels():
+    pd.set_active_classes(["duck", "heron", "raccoon"])
+    assert pd.OID_CLASSES == {"/m/09ddx": "duck", "/m/0dq75": "raccoon"}
+
+    pd.set_active_classes(list(pd.DEFAULT_CLASSES))
+    assert pd.OID_CLASSES["/m/01g317"] == "person"
+    assert pd.OID_CLASSES["/m/0bt9lr"] == "dog"
+    assert pd.OID_CLASSES["/m/01yrx"] == "cat"
+    # Houseplant and Plant both fold into "plant"
+    assert pd.OID_CLASSES["/m/03fp41"] == "plant"
+    assert pd.OID_CLASSES["/m/05s2s"] == "plant"
+
+
+def test_set_active_classes_defines_index_order():
+    pd.set_active_classes(["heron", "person", "duck"])
+    assert pd.UNIFIED_CLASSES.index("heron") == 0
+    assert pd.UNIFIED_CLASSES.index("person") == 1
+    assert pd.UNIFIED_CLASSES.index("duck") == 2
+
+
+def test_build_remap_drops_inactive_classes():
+    pd.set_active_classes(["duck", "heron", "raccoon"])
+    remap = pd._build_remap(["heron", "person", "cattle"])
+    assert remap == {0: pd.UNIFIED_CLASSES.index("heron")}
+
+    pd.set_active_classes(list(pd.DEFAULT_CLASSES))
+    remap = pd._build_remap(["heron", "person", "cattle"])
+    assert remap == {
+        0: pd.UNIFIED_CLASSES.index("heron"),
+        1: pd.UNIFIED_CLASSES.index("person"),
+    }


### PR DESCRIPTION
## Why

pond_v1 regularly misclassifies humans at the pond as herons. A model fine-tuned on only [duck, heron, raccoon] loses the COCO-pretrained features that distinguish people, so out-of-distribution objects collapse into the nearest target silhouette. This adds **distractor classes** — person, dog, cat, plant — to the default training set so the model has a correct bucket for them, while runtime behavior stays entirely config-driven.

## What

- **`training/prepare_dataset.py`**: new `--classes` CLI arg (comma-separated, ordered — order defines model class indices), default `duck,heron,raccoon,person,dog,cat,plant`. Open Images label IDs added for person/dog/cat/plant (Houseplant + Plant fold into `plant`; IDs verified against `oidv6-class-descriptions.csv`). Labels outside the active list drop with warnings, so `--classes duck,heron,raccoon` reproduces today's 3-class behavior exactly. Alias matching is now token-based (`blue-heron` → heron, but no more `cattle` → cat substring traps). Fixed a latent KeyError in the OID progress print under custom class lists.
- **Trainer**: `prepare_dataset` / `prepare_and_train` jobs pass `--classes` from job params → `training.defaults.classes` → script default, with fail-fast token validation (a malformed value would otherwise produce a near-empty dataset discovered after a multi-hour Orin run).
- **Web UI**: visible Classes field on the Training Jobs page (prefilled from config, shown for prepare jobs only). Labeling-queue and frame-browser datalists now suggest the training class list — hand-drawn `person` boxes already in the DB start counting in the next dataset.
- **Runtime: no code changes.** Distractors are filtered by `detection.target_classes`; an unchanged config drops them at inference. Deterrents remain opt-in per class.
- **Docs**: the `training:` config section is documented in CONFIG_REFERENCE.md for the first time, plus distractor runtime recipes (log-without-notify via enumerated rules, never add `plant` to `target_classes`). README, example config, STATUS, ROADMAP updated.
- **Tests/CI**: new `training/tests/` (stdlib-only, 11 tests); `training/` and `services/trainer/src` added to CI ruff scope; new training pytest CI job.

## Verification

- ruff clean (full CI scope incl. new paths), mypy clean (web, notifier, deterrent, backup)
- 11 training tests + 233 web tests pass
- Smoke: default and 3-class runs print active classes and behave correctly
- CONTRIBUTING self-review pass done; its two should-fixes (hyphenated labels, trainer-side validation) are included

## Deploy note

Requires a **trainer image rebuild** — `prepare_dataset.py` is baked into the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)