### PR TITLE
fix(training): stop detector auto-resume from OOM-killing long training runs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -80,6 +80,27 @@
   battery devices — the Tuya LAN fallback listed in ROADMAP Future Ideas is
   explicitly not viable for sleeping devices.
 
+## Recently Fixed (unreleased)
+
+- **Detector auto-resume mid-training (OOM-killed pond_v3).** The
+  pause/resume protocol's hard timeout was 2 hours, but a real
+  `prepare_and_train` run takes 10+ hours on the Orin Nano. At the
+  2-hour mark the detector auto-resumed and reloaded its models while
+  training still held the GPU; the resulting memory contention
+  OOM-killed the training subprocess mid-validation (job `7eeb0cbb`,
+  2026-07-11 03:21Z). Ceiling raised to 24 hours — the 90s trainer
+  heartbeat TTL remains the crash guard. Also: the detector now acks a
+  resume request even when it is already running (previously the
+  trainer's post-job resume timed out with a misleading error after
+  any auto-resume), the paused state key is refreshed while paused so
+  the UI doesn't show "unknown" after STATE_TTL expires mid-run, and
+  the trainer logs a warning when the resume ack is missing instead of
+  silently ignoring it. Known limitation: the heartbeat proves the
+  trainer *process* is alive, not that training is progressing — a
+  hung training subprocess now costs up to 24h of detection downtime
+  (was 2h). Tying the heartbeat to subprocess output is a candidate
+  follow-up.
+
 ## Recently Fixed (v1.16.7)
 
 - **Containerized training first-run bugs.** The trainer service's

