### PR TITLE
fix(training): first-run fixes for containerized training pipeline (v1.16.7)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         if: github.event_name != 'push'
         run: |
           docker build \
-            --tag scarguard-web:test \
+            --tag scarguard-web:test-${{ github.run_id }} \
             --file services/web/Dockerfile \
             --build-arg VERSION=dev-${{ github.sha }} \
             --build-arg GIT_COMMIT=${{ github.sha }} \
@@ -89,7 +89,7 @@ jobs:
         if: github.event_name != 'push'
         uses: aquasecurity/trivy-action@314ff8b43182423b84c50b1670b0e10f858f2d98  # FLOATING BRANCH — was: @master (resolved 2026-05-23); switch to a tagged release when ready
         with:
-          image-ref: scarguard-web:test
+          image-ref: scarguard-web:test-${{ github.run_id }}
           format: table
           exit-code: 1
           severity: CRITICAL,HIGH
@@ -103,7 +103,7 @@ jobs:
       - name: Test web in container
         if: github.event_name != 'push'
         run: |
-          cid=$(docker create --user root --entrypoint "" scarguard-web:test sh -c "pip install --quiet pytest httpx && python3 -m pytest /app/tests/ -v --tb=short")
+          cid=$(docker create --user root --entrypoint "" scarguard-web:test-${{ github.run_id }} sh -c "pip install --quiet pytest httpx && python3 -m pytest /app/tests/ -v --tb=short")
           docker cp ${{ github.workspace }}/services/web/tests/. "$cid:/app/tests/"
           docker cp ${{ github.workspace }}/shared/. "$cid:/app/shared/"
           docker start -a "$cid"
@@ -113,7 +113,7 @@ jobs:
 
       - name: Clean up
         if: always() && github.event_name != 'push'
-        run: docker rmi scarguard-web:test || true
+        run: docker rmi scarguard-web:test-${{ github.run_id }} || true
 
   # ── Build notifier (x86 runner) ─────────────────────────────────────────────
   build-notifier:
@@ -153,14 +153,14 @@ jobs:
         if: github.event_name != 'push'
         run: |
           docker build \
-            --tag scarguard-notifier:test \
+            --tag scarguard-notifier:test-${{ github.run_id }} \
             --file services/notifier/Dockerfile \
             .
 
       - name: Test notifier in container
         if: github.event_name != 'push'
         run: |
-          cid=$(docker create --user root --entrypoint "" scarguard-notifier:test sh -c "pip install --quiet pytest && python3 -m pytest /app/tests/ -v --tb=short")
+          cid=$(docker create --user root --entrypoint "" scarguard-notifier:test-${{ github.run_id }} sh -c "pip install --quiet pytest && python3 -m pytest /app/tests/ -v --tb=short")
           docker cp ${{ github.workspace }}/services/notifier/tests/. "$cid:/app/tests/"
           docker cp ${{ github.workspace }}/shared/. "$cid:/app/shared/"
           docker start -a "$cid"
@@ -172,7 +172,7 @@ jobs:
         if: github.event_name != 'push'
         uses: aquasecurity/trivy-action@314ff8b43182423b84c50b1670b0e10f858f2d98  # FLOATING BRANCH — was: @master (resolved 2026-05-23); switch to a tagged release when ready
         with:
-          image-ref: scarguard-notifier:test
+          image-ref: scarguard-notifier:test-${{ github.run_id }}
           format: table
           exit-code: 1
           severity: CRITICAL,HIGH
@@ -181,7 +181,7 @@ jobs:
 
       - name: Clean up
         if: always() && github.event_name != 'push'
-        run: docker rmi scarguard-notifier:test || true
+        run: docker rmi scarguard-notifier:test-${{ github.run_id }} || true
 
   # ── Build deterrent (x86 runner) ─────────────────────────────────────────────
   build-deterrent:
@@ -221,14 +221,14 @@ jobs:
         if: github.event_name != 'push'
         run: |
           docker build \
-            --tag scarguard-deterrent:test \
+            --tag scarguard-deterrent:test-${{ github.run_id }} \
             --file services/deterrent/Dockerfile \
             .
 
       - name: Test deterrent in container
         if: github.event_name != 'push'
         run: |
-          cid=$(docker create --user root --entrypoint "" scarguard-deterrent:test sh -c "pip install --quiet pytest && python3 -m pytest /app/tests/ -v --tb=short")
+          cid=$(docker create --user root --entrypoint "" scarguard-deterrent:test-${{ github.run_id }} sh -c "pip install --quiet pytest && python3 -m pytest /app/tests/ -v --tb=short")
           docker cp ${{ github.workspace }}/services/deterrent/tests/. "$cid:/app/tests/"
           docker cp ${{ github.workspace }}/shared/. "$cid:/app/shared/"
           docker start -a "$cid"
@@ -240,7 +240,7 @@ jobs:
         if: github.event_name != 'push'
         uses: aquasecurity/trivy-action@314ff8b43182423b84c50b1670b0e10f858f2d98  # FLOATING BRANCH — was: @master (resolved 2026-05-23); switch to a tagged release when ready
         with:
-          image-ref: scarguard-deterrent:test
+          image-ref: scarguard-deterrent:test-${{ github.run_id }}
           format: table
           exit-code: 1
           severity: CRITICAL,HIGH
@@ -249,7 +249,7 @@ jobs:
 
       - name: Clean up
         if: always() && github.event_name != 'push'
