### PR TITLE
chore(infra): force Node 24 for JS actions on Orin runner

### DIFF
--- a/infra/docker-compose.runner.yml
+++ b/infra/docker-compose.runner.yml
@@ -28,6 +28,8 @@ services:
       - RUNNER_NAME=${RUNNER_NAME:-orin-nano}
       - RUNNER_LABELS=${RUNNER_LABELS:-self-hosted,linux,arm64,jetson}
       - REPO_URL=${REPO_URL}
+      # GitHub is retiring Node 20 action runtimes; runners are Node 24-capable
+      - FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true
     volumes:
       # Persistent runner config — survives rebuilds, avoids re-registration
       - runner-data:/home/runner


### PR DESCRIPTION
Captures the live edit lab-admin made on the Orin checkout (detached at v0.16.5): adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to the runner environment in `infra/docker-compose.runner.yml`.

GitHub is retiring Node 20 action runtimes and the lab runners are being updated to support Node 24, so forcing it at the runner level keeps all JS actions on Node 24 with no per-workflow workarounds. None of our workflows pin a Node version, so this env var is the only change needed.

Committing it means the next redeploy/re-checkout of the runner compose won't silently drop the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)