--- a/docs/design-video-upload-training.md
+++ b/docs/design-video-upload-training.md
@@ -172,7 +172,7 @@ The web service creates these tables on startup (same pattern as existing
 ```
 Trainer                         Detector
    │                               │
-   │─── PUBLISH command ──────────►│  {"action":"pause", "request_id":"abc", "timeout":7200}
+   │─── PUBLISH command ──────────►│  {"action":"pause", "request_id":"abc", "timeout":86400}
    │    (scarguard:detector:command)│
    │                               │  1. Set paused_ref = True
    │                               │  2. Wait for in-flight inference to drain (≤5s)
@@ -236,7 +236,7 @@ pipeline logic.
 | OOM during training | Kernel kills trainer → heartbeat expires → auto-resume |
 
 **Hard requirement:** the detector must never remain paused indefinitely.
-The timeout (default 7200s) is the backstop.
+The timeout (default 86400s = 24h) is the backstop for a trainer that is alive but never finishes; the 90s heartbeat TTL is the crash guard.
 
 ### 4.5 Fallback: container stop/start
 
@@ -856,7 +856,7 @@ and the detector auto-resumes.
 
 ### 11.3 Pause timeout
 
-The pause request includes `timeout` (default 7200s).  The detector tracks
+The pause request includes `timeout` (default 86400s = 24h).  The detector tracks
 `paused_since` and auto-resumes when `now - paused_since > timeout`.
 This covers: trainer hung, heartbeat mechanism itself broken, Redis down.
 

--- a/services/detector/src/pause_handler.py
+++ b/services/detector/src/pause_handler.py
@@ -49,6 +49,7 @@ class PauseHandler:
         self._watcher_stop = threading.Event()
         self._paused_since: float = 0.0
         self._pause_timeout: float = DEFAULT_PAUSE_TIMEOUT
+        self._pause_request_id: str = ""
         self._transition_lock = threading.Lock()
 
     def start(self) -> None:
@@ -93,6 +94,7 @@ class PauseHandler:
             logger.info("Pausing detector (request_id=%s, timeout=%ds)", request_id, timeout)
             self._paused_since = time.monotonic()
             self._pause_timeout = float(timeout)
+            self._pause_request_id = request_id
             self._paused_ref.set(True)
 
             self._global_stop.wait(_DRAIN_WAIT)
@@ -107,7 +109,11 @@ class PauseHandler:
     def _do_resume(self, request_id: str, reason: str = "command") -> None:
         with self._transition_lock:
             if not self._paused_ref.get():
-                logger.info("Not paused — ignoring resume request %s", request_id)
+                # Still ack: after an auto-resume the trainer's own resume
+                # request must not time out waiting for a state it can never
+                # see — republish "running" under the requester's id.
+                logger.info("Not paused — acking resume request %s as running", request_id)
+                self._publish_state("running", request_id=request_id)
                 return
 
             logger.info("Resuming detector (request_id=%s, reason=%s)", request_id, reason)
@@ -188,6 +194,11 @@ class PauseHandler:
                     logger.warning("Trainer heartbeat missing — auto-resuming")
                     self._do_resume("auto-heartbeat", reason="heartbeat-expired")
                     break
+
+                # Refresh the state key: a pause outlives STATE_TTL, and
+                # letting it expire shows the UI "unknown" for the rest of
+                # a long training run.
+                self._publish_state("paused", request_id=self._pause_request_id)
 
                 self._watcher_stop.wait(30)
         except Exception:

--- a/services/trainer/src/job_runner.py
+++ b/services/trainer/src/job_runner.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from pause_protocol import PauseClient
+from pause_protocol import DEFAULT_PAUSE_TIMEOUT, PauseClient
 from redis_client import make_sync_client
 
 logger = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ class JobContext:
     def is_cancelled(self) -> bool:
         return bool(self._redis.exists(_cancel_key(self.job_id))) or self.stop_event.is_set()
 
-    def pause_detector(self, timeout: int = 7200) -> bool:
+    def pause_detector(self, timeout: int = DEFAULT_PAUSE_TIMEOUT) -> bool:
         ok = self._pause_client.pause(timeout=timeout)
         if ok:
             self._pause_client.start_heartbeat()
@@ -98,7 +98,11 @@ class JobContext:
 
     def resume_detector(self) -> None:
         self._pause_client.stop_heartbeat()
-        self._pause_client.resume()
+        if not self._pause_client.resume():
+            logger.warning(
+                "Detector did not confirm resume — it may have auto-resumed "
+                "earlier (check detector logs for GPU contention during training)"
+            )
 
     def training_config(self) -> dict:
         return self.cfg.get("training", {})

--- a/shared/pause_protocol.py
+++ b/shared/pause_protocol.py
@@ -29,7 +29,13 @@ HEARTBEAT_INTERVAL = 30  # seconds between heartbeat writes
 HEARTBEAT_TTL = 90  # key TTL — expires if trainer stops writing
 
 # Default pause timeout — detector auto-resumes after this many seconds.
-DEFAULT_PAUSE_TIMEOUT = 7200  # 2 hours
+# This is a last-resort ceiling for a trainer that is alive (heartbeating)
+# but never finishes; the 90s heartbeat TTL is the crash guard. It must
+# comfortably exceed a real training run: a full prepare_and_train on the
+# Orin Nano runs 10+ hours, and an auto-resume mid-training puts detector
+# inference and the training subprocess on the GPU together, OOM-killing
+# the training run (pond_v3, 2026-07-11).
+DEFAULT_PAUSE_TIMEOUT = 86400  # 24 hours
 
 
 class PauseClient:
@@ -38,7 +44,7 @@ class PauseClient:
     Usage::
 
         client = PauseClient(redis_cfg)
-        if client.pause(timeout=7200):
+        if client.pause():
             client.start_heartbeat()
             try:
                 do_training_work()


### PR DESCRIPTION
## What happened

The pond_v3 training run (job `7eeb0cbb`) died overnight at 03:21Z. Reconstruction from the Orin logs (via lab-admin) + code:

1. Trainer paused the detector with the default `timeout=7200` — **2 hours**.
2. Training legitimately ran 10+ hours. At the 2h mark the detector's heartbeat watcher hit `Pause timeout exceeded — auto-resuming` and reloaded YOLO models onto the GPU **while training still held it** — the trainer heartbeat was alive the whole time, but the hard timeout fires regardless.
3. Detector inference + training shared the Orin's unified memory until the OOM killer took the training subprocess (`exit -9`) mid-validation.
4. The trainer's `finally` resume was then ignored by the already-running detector (`Not paused — ignoring`) with **no ack**, producing the misleading "timed out waiting for state=running" error.

## Fixes

- **`DEFAULT_PAUSE_TIMEOUT` 7200 → 86400 (24h).** The 90s heartbeat TTL is the crash guard; the ceiling only backstops a trainer that is alive but never finishes.
- **Detector acks resume even when already running** — republishes `state=running` under the requester's `request_id`, so the post-job resume can't falsely time out after any auto-resume.
- **Paused state key refreshed while paused** — previously `STATE_TTL` (1h) expired mid-run and the Training Jobs UI showed detector state "unknown" for the remaining hours of training (self-review finding).
- **Trainer warns on missing resume ack** instead of silently discarding the return value.
- Design doc timeout references updated; STATUS.md entry added.

## Known limitation (documented, not fixed here)

The heartbeat proves the trainer *process* is alive, not that training is *progressing*. A hung training subprocess now costs up to 24h of detection downtime (was 2h). Tying the heartbeat to subprocess output is a candidate follow-up.

## Testing

- ruff (all services) clean; mypy web+shared clean (detector excluded from CI mypy per convention).
- Self-review subagent run per CONTRIBUTING; its should-fix findings (state-key TTL blindness, stale 7200 docs) are incorporated.
- Note: the relaunched pond_v3 job (`b280b15f`, running now) is on the old images and will hit the same 2h auto-resume — it needs this fix deployed and a relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)