-        run: docker rmi scarguard-deterrent:test || true
+        run: docker rmi scarguard-deterrent:test-${{ github.run_id }} || true
 
   # ── Build backup (x86 runner) ───────────────────────────────────────────────
   build-backup:
@@ -289,14 +289,14 @@ jobs:
         if: github.event_name != 'push'
         run: |
           docker build \
-            --tag scarguard-backup:test \
+            --tag scarguard-backup:test-${{ github.run_id }} \
             --file services/backup/Dockerfile \
             .
 
       - name: Test backup in container
         if: github.event_name != 'push'
         run: |
-          cid=$(docker create --user root --entrypoint "" scarguard-backup:test sh -c "pip install --quiet pytest && python3 -m pytest /app/tests/ -v --tb=short")
+          cid=$(docker create --user root --entrypoint "" scarguard-backup:test-${{ github.run_id }} sh -c "pip install --quiet pytest && python3 -m pytest /app/tests/ -v --tb=short")
           docker cp ${{ github.workspace }}/services/backup/tests/. "$cid:/app/tests/"
           docker cp ${{ github.workspace }}/shared/. "$cid:/app/shared/"
           docker start -a "$cid"
@@ -308,7 +308,7 @@ jobs:
         if: github.event_name != 'push'
         uses: aquasecurity/trivy-action@314ff8b43182423b84c50b1670b0e10f858f2d98  # FLOATING BRANCH — was: @master (resolved 2026-05-23); switch to a tagged release when ready
         with:
-          image-ref: scarguard-backup:test
+          image-ref: scarguard-backup:test-${{ github.run_id }}
           format: table
           exit-code: 1
           severity: CRITICAL,HIGH
@@ -317,7 +317,7 @@ jobs:
 
       - name: Clean up
         if: always() && github.event_name != 'push'
-        run: docker rmi scarguard-backup:test || true
+        run: docker rmi scarguard-backup:test-${{ github.run_id }} || true
 
   # ── Build caddy (x86 runner) ────────────────────────────────────────────────
   build-caddy:
@@ -386,7 +386,7 @@ jobs:
         if: github.event_name != 'push'
         run: |
           docker build \
-            --tag scarguard-log-streamer:test \
+            --tag scarguard-log-streamer:test-${{ github.run_id }} \
             --file services/log-streamer/Dockerfile \
             .
 
@@ -394,7 +394,7 @@ jobs:
         if: github.event_name != 'push'
         uses: aquasecurity/trivy-action@314ff8b43182423b84c50b1670b0e10f858f2d98  # FLOATING BRANCH — was: @master (resolved 2026-05-23); switch to a tagged release when ready
         with:
-          image-ref: scarguard-log-streamer:test
+          image-ref: scarguard-log-streamer:test-${{ github.run_id }}
           format: table
           exit-code: 1
           severity: CRITICAL,HIGH
@@ -403,7 +403,7 @@ jobs:
 
       - name: Clean up
         if: always() && github.event_name != 'push'
-        run: docker rmi scarguard-log-streamer:test || true
+        run: docker rmi scarguard-log-streamer:test-${{ github.run_id }} || true
 
   # ── Build trainer — Jetson/L4T (Orin runner, ARM64) ──────────────────────────
   # Same L4T base as detector — ARM64 only, no x86 variant.
@@ -419,17 +419,17 @@ jobs:
         run: |
           docker build \
             --file services/trainer/Dockerfile \
-            --tag scarguard-trainer:build-validate \
+            --tag scarguard-trainer:build-validate-${{ github.run_id }} \
             .
 
       - name: Import smoke test
         run: |
-          docker run --rm scarguard-trainer:build-validate \
+          docker run --rm scarguard-trainer:build-validate-${{ github.run_id }} \
             python3 -c "import yaml, redis, cv2; from ultralytics import YOLO; print('Trainer imports OK')"
 
       - name: Clean up
         if: always()
-        run: docker rmi scarguard-trainer:build-validate || true
+        run: docker rmi scarguard-trainer:build-validate-${{ github.run_id }} || true
 
   # ── Build detector — Jetson/L4T (Orin runner, ARM64) ─────────────────────────
   build-detector:
@@ -444,7 +444,7 @@ jobs:
         run: |
           docker build \
             --file services/detector/Dockerfile \
-            --tag scarguard-detector:build-validate \
+            --tag scarguard-detector:build-validate-${{ github.run_id }} \
             .
 
       - name: GPU smoke test
@@ -452,7 +452,7 @@ jobs:
           docker run --rm \
             --runtime nvidia \
             -e NVIDIA_VISIBLE_DEVICES=all \
-            scarguard-detector:build-validate \
+            scarguard-detector:build-validate-${{ github.run_id }} \
             python3 -c "
           import torch
           assert torch.cuda.is_available(), 'CUDA not available — check NVIDIA runtime'
@@ -468,7 +468,7 @@ jobs:
       - name: Inference benchmark (GPU)
         run: |
           cid=$(docker create --user root --entrypoint "" --runtime nvidia -e NVIDIA_VISIBLE_DEVICES=all \
-            scarguard-detector:build-validate python3 /ci/smoke_inference.py)
+            scarguard-detector:build-validate-${{ github.run_id }} python3 /ci/smoke_inference.py)
           docker cp ${{ github.workspace }}/tests/ci/. "$cid:/ci/"
           docker start -a "$cid"
           rc=$?
@@ -477,7 +477,7 @@ jobs:
 
       - name: Clean up build-validate image
         if: always()
-        run: docker rmi scarguard-detector:build-validate || true
+        run: docker rmi scarguard-detector:build-validate-${{ github.run_id }} || true
 
   # ── Build detector — x86 CUDA+CPU (x86 runner) ─────────────────────────────
   build-detector-x86:
@@ -492,14 +492,14 @@ jobs:
         run: |
           docker build \
             --file services/detector/Dockerfile.x86 \
-            --tag scarguard-detector-x86:build-validate \
+            --tag scarguard-detector-x86:build-validate-${{ github.run_id }} \
             .
 
       # Uses docker create + cp instead of bind mounts — see comment on Jetson job.
       - name: Inference benchmark (CPU)
         if: github.event_name != 'push'
         run: |
-          cid=$(docker create --user root --entrypoint "" scarguard-detector-x86:build-validate python3 /ci/smoke_inference.py)
+          cid=$(docker create --user root --entrypoint "" scarguard-detector-x86:build-validate-${{ github.run_id }} python3 /ci/smoke_inference.py)
           docker cp ${{ github.workspace }}/tests/ci/. "$cid:/ci/"
           docker start -a "$cid"
           rc=$?
@@ -510,7 +510,7 @@ jobs:
         if: github.event_name != 'push'
         uses: aquasecurity/trivy-action@314ff8b43182423b84c50b1670b0e10f858f2d98  # FLOATING BRANCH — was: @master (resolved 2026-05-23); switch to a tagged release when ready
         with:
-          image-ref: scarguard-detector-x86:build-validate
+          image-ref: scarguard-detector-x86:build-validate-${{ github.run_id }}
           format: table
           exit-code: 1
           severity: CRITICAL
@@ -523,7 +523,7 @@ jobs:
 
       - name: Clean up
         if: always()
-        run: docker rmi scarguard-detector-x86:build-validate || true
+        run: docker rmi scarguard-detector-x86:build-validate-${{ github.run_id }} || true
 
   # ── Compose smoke test (x86 runner) ─────────────────────────────────────────
   compose-smoke-test:

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ tmp/
 
 # Claude Code runtime artifacts (scheduled task locks, etc.)
 .claude/
+
+# Local training artifacts (datasets, venvs, ultralytics runs)
+training/.venv/
+training/merged_dataset*/
+training/runs/

--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -172,10 +172,14 @@ Labeled events power the training pipeline:
 ### Training Configuration (`training:` section)
 
 The `training:` YAML section configures the trainer service (dataset
-preparation and on-device fine-tuning jobs). It is a passthrough section:
-not part of the structured config UI's schema, but preserved by UI saves.
-`training.sources.roboflow.api_key` is sensitive (encrypted at rest,
-redacted for viewers).
+preparation and on-device fine-tuning jobs). It is editable on the
+Config page under the **Training** sub-tab (v1.16.7+).
+`training.sources.roboflow.api_key` is sensitive: redacted in the UI
+and raw-YAML views, but stored in plaintext — the trainer reads
+`scarguard.yml` directly and cannot decrypt secret-box values (same
+trade-off as camera RTSP URLs for the detector). Without a Roboflow
+key, dataset preparation skips the Roboflow Universe sources and logs
+a warning — heron training coverage depends on them.
 
 | Key | Default | Description |
 |---|---|---|

--- a/STATUS.md
+++ b/STATUS.md
@@ -80,6 +80,20 @@
   battery devices — the Tuya LAN fallback listed in ROADMAP Future Ideas is
   explicitly not viable for sleeping devices.
 
+## Recently Fixed (v1.16.7)
+
+- **Containerized training first-run bugs.** The trainer service's
+  `prepare_and_train` path had never run end-to-end (pond_v1/v2 were
+  trained by hand). Four defects found and fixed during the first real
+  run: silent Roboflow skip when no API key is configured (now a loud
+  warning in the job log and result), bare base-model names triggering
+  a GitHub download instead of using a checkpoint staged in `/models`,
+  ultralytics writing run output to the read-only `/app` (now directed
+  to the training workspace via `--project`), and `data.yaml` carrying
+  a relative `path:` that only resolved when cwd was the dataset dir
+  (now absolute). Training settings (Roboflow key, base model, epochs,
+  etc.) are now editable in the Config UI under the Training sub-tab.
+
 ## Not Yet Built
 
 - Custom-trained heron model (have the tooling now, need labeled data)

--- a/services/config-api/requirements.txt
+++ b/services/config-api/requirements.txt
@@ -4,4 +4,4 @@ pydantic==2.12.5
 pyyaml==6.0.3
 redis==7.4.0
 cryptography==48.0.1
-python-multipart==0.0.27
+python-multipart==0.0.30

--- a/services/config-api/requirements.txt
+++ b/services/config-api/requirements.txt
@@ -3,5 +3,5 @@ uvicorn[standard]==0.43.0
 pydantic==2.12.5
 pyyaml==6.0.3
 redis==7.4.0
-cryptography==46.0.7
+cryptography==48.0.1
 python-multipart==0.0.27

--- a/services/detector/Dockerfile.x86
+++ b/services/detector/Dockerfile.x86
@@ -9,7 +9,9 @@ ARG PYTORCH_TAG=2.6.0-cuda12.4-cudnn9-runtime
 FROM pytorch/pytorch:${PYTORCH_TAG}
 
 # OpenCV headless deps (no GStreamer needed on x86 — cv2 handles RTSP directly)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# upgrade -y: the pytorch base image ships stale Ubuntu packages
+# (e.g. linux-libc-dev kernel-header CVEs) that trip the Trivy gate.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     libgl1 \
     libglib2.0-0 \
     gosu \

--- a/services/deterrent/requirements.txt
+++ b/services/deterrent/requirements.txt
@@ -3,4 +3,4 @@ pyyaml==6.0.3
 pydantic==2.12.5
 tinytuya==1.17.6
 tzdata==2025.3
-cryptography==46.0.7
+cryptography==48.0.1

--- a/services/notifier/requirements.txt
+++ b/services/notifier/requirements.txt
@@ -4,4 +4,4 @@ pydantic==2.12.5
 requests==2.33.1
 tzdata==2025.3
 Pillow==12.2.0
-cryptography==46.0.7
+cryptography==48.0.1

--- a/services/trainer/src/job_runner.py
+++ b/services/trainer/src/job_runner.py
@@ -380,10 +380,18 @@ def _run_prepare_dataset(ctx: JobContext) -> dict:
 
     rf_cfg = sources.get("roboflow", {})
     rf_key = rf_cfg.get("api_key", "")
+    roboflow_key_missing = False
     if rf_key and not ctx.params.get("skip_roboflow"):
         cmd += ["--roboflow-key", rf_key]
     else:
         cmd.append("--skip-roboflow")
+        if not ctx.params.get("skip_roboflow"):
+            roboflow_key_missing = True
+            ctx.append_log(
+                "WARNING: Roboflow source skipped — training.sources.roboflow.api_key "
+                "is not set in scarguard.yml. Heron coverage depends on Roboflow; "
+                "expect low annotation counts."
+            )
 
     if ctx.params.get("skip_orin"):
         cmd.append("--skip-orin")
@@ -396,7 +404,12 @@ def _run_prepare_dataset(ctx: JobContext) -> dict:
     cmd += ["--max-oid-per-class", str(ctx.params.get("max_oid_per_class", oid_cfg.get("max_per_class", 1500)))]
     cmd += ["--oid-workers", str(oid_cfg.get("workers", 16))]
 
-    return _run_subprocess(ctx, cmd, phase="prepare_dataset")
+    result = _run_subprocess(ctx, cmd, phase="prepare_dataset")
+    if roboflow_key_missing and "error" not in result:
+        result["warnings"] = [
+            "Roboflow source skipped: training.sources.roboflow.api_key is not configured"
+        ]
+    return result
 
 
 _SECRET_ARGS = {"--roboflow-key"}
@@ -423,12 +436,17 @@ def _run_subprocess(ctx: JobContext, cmd: list[str], phase: str) -> dict:
     ctx.publish_progress(phase, 0, f"Starting {phase}")
     ctx.append_log(f"$ {_redact_cmd(cmd)}")
 
+    # Run from the writable workspace: /app is read-only for the service
+    # user, and ultralytics resolves relative output paths and asset
+    # downloads against the process cwd.
+    WORKSPACE_DIR.mkdir(parents=True, exist_ok=True)
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,
+        cwd=str(WORKSPACE_DIR),
     )
 
     lines: list[str] = []
@@ -493,11 +511,20 @@ def _run_train(ctx: JobContext) -> dict:
     output_name = ctx.params.get("output_name", "trained.pt")
     output_path = Path(MODELS_DIR) / output_name
 
+    # Bare checkpoint names resolve against MODELS_DIR when staged there,
+    # so a local yolov8n.pt is used instead of a GitHub download.
+    base_model = str(ctx.params.get("base_model", defaults.get("base_model", "yolov8n.pt")) or "yolov8n.pt")
+    if "/" not in base_model:
+        staged = Path(MODELS_DIR) / base_model
+        if staged.is_file():
+            base_model = str(staged)
+
     cmd = [
         "python3", str(SCRIPTS_DIR / "train.py"),
         "--data", str(data_yaml),
-        "--base-model", ctx.params.get("base_model", defaults.get("base_model", "yolov8n.pt")),
+        "--base-model", base_model,
         "--output", str(output_path),
+        "--project", str(WORKSPACE_DIR / "runs"),
         "--epochs", str(ctx.params.get("epochs", defaults.get("epochs", 100))),
         "--imgsz", str(ctx.params.get("image_size", defaults.get("image_size", 480))),
         "--batch", str(ctx.params.get("batch_size", defaults.get("batch_size", 2))),

--- a/services/web/requirements.txt
+++ b/services/web/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.135.3
 uvicorn[standard]==0.43.0
 jinja2==3.1.6
-python-multipart==0.0.27
+python-multipart==0.0.30
 pyyaml==6.0.3
 pydantic==2.12.5
 redis==7.4.0

--- a/services/web/requirements.txt
+++ b/services/web/requirements.txt
@@ -9,4 +9,4 @@ aiofiles==25.1.0
 tzdata==2025.3
 astral==3.2
 bcrypt==5.0.0
-cryptography==46.0.7
+cryptography==48.0.1

--- a/services/web/src/config_model.py
+++ b/services/web/src/config_model.py
@@ -310,6 +310,69 @@ class TLSConfig(BaseModel):
     key_path: str = "/config/certs/key.pem"
 
 
+class TrainingRoboflowConfig(BaseModel):
+    api_key: str = ""
+
+
+class TrainingOpenImagesConfig(BaseModel):
+    max_per_class: int = 1500
+    workers: int = 16
+
+
+class TrainingSourcesConfig(BaseModel):
+    roboflow: TrainingRoboflowConfig = TrainingRoboflowConfig()
+    open_images: TrainingOpenImagesConfig = TrainingOpenImagesConfig()
+
+
+class TrainingDefaultsConfig(BaseModel):
+    base_model: str = "yolov8n.pt"
+    epochs: int = 100
+    image_size: int = 480
+    batch_size: int = 2
+    patience: int = 20
+    val_split: float = 0.15
+    classes: str = ""
+
+    @field_validator("classes", mode="before")
+    @classmethod
+    def classes_to_str(cls, v: object) -> str:
+        # YAML may hold a list; the trainer accepts either, the form uses
+        # a comma-separated string.
+        if isinstance(v, (list, tuple)):
+            return ",".join(str(c) for c in v)
+        return str(v) if v is not None else ""
+
+    @field_validator("val_split", mode="before")
+    @classmethod
+    def val_split_clamp(cls, v: object) -> float:
+        # Coerce rather than raise: a strict validator here would make
+        # _parse_cfg fall back to a default TrainingConfig, rendering the
+        # form with an empty (not redacted) API key that the next save
+        # would persist — wiping the stored secret.
+        try:
+            f = float(v)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return 0.15
+        if not 0.0 < f < 1.0:
+            return 0.15
+        return f
+
+
+class TrainingVideoConfig(BaseModel):
+    low_confidence: float = 0.05
+    dedupe_iou: float = 0.85
+    dedupe_window: int = 5
+    background_sample_interval: int = 10
+
+
+class TrainingConfig(BaseModel):
+    """Training pipeline settings read by the trainer service."""
+
+    sources: TrainingSourcesConfig = TrainingSourcesConfig()
+    defaults: TrainingDefaultsConfig = TrainingDefaultsConfig()
+    video: TrainingVideoConfig = TrainingVideoConfig()
+
+
 class TuyaCredentialsConfig(BaseModel):
     api_key: str = ""
     api_secret: str = ""
@@ -428,3 +491,4 @@ class StructuredConfigPayload(BaseModel):
     notifications: NotificationsConfig = NotificationsConfig()
     tls: TLSConfig = TLSConfig()
     deterrent: ActuationConfig = ActuationConfig()
+    training: TrainingConfig = TrainingConfig()

--- a/services/web/src/routes/config.py
+++ b/services/web/src/routes/config.py
@@ -21,6 +21,7 @@ from config_model import (
     StructuredConfigPayload,
     SystemConfig,
     TLSConfig,
+    TrainingConfig,
 )
 from config_redact import (
     _CHANNEL_SENSITIVE_KEYS,
@@ -103,6 +104,7 @@ def _parse_cfg(raw_cfg: dict) -> StructuredConfigPayload:
         notifications=_section(NotificationsConfig, raw_cfg.get("notifications", {})),
         tls=_section(TLSConfig, raw_cfg.get("tls", {})),
         deterrent=_section(ActuationConfig, raw_cfg.get("deterrent", {})),
+        training=_section(TrainingConfig, raw_cfg.get("training", {})),
     )
 
 
@@ -126,6 +128,9 @@ def _redact_parsed_cfg(cfg: StructuredConfigPayload) -> None:
         tuya.api_key = REDACTED_PLACEHOLDER
     if tuya.api_secret:
         tuya.api_secret = REDACTED_PLACEHOLDER
+    roboflow = cfg.training.sources.roboflow
+    if roboflow.api_key:
+        roboflow.api_key = REDACTED_PLACEHOLDER
 
 
 def _cameras_json(cfg_cameras: list[CameraConfig]) -> str:
@@ -275,8 +280,12 @@ async def get_secrets(request: Request) -> Response:
 
     result: dict[str, Any] = {}
 
-    # Structural paths — tuya keys
+    # Structural paths — tuya keys.  The training Roboflow key is handled
+    # separately below: this loop keys results by last path segment, which
+    # would collide with the Tuya ``api_key``.
     for path in _STRUCTURAL_PATHS:
+        if path[0] == "training":
+            continue
         val: Any = cfg
         for seg in path:
             if seg == "[]":
@@ -288,6 +297,12 @@ async def get_secrets(request: Request) -> Response:
                 break
         if isinstance(val, str) and val:
             result[path[-1]] = val
+
+    rf_val: Any = cfg
+    for seg in ("training", "sources", "roboflow", "api_key"):
+        rf_val = rf_val.get(seg) if isinstance(rf_val, dict) else None
+    if isinstance(rf_val, str) and rf_val:
+        result["roboflow_api_key"] = rf_val
 
     # Camera RTSP URLs
     cameras: list[dict[str, str]] = []
@@ -460,6 +475,33 @@ async def save_structured_config(request: Request) -> Response:
         existing_act = {}
     existing_act["enabled"] = payload.deterrent.enabled
     existing["deterrent"] = existing_act
+
+    # Merge training: nested-merge each group so keys the form doesn't know
+    # about survive.  A redacted Roboflow key means "unchanged" — drop it so
+    # the existing secret is preserved.
+    existing_training = existing.get("training", {})
+    if not isinstance(existing_training, dict):
+        existing_training = {}
+    training_dump = payload.training.model_dump(exclude_unset=True)
+    rf_dump = training_dump.get("sources", {}).get("roboflow", {})
+    if rf_dump.get("api_key") == REDACTED_PLACEHOLDER:
+        rf_dump.pop("api_key")
+    for group in ("sources", "defaults", "video"):
+        if group in training_dump:
+            existing_group = existing_training.get(group, {})
+            if not isinstance(existing_group, dict):
+                existing_group = {}
+            if group == "sources":
+                # sources has its own nested dicts (roboflow, open_images)
+                for src_key, src_val in training_dump[group].items():
+                    existing_src = existing_group.get(src_key, {})
+                    if not isinstance(existing_src, dict):
+                        existing_src = {}
+                    existing_group[src_key] = {**existing_src, **src_val}
+                training_dump[group] = existing_group
+            else:
+                training_dump[group] = {**existing_group, **training_dump[group]}
+    existing["training"] = {**existing_training, **training_dump}
 
     config_store.save(existing)
     warnings = _find_orphan_references(existing)

--- a/services/web/src/static/config.js
+++ b/services/web/src/static/config.js
@@ -105,7 +105,7 @@ document.querySelectorAll(".subtab-btn").forEach(btn => {
 });
 
 (function initSubtab() {
-  const valid = ["system", "detection", "cameras", "notifications", "advanced"];
+  const valid = ["system", "detection", "cameras", "notifications", "training", "advanced"];
   const hash = (location.hash || "").replace(/^#/, "");
   _activateSubtab(valid.includes(hash) ? hash : "system");
 })();
@@ -574,6 +574,34 @@ function readForm() {
     deterrent: {
       enabled: document.getElementById("deterrent-enabled").checked,
     },
+    training: {
+      sources: {
+        roboflow: {
+          api_key: document.getElementById("training-roboflow-key").value.trim(),
+        },
+        open_images: {
+          // 0 is a valid cap (skip OID images entirely) — don't || it away.
+          max_per_class: (v => isNaN(v) ? 1500 : v)(parseInt(document.getElementById("training-oid-max").value, 10)),
+          workers: parseInt(document.getElementById("training-oid-workers").value, 10) || 16,
+        },
+      },
+      defaults: {
+        base_model: document.getElementById("training-base-model").value.trim() || "yolov8n.pt",
+        epochs: parseInt(document.getElementById("training-epochs").value, 10) || 100,
+        image_size: parseInt(document.getElementById("training-imgsz").value, 10) || 480,
+        batch_size: parseInt(document.getElementById("training-batch").value, 10) || 2,
+        patience: parseInt(document.getElementById("training-patience").value, 10) || 20,
+        val_split: parseFloat(document.getElementById("training-val-split").value) || 0.15,
+        classes: document.getElementById("training-classes").value
+          .split(",").map(s => s.trim().toLowerCase()).filter(Boolean).join(","),
+      },
+      video: {
+        low_confidence: parseFloat(document.getElementById("training-video-lowconf").value) || 0.05,
+        dedupe_iou: parseFloat(document.getElementById("training-video-dedupe-iou").value) || 0.85,
+        dedupe_window: parseInt(document.getElementById("training-video-dedupe-window").value, 10) || 5,
+        background_sample_interval: parseInt(document.getElementById("training-bg-interval").value, 10) || 10,
+      },
+    },
   };
 }
 
@@ -604,6 +632,10 @@ function validate(data) {
     errors.push("TLS: Certificate path is required for manual mode");
   if (tls.mode === "manual" && !tls.key_path)
     errors.push("TLS: Key path is required for manual mode");
+
+  const vs = data.training.defaults.val_split;
+  if (isNaN(vs) || vs <= 0 || vs >= 1)
+    errors.push("Training: validation split must be between 0 and 1 (exclusive)");
 
   const sched = data.system.schedule;
   const timeRe = /^\d{2}:\d{2}$/;
@@ -1417,6 +1449,15 @@ function _markRevealed(input, revealed) {
 }
 
 function _applySecrets(secrets) {
+  // Training Roboflow API key
+  if (secrets.roboflow_api_key) {
+    var rfEl = document.getElementById("training-roboflow-key");
+    if (rfEl) {
+      rfEl.value = secrets.roboflow_api_key;
+      _markRevealed(rfEl, true);
+    }
+  }
+
   // Camera RTSP URLs
   if (Array.isArray(secrets.cameras)) {
     var camCards = document.querySelectorAll("#cameras-list .camera-card");

--- a/services/web/src/templates/config.html
+++ b/services/web/src/templates/config.html
@@ -41,6 +41,7 @@
     <button type="button" class="subtab-btn" data-subtab="detection">Detection</button>
     <button type="button" class="subtab-btn" data-subtab="cameras">Cameras</button>
     <button type="button" class="subtab-btn" data-subtab="notifications">Notifications</button>
+    <button type="button" class="subtab-btn" data-subtab="training">Training</button>
     <button type="button" class="subtab-btn subtab-advanced expert-only" data-subtab="advanced">Advanced</button>
   </div>
 
@@ -244,6 +245,94 @@
           <div class="field-group expert-only">
             <label>Frame skip (process every Nth frame)</label>
             <input type="number" id="det-frame-skip" value="{{ cfg.detection.frame_skip }}" min="1" max="60">
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {# ── Training ─────────────────────────────────────────────────────────────── #}
+  <div class="config-section" id="section-training" data-subtab="training">
+    <div class="config-section-header" data-toggle-section="section-training">
+      <span class="config-section-label">Training</span>
+      <span class="config-section-chevron">▾</span>
+    </div>
+    <div class="config-section-body">
+      <div class="card">
+        <div class="field-group">
+          <label>Roboflow API key</label>
+          <input type="text" id="training-roboflow-key" value="{{ cfg.training.sources.roboflow.api_key }}"
+                 placeholder="Get a free key at roboflow.com → Settings → API Keys">
+          <p class="hint">
+            Without a key, dataset preparation skips the Roboflow Universe
+            datasets — heron coverage depends on them.
+          </p>
+        </div>
+        <div class="field-row">
+          <div class="field-group">
+            <label>Open Images: max images per class</label>
+            <input type="number" id="training-oid-max" value="{{ cfg.training.sources.open_images.max_per_class }}" min="0" max="50000">
+          </div>
+          <div class="field-group expert-only">
+            <label>Open Images: download threads</label>
+            <input type="number" id="training-oid-workers" value="{{ cfg.training.sources.open_images.workers }}" min="1" max="64">
+          </div>
+        </div>
+        <div class="field-group">
+          <label>Base model (checkpoint to fine-tune from)</label>
+          <input type="text" id="training-base-model" value="{{ cfg.training.defaults.base_model }}"
+                 placeholder="/models/yolov8n.pt">
+          <p class="hint">
+            Bare names (e.g. <code>yolov8n.pt</code>) resolve against the
+            models directory when staged there, otherwise download from
+            the ultralytics GitHub releases.
+          </p>
+        </div>
+        <div class="field-group">
+          <label>Training classes (comma-separated, order defines model class indices)</label>
+          <input type="text" id="training-classes" value="{{ cfg.training.defaults.classes }}"
+                 placeholder="duck, heron, raccoon, person, dog, cat, plant">
+        </div>
+        <div class="field-row">
+          <div class="field-group">
+            <label>Epochs</label>
+            <input type="number" id="training-epochs" value="{{ cfg.training.defaults.epochs }}" min="1" max="1000">
+          </div>
+          <div class="field-group">
+            <label>Image size</label>
+            <input type="number" id="training-imgsz" value="{{ cfg.training.defaults.image_size }}" min="160" max="1920" step="32">
+          </div>
+          <div class="field-group">
+            <label>Batch size</label>
+            <input type="number" id="training-batch" value="{{ cfg.training.defaults.batch_size }}" min="1" max="128">
+          </div>
+        </div>
+        <div class="field-row">
+          <div class="field-group expert-only">
+            <label>Early-stop patience (epochs)</label>
+            <input type="number" id="training-patience" value="{{ cfg.training.defaults.patience }}" min="1" max="200">
+          </div>
+          <div class="field-group expert-only">
+            <label>Validation split</label>
+            <input type="number" id="training-val-split" value="{{ cfg.training.defaults.val_split }}" min="0.01" max="0.5" step="0.01">
+          </div>
+          <div class="field-group expert-only">
+            <label>Background sample interval (every Nth frame)</label>
+            <input type="number" id="training-bg-interval" value="{{ cfg.training.video.background_sample_interval }}" min="1" max="300">
+          </div>
+        </div>
+        <div class="field-row expert-only">
+          <div class="field-group">
+            <label>Video: low-confidence pass threshold</label>
+            <input type="number" id="training-video-lowconf" value="{{ cfg.training.video.low_confidence }}" min="0.01" max="1" step="0.01">
+          </div>
+          <div class="field-group">
+            <label>Video: dedup IoU threshold</label>
+            <input type="number" id="training-video-dedupe-iou" value="{{ cfg.training.video.dedupe_iou }}" min="0.1" max="1" step="0.05">
+          </div>
+          <div class="field-group">
+            <label>Video: dedup frame window</label>
+            <input type="number" id="training-video-dedupe-window" value="{{ cfg.training.video.dedupe_window }}" min="1" max="60">
           </div>
         </div>
       </div>

--- a/services/web/tests/test_routes.py
+++ b/services/web/tests/test_routes.py
@@ -260,6 +260,68 @@ class TestConfig:
         assert saved["redis"] == {"host": "redis", "port": 6379}
         assert "webhooks" in saved
 
+    def test_structured_save_training_merge(self, client, monkeypatch):
+        """Training saves keep the real Roboflow key when redacted and
+        preserve video keys the form doesn't send."""
+        existing = {
+            "system": {"armed": True, "log_level": "info"},
+            "cameras": [],
+            "detection": {
+                "model_path": "/models/best.pt",
+                "confidence_threshold": 0.25,
+                "target_classes": [],
+                "cooldown_seconds": 30,
+                "frame_skip": 2,
+            },
+            "notifications": {},
+            "training": {
+                "sources": {"roboflow": {"api_key": "real-secret-key"}},
+                "video": {"low_confidence": 0.07},
+            },
+        }
+        saved_cfgs = []
+        monkeypatch.setattr("config_store.load", lambda: existing)
+        monkeypatch.setattr("config_store.save", lambda cfg: saved_cfgs.append(cfg))
+
+        payload = {
+            "system": {"armed": True, "log_level": "info"},
+            "cameras": [],
+            "detection": {
+                "model_path": "/models/best.pt",
+                "confidence_threshold": 0.25,
+                "target_classes": [],
+                "cooldown_seconds": 30,
+                "frame_skip": 2,
+            },
+            "notifications": {"channels": []},
+            "training": {
+                "sources": {
+                    "roboflow": {"api_key": "***REDACTED***"},
+                    "open_images": {"max_per_class": 2000, "workers": 16},
+                },
+                "defaults": {
+                    "base_model": "yolov8n.pt",
+                    "epochs": 150,
+                    "image_size": 480,
+                    "batch_size": 2,
+                    "patience": 20,
+                    "val_split": 0.15,
+                    "classes": "duck,heron",
+                },
+            },
+        }
+        resp = client.post("/config/structured", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        saved = saved_cfgs[0]
+        # Redacted placeholder must not clobber the stored secret.
+        assert saved["training"]["sources"]["roboflow"]["api_key"] == "real-secret-key"
+        # Sections the form did not send survive untouched.
+        assert saved["training"]["video"]["low_confidence"] == 0.07
+        # New values land.
+        assert saved["training"]["defaults"]["epochs"] == 150
+        assert saved["training"]["sources"]["open_images"]["max_per_class"] == 2000
+
     def test_structured_save_preserves_existing_timezone_when_omitted(self, client, monkeypatch):
         """Structured saves that omit system.timezone must not reset it to UTC."""
         existing = {

--- a/training/prepare_dataset.py
+++ b/training/prepare_dataset.py
@@ -850,6 +850,7 @@ def merge_and_split(
     seed: int,
 ) -> None:
     """Write a unified YOLO dataset with a randomised train/val split."""
+    output_dir = output_dir.resolve()
     print(f"\n{'='*60}")
     print(f"Merging {len(samples)} samples")
     print("=" * 60)
@@ -899,9 +900,11 @@ def merge_and_split(
         else:
             n_background += 1
 
+    # Absolute path: ultralytics resolves a relative ``path`` against the
+    # process cwd (or its datasets_dir), not the data.yaml location.
     (output_dir / "data.yaml").write_text(
         f"# ScarGuard merged training dataset\n"
-        f"path: .\n"
+        f"path: {output_dir}\n"
         f"train: images/train\n"
         f"val: images/val\n"
         f"\n"

--- a/training/tests/test_prepare_dataset.py
+++ b/training/tests/test_prepare_dataset.py
@@ -93,3 +93,18 @@ def test_build_remap_drops_inactive_classes():
         0: pd.UNIFIED_CLASSES.index("heron"),
         1: pd.UNIFIED_CLASSES.index("person"),
     }
+
+
+def test_merge_and_split_writes_absolute_dataset_path(tmp_path):
+    """ultralytics resolves a relative ``path`` against the process cwd,
+    so data.yaml must carry the absolute dataset directory."""
+    img = tmp_path / "img.jpg"
+    img.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg")
+    samples = [
+        pd.Sample(image=img, label_lines=["0 0.5 0.5 0.2 0.2"], source="test"),
+    ]
+    out = tmp_path / "merged"
+    pd.merge_and_split(samples, out, val_split=0.5, seed=1)
+    text = (out / "data.yaml").read_text()
+    assert f"path: {out}\n" in text
+    assert "path: .\n" not in text

--- a/training/train.py
+++ b/training/train.py
@@ -47,6 +47,10 @@ def _parse_args() -> argparse.Namespace:
         help="Device to train on (0 for GPU, cpu for CPU)",
     )
     p.add_argument(
+        "--project", type=str, default="runs",
+        help="Directory for ultralytics run output (must be writable)",
+    )
+    p.add_argument(
         "--force", action="store_true",
         help="Proceed even if a class has fewer than 500 images",
     )
@@ -174,6 +178,7 @@ def main() -> None:
         batch=args.batch,
         patience=args.patience,
         device=args.device,
+        project=args.project,
         verbose=True,
     )
 


### PR DESCRIPTION
## What

Five defects found tonight during the **first ever end-to-end `prepare_and_train` run** on the Orin (pond_v1/v2 were trained by hand in /tmp, so the containerized path had never executed). Each was hit live, worked around on the box to unblock the pond_v3 run, and is fixed here durably.

| # | Defect | Fix |
|---|--------|-----|
| 1 | No structured config UI for `training.*` (config-UI rule violation) | New **Training** sub-tab on the Config page: Roboflow key (redacted + reveal + merge-on-save), Open Images caps, base model, classes, epochs/imgsz/batch/patience/val-split, video-processing knobs |
| 2 | Prepare silently skipped Roboflow with no API key → heron got 20 annotations and training aborted with no hint why | Loud warning in the job log + `warnings` key in the job result |
| 3 | Bare base-model name (`yolov8n.pt`) → GitHub download even with the file staged in `/models`, crashing on read-only `/app` | Resolve bare names against `MODELS_DIR` first; trainer subprocesses now run with `cwd=` the writable workspace |
| 4 | ultralytics wrote run output to `<cwd>/runs` = `/app/runs` (read-only for service user) | `train.py --project` arg; trainer passes the workspace dir |
| 5 | `data.yaml` carried `path: .`, resolved by ultralytics against process cwd, not the yaml's dir | Absolute dataset path written (and resolved inside `merge_and_split`) |

Also fixes a latent `get_secrets` bug: the Roboflow path (last in `_STRUCTURAL_PATHS`) overwrote the Tuya `api_key` in the reveal response; the Roboflow key now returns under a distinct `roboflow_api_key` name. CONFIG_REFERENCE corrected: the key is redacted, **not** encrypted at rest (the trainer reads `scarguard.yml` directly).

## Live workarounds this replaces (on the Orin)

- `chown -R scarguard /app` inside `scarguard-trainer` (ephemeral — lost on container recreate)
- hand-edited `path:` in the generated `merged_dataset/data.yaml`

After this image ships, neither is needed.

## Testing

- New route test: training merge-on-save preserves redacted secret + unsent video keys, lands new values
- New prepare test: `data.yaml` carries the absolute dataset path
- ruff (all services) clean; mypy web/notifier/deterrent/backup clean; full web route suite + training tests pass
- Self-review subagent run per CONTRIBUTING; its 3 should-fix findings are incorporated (unstaged-model cwd crash, strict val_split validator that could wipe the stored key via the `_section` fallback, JS zero-collapse on the OID cap)

## Follow-up (not in this PR)

- `workspace/runs/` accumulates ultralytics run dirs unbounded; consider pruning after the best-weights copